### PR TITLE
Fix push issues, when using a registry.

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccessUnirest.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccessUnirest.java
@@ -240,7 +240,13 @@ public class DockerAccessUnirest implements DockerAccess {
     /** {@inheritDoc} */
     public void pushImage(String image, AuthConfig authConfig) throws MojoExecutionException {
         ImageName name = new ImageName(image);
-        String pushUrl = url + "/images/" + URLParamEncoder.encode(name.getRepository()) + "/push";
+        String pushUrl = url + "/images/"
+                + URLParamEncoder.encode(
+                name.getRegistry() != null && !name.getRegistry().isEmpty()
+                        ? name.getRegistry() + "/" + name.getRepository()
+                        : name.getRepository()
+                )
+                + "/push";
         pushUrl = addTagAndRegistry(pushUrl,name);
         pullOrPushImage(image,pushUrl,"pushing",authConfig);
     }


### PR DESCRIPTION
In the 0.9.11 and docker 1.3.0 the push doesn't work if we are trying to push to a local registry. 

What seems to be missing is the registry as a prefix to the repository. This pull request fixes this problem.
