### PR TITLE
support for additional container configuration options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,19 +115,25 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
       <version>${jmockit.version}</version>
       <scope>test</scope>
     </dependency>
-
+    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+   
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.2.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/jolokia/docker/maven/access/ContainerConfig.java
+++ b/src/main/java/org/jolokia/docker/maven/access/ContainerConfig.java
@@ -1,0 +1,132 @@
+package org.jolokia.docker.maven.access;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jolokia.docker.maven.util.EnvUtil;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+
+/**
+ * Represents a configuration used to create a container
+ */
+public class ContainerConfig {
+
+    private final String imageName;
+
+    private final JSONObject object = new JSONObject();
+
+    public ContainerConfig(String imageName) {
+        this.imageName = imageName;
+        object.put("Image", imageName);
+    }
+
+    public ContainerConfig bind(List<String> bind) {
+        if (bind != null && !bind.isEmpty()) {
+            JSONObject volumes = new JSONObject();
+            for (String volume : bind) {
+                if (volume.contains(":")) {
+                    volume = volume.split(":")[0];
+                }
+                volumes.put(volume, new JSONObject());
+            }
+            object.put("Volumes", volumes);
+        }
+        return this;
+    }
+
+    public ContainerConfig command(String command) {
+        if (command != null) {
+            JSONArray a = new JSONArray();
+            for (String s : EnvUtil.splitWOnSpaceWithEscape(command)) {
+                a.put(s);
+            }
+            object.put("Cmd", a);
+        }
+        return this;
+    }
+
+    public ContainerConfig domainname(String domainname) {
+        add("Domainname", domainname);
+        return this;
+    }
+
+    public ContainerConfig entrypoint(String entrypoint) {
+        if (entrypoint != null) {
+            add("Entrypoint", entrypoint);
+        }
+        return this;
+    }
+
+    public ContainerConfig environment(Map<String, String> env) throws IllegalArgumentException {
+        if (env != null && env.size() > 0) {
+            JSONArray a = new JSONArray();
+            for (Map.Entry<String, String> entry : env.entrySet()) {
+                String value = entry.getValue();
+                if (value == null || value.length() == 0) {
+                    throw new IllegalArgumentException(String.format("Env variable '%s' must not be null or empty when running %s",
+                            entry.getKey(), imageName));
+                }
+                a.put(entry.getKey() + "=" + entry.getValue());
+            }
+            object.put("Env", a);
+        }
+        return this;
+    }
+
+    public ContainerConfig exposedPorts(Set<Integer> ports) {
+        if (ports != null && ports.size() > 0) {
+            JSONObject exposedPorts = new JSONObject();
+            for (Integer port : ports) {
+                exposedPorts.put(port.toString() + "/tcp", new JSONObject());
+            }
+            object.put("ExposedPorts", exposedPorts);
+        }
+        return this;
+    }
+
+    public String getImageName() {
+        return imageName;
+    }
+
+    public ContainerConfig hostname(String hostname) {
+        add("Hostname", hostname);
+        return this;
+    }
+
+    public ContainerConfig memory(long memory) {
+        if (memory != 0) {
+            object.put("Memory", memory);
+        }
+        return this;
+    }
+
+    public ContainerConfig memorySwap(long memorySwap) {
+        if (memorySwap != 0) {
+            object.put("MemorySwap", memorySwap);
+        }
+        return this;
+    }
+
+    public String toJson() {
+        return object.toString();
+    }
+
+    public ContainerConfig user(String user) {
+        add("User", user);
+        return this;
+    }
+
+    public ContainerConfig workingDir(String workingDir) {
+        add("WorkingDir", workingDir);
+        return this;
+    }
+
+    private void add(String name, String value) {
+        if (value != null) {
+            object.put(name, value);
+        }
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/access/ContainerHostConfig.java
+++ b/src/main/java/org/jolokia/docker/maven/access/ContainerHostConfig.java
@@ -1,0 +1,125 @@
+package org.jolokia.docker.maven.access;
+
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+
+/**
+ * Represents a configuration used to start a container
+ */
+public class ContainerHostConfig {
+
+    private final JSONObject object = new JSONObject();
+
+    public ContainerHostConfig bind(List<String> bind) {
+        if (bind != null && !bind.isEmpty()) {
+            JSONArray host = new JSONArray();
+            for (String volume : bind) {
+                if (volume.contains(":")) {
+                    host.put(volume);
+                }
+            }
+            object.put("Binds", host);
+        }
+        return this;
+    }
+
+    public ContainerHostConfig capAdd(List<String> capAdd)
+    {
+        if (capAdd != null) {
+            object.put("CapAdd", new JSONArray(capAdd));
+        }
+        return this;
+    }
+
+    public ContainerHostConfig capDrop(List<String> capDrop)
+    {
+        if (capDrop != null) {
+            object.put("CapDrop", new JSONArray(capDrop));
+        }
+        return this;
+    }
+
+    public ContainerHostConfig dns(List<String> dns)
+    {
+        if (dns != null) {
+            object.put("Dns", new JSONArray(dns));
+        }
+        return this;
+    }
+
+    public ContainerHostConfig dnsSearch(List<String> dnsSearch)
+    {
+        if (dnsSearch != null) {
+            object.put("DnsSearch", new JSONArray(dnsSearch));
+        }
+        return this;
+    }
+    
+    public ContainerHostConfig links(List<String> links) {
+        if (links != null) {
+            object.put("Links", new JSONArray(links));
+        }
+        return this;
+    }
+    
+    public ContainerHostConfig portBindings(PortMapping portMapping) {
+        Map<Integer, Integer> portMap = portMapping.getPortsMap();
+        if (!portMap.isEmpty()) {
+            JSONObject portBindings = new JSONObject();
+            Map<Integer, String> bindToMap = portMapping.getBindToMap();
+
+            for (Map.Entry<Integer, Integer> entry : portMap.entrySet()) {
+                Integer port = entry.getKey();
+                Integer hostPort = entry.getValue();
+
+                JSONObject o = new JSONObject();
+                o.put("HostPort", hostPort != null ? hostPort.toString() : "");
+
+                if (bindToMap.containsKey(port)) {
+                    o.put("HostIp", bindToMap.get(port));
+                }
+
+                JSONArray array = new JSONArray();
+                array.put(o);
+
+                portBindings.put(port + "/tcp", array);
+            }
+
+            object.put("PortBindings", portBindings);
+        }
+        return this;
+    }
+
+    public ContainerHostConfig privileged(boolean privileged)
+    {
+        object.put("Privileged", privileged);
+        return this;
+    }
+
+    public ContainerHostConfig restartPolicy(String name, int retry)
+    {
+        if (name != null) {
+            JSONObject policy = new JSONObject();
+            policy.put("Name", name);
+            policy.put("MaximumRetryCount", retry);
+            
+            object.put("RestartPolicy", policy);
+        }
+        return this;
+    }
+    
+    public String toJson() {
+        return object.toString();
+    }
+
+    public ContainerHostConfig volumesFrom(List<String> volumesFrom) {
+        if (volumesFrom != null) {
+            object.put("VolumesFrom", new JSONArray(volumesFrom));
+        }
+        return this;
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
@@ -24,14 +24,11 @@ public interface DockerAccess {
     /**
      * Create a container from the given image.
      *
-     * @param image the image from which the container should be created
-     * @param command an optional command which gets executed when starting the container. might be null.
-     * @param ports ports to expose, can be null
-     * @param env map with environment variables to use
+     * @param configuration container configuration
      * @return the container id
      * @throws DockerAccessException if the container could not be created.
      */
-    String createContainer(String image, String command, Set<Integer> ports, Map<String, String> env) throws DockerAccessException;
+    String createContainer(ContainerConfig configuration) throws DockerAccessException;
 
     /**
      * Get the the name of a container for a given container id
@@ -45,12 +42,11 @@ public interface DockerAccess {
     /**
      * Start a container.
      *
-     * @param containerId id of container to start
-     * @param portMapping port mapping to use. Must not be null.
-     * @param volumesFrom mount volumes from the given container id. Can be null.
+     * @param containerId container id
+     * @param configuration container host configuration
      * @throws DockerAccessException if the container could not be started.
      */
-    void startContainer(String containerId, PortMapping portMapping, List<String> volumesFrom, List<String> links) throws DockerAccessException;
+    void startContainer(String containerId, ContainerHostConfig configuration) throws DockerAccessException;
 
     /**
      * Stop a container.

--- a/src/main/java/org/jolokia/docker/maven/config/ImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/ImageConfiguration.java
@@ -56,12 +56,13 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable {
         return name;
     }
 
-    public String getAlias() {
+    @Override
+	public String getAlias() {
         return alias;
     }
 
     public RunImageConfiguration getRunConfiguration() {
-        return run;
+        return (run == null) ? RunImageConfiguration.DEFAULT : run;
     }
 
     public BuildImageConfiguration getBuildConfiguration() {

--- a/src/main/java/org/jolokia/docker/maven/config/RunImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/RunImageConfiguration.java
@@ -3,25 +3,74 @@ package org.jolokia.docker.maven.config;
 import java.util.List;
 import java.util.Map;
 
+import org.jolokia.docker.maven.access.ContainerHostConfig;
+import org.jolokia.docker.maven.config.RunImageConfiguration.Builder;
+import org.jolokia.docker.maven.config.RunImageConfiguration.RestartPolicy;
+
+
 /**
  * @author roland
  * @since 02.09.14
  */
 public class RunImageConfiguration {
 
-    public static final RunImageConfiguration DEFAULT = new RunImageConfiguration();
+    static final RunImageConfiguration DEFAULT = new RunImageConfiguration();
 
     // Environment variables to set when starting the container. key: variable name, value: env value
     /**
      * @parameter
      */
-    private Map<String,String> env;
+    private Map<String, String> env;
 
+    private boolean privileged;
+    
     // Command to execute in container
     /**
      * @parameter
      */
     private String command;
+
+    // container domain name
+    /**
+     * @parameter
+     */
+    private String domainname;
+
+    // container entry point
+    /**
+     * @parameter
+     */
+    private String entrypoint;
+
+    // container hostname
+    /**
+     * @parameter
+     */
+    private String hostname;
+
+    // container user
+    /**
+     * @parameter
+     */
+    private String user;
+
+    // working directory
+    /**
+     * @paramter
+     */
+    private String workingDir;
+
+    // memory in bytes
+    /**
+     * @parameter
+     */
+    private long memory;
+
+    // total memory (swap + ram) in bytes, -1 to disable
+    /**
+     * @parameter
+     */
+    private long memorySwap;
 
     // Path to a file where the dynamically mapped properties are written to
     /**
@@ -29,6 +78,26 @@ public class RunImageConfiguration {
      */
     private String portPropertyFile;
 
+    /**
+     * @parameter
+     */
+    private List<String> dns;
+
+    /**
+     * @parameter
+     */
+    private List<String> dnsSearch;
+
+    /**
+     * @parameter
+     */
+    private List<String> capAdd;
+
+    /**
+     * @parameter
+     */
+    private List<String> capDrop;
+    
     // Port mapping. Can contain symbolic names in which case dynamic
     // ports are used
     /**
@@ -41,6 +110,11 @@ public class RunImageConfiguration {
      * @parameter
      */
     private List<String> volumes;
+
+    /**
+     * @parameter
+     */
+    private List<String> bind;
 
     // Links to other container started
     /**
@@ -55,22 +129,40 @@ public class RunImageConfiguration {
      */
     private WaitConfiguration wait;
 
-    public RunImageConfiguration() {}
+    /**
+     * @parameter
+     */
+    private RestartPolicy restartPolicy;
 
-    RunImageConfiguration(Map<String, String> env, String command, String portPropertyFile,
-                          List<String> ports, List<String> volumes, List<String> links,
-                          WaitConfiguration wait) {
-        this.env = env;
-        this.command = command;
-        this.portPropertyFile = portPropertyFile;
-        this.ports = ports;
-        this.volumes = volumes;
-        this.links = links;
-        this.wait = wait;
+    public RunImageConfiguration() {
     }
 
     public Map<String, String> getEnv() {
         return env;
+    }
+
+    public String getEntrypoint() {
+        return entrypoint;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public String getDomainname() {
+        return domainname;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public long getMemory() {
+        return memory;
+    }
+
+    public long getMemorySwap() {
+        return memorySwap;
     }
 
     public List<String> getPorts() {
@@ -85,8 +177,32 @@ public class RunImageConfiguration {
         return portPropertyFile;
     }
 
+    public String getWorkingDir() {
+        return workingDir;
+    }
+    
     public WaitConfiguration getWaitConfiguration() {
         return wait;
+    }
+
+    public List<String> getBind() {
+        return bind;
+    }
+    
+    public List<String> getCapAdd() {
+        return capAdd;
+    }
+
+    public List<String> getCapDrop() {
+        return capDrop;
+    }
+    
+    public List<String> getDns() {
+        return dns;
+    }
+
+    public List<String> getDnsSearch() {
+        return dnsSearch;
     }
 
     public List<String> getVolumesFrom() {
@@ -97,55 +213,156 @@ public class RunImageConfiguration {
         return links;
     }
 
-    // ======================================================================================
+    public boolean getPrivileged() {
+        return privileged;
+    }
+
+    public RunImageConfiguration.RestartPolicy getRestartPolicy() {
+        return (restartPolicy == null) ? RestartPolicy.DEFAULT : restartPolicy;
+    }
+    
+// ======================================================================================
 
     public static class Builder {
-        private Map<String, String> env;
-        private String command;
-        private String portPropertyFile;
-        private List<String> ports;
-        private List<String> volumes;
-        private List<String> links;
-        private WaitConfiguration wait;
+        private RunImageConfiguration config = new RunImageConfiguration();
 
         public Builder env(Map<String, String> env) {
-            this.env = env;
+            config.env = env;
             return this;
         }
 
         public Builder command(String command) {
-            this.command = command;
+            config.command = command;
+            return this;
+        }
+
+        public Builder domainname(String domainname) {
+            config.domainname = domainname;
+            return this;
+        }
+
+        public Builder entrypoint(String entrypoint) {
+            config.entrypoint = entrypoint;
+            return this;
+        }
+
+        public Builder hostname(String hostname) {
+            config.hostname = hostname;
             return this;
         }
 
         public Builder portPropertyFile(String portPropertyFile) {
-            this.portPropertyFile = portPropertyFile;
+            config.portPropertyFile = portPropertyFile;
             return this;
         }
 
+        public Builder workingDir(String workingDir) {
+            config.workingDir = workingDir;
+            return this;
+        }
+
+        public Builder user(String user) {
+            config.user = user;
+            return this;
+        }
+
+        public Builder memory(long memory) {
+            config.memory = memory;
+            return this;
+        }
+
+        public Builder memorySwap(long memorySwap) {
+            config.memorySwap = memorySwap;
+            return this;
+        }
+
+        public Builder bind(List<String> bind) {
+            config.bind = bind;
+            return this;
+        }
+
+        public Builder capAdd(List<String> capAdd) {
+            config.capAdd = capAdd;
+            return this;
+        }
+        
+        public Builder capDrop(List<String> capDrop) {
+            config.capDrop = capDrop;
+            return this;
+        }
+        
+        public Builder dns(List<String> dns) {
+            config.dns = dns;
+            return this;
+        }
+        
+        public Builder dnsSearch(List<String> dnsSearch) {
+            config.dnsSearch = dnsSearch;
+            return this;
+        }
+        
         public Builder ports(List<String> ports) {
-            this.ports = ports;
+            config.ports = ports;
             return this;
         }
 
         public Builder volumes(List<String> volumes) {
-            this.volumes = volumes;
+            config.volumes = volumes;
             return this;
         }
 
         public Builder links(List<String> links) {
-            this.links = links;
+            config.links = links;
             return this;
         }
 
         public Builder wait(WaitConfiguration wait) {
-            this.wait = wait;
+            config.wait = wait;
             return this;
         }
 
+        public Builder privileged(boolean privileged) {
+            config.privileged = privileged;
+            return this;
+        }
+        
+        public Builder restartPolicy(RestartPolicy restartPolicy) {
+            config.restartPolicy = restartPolicy;
+            return this;
+        }    
+        
         public RunImageConfiguration build() {
-            return new RunImageConfiguration(env, command, portPropertyFile, ports,
-                                             volumes, links, wait);
+            return config;
+        }
+    }
+
+    public static class RestartPolicy {
+
+        private static final RestartPolicy DEFAULT = new RestartPolicy();
+        
+        /**
+         * @parameter
+         */
+        private String name;
+
+        /**
+         * @parameter
+         */
+        private int retry;
+
+        public RestartPolicy() {}
+        
+        public RestartPolicy(String name, int retry) {
+            this.name = name;
+            this.retry = retry;
+        }
+        
+        public String getName() {
+            return name;
+        }
+
+        public int getRetry() {
+            return retry;
         }
     }
 }

--- a/src/test/java/org/jolokia/docker/maven/StartMojoContainerConfigsTest.java
+++ b/src/test/java/org/jolokia/docker/maven/StartMojoContainerConfigsTest.java
@@ -1,0 +1,125 @@
+package org.jolokia.docker.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Scanner;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.jolokia.docker.maven.access.ContainerConfig;
+import org.jolokia.docker.maven.access.ContainerHostConfig;
+import org.jolokia.docker.maven.access.DockerAccess;
+import org.jolokia.docker.maven.access.DockerAccessException;
+import org.jolokia.docker.maven.access.PortMapping;
+import org.jolokia.docker.maven.config.RunImageConfiguration;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+
+public class StartMojoContainerConfigsTest {
+
+    private static final String BIND = "/tmp:/tmp";
+
+    @Test
+    @SuppressWarnings("unused")
+    public void testCreateContainerAllConfig() throws Exception {
+        /*-
+         * this is really two tests in one
+         *  - verify the start mojo calls all the methods to build the container configs
+         *  - the container configs produce the correct json when all options are specified
+         *  
+         * it didn't seem worth the effor to build a separate test to verify the json and then mock/verify all the calls here
+         */
+        final RunImageConfiguration runConfig =
+                new RunImageConfiguration.Builder().hostname("hostname").domainname("domain.com").user("user").memory(1).memorySwap(1)
+                        .env(env()).command("date").entrypoint("entrypoint").bind(bind()).workingDir("/foo").ports(ports()).links(links())
+                        .volumes(volumesFrom()).dns(dns()).dnsSearch(dnsSearch()).privileged(true).capAdd(capAdd()).capDrop(capDrop())
+                        .restartPolicy(restartPolicy()).build();
+
+        StartMojo mojo = new StartMojo() {
+            @Override
+            List<String> findContainersForImages(List<String> images) throws MojoExecutionException {
+                return images;
+            }
+
+            @Override
+            List<String> findLinksWithContainerNames(DockerAccess docker, List<String> links) throws DockerAccessException {
+                return links;
+            }
+        };
+
+        PortMapping portMapping = mojo.getPortMapping(runConfig, new Properties());
+
+        ContainerConfig config = mojo.createContainerConfig("base", runConfig, portMapping.getContainerPorts());
+        ContainerHostConfig hostConfig = mojo.createHostConfig(null, runConfig, portMapping);
+
+        String expectedConfig = loadFile("docker/createContainerAll.json");
+        JSONAssert.assertEquals(expectedConfig, config.toJson(), true);
+
+        String expectedHostConfig = loadFile("docker/createHostConfigAll.json");
+        JSONAssert.assertEquals(expectedHostConfig, hostConfig.toJson(), true);
+    }
+
+    private List<String> bind() {
+        return Arrays.asList(BIND);
+    }
+
+    private List<String> capAdd() {
+        return Arrays.asList("NET_ADMIN");
+    }
+
+    private List<String> capDrop() {
+        return Arrays.asList("MKNOD");
+    }
+
+    private List<String> dns() {
+        return Arrays.asList("8.8.8.8");
+    }
+
+    private List<String> dnsSearch() {
+        return Arrays.asList("domain.com");
+    }
+
+    private Map<String, String> env() {
+        Map<String, String> env = new HashMap<>();
+        env.put("foo", "bar");
+
+        return env;
+    }
+
+    private List<String> links() {
+        return Arrays.asList("redis3:redis");
+    }
+
+    private String loadFile(String fileName) {
+        StringBuilder buffer = new StringBuilder();
+        File file = new File(getClass().getClassLoader().getResource(fileName).getFile());
+
+        try (Scanner scanner = new Scanner(file)) {
+            while (scanner.hasNextLine()) {
+                buffer.append(scanner.nextLine());
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return buffer.toString();
+    }
+
+    private List<String> ports() {
+        return Arrays.asList("0.0.0.0:11022:22");
+    }
+
+    private RunImageConfiguration.RestartPolicy restartPolicy() {
+        return new RunImageConfiguration.RestartPolicy("on-failure", 1);
+    }
+
+    private List<String> volumesFrom() {
+        return Arrays.asList("parent", "other:ro");
+    }
+}

--- a/src/test/resources/docker/createContainerAll.json
+++ b/src/test/resources/docker/createContainerAll.json
@@ -1,0 +1,14 @@
+{
+	"Hostname": "hostname",
+	"Domainname": "domain.com",
+	"User": "user",
+	"Memory": 1,
+	"MemorySwap": 1,
+	"Env": [ "foo=bar" ],
+	"Cmd": [ "date" ],
+	"Entrypoint": "entrypoint",
+	"Image": "base",
+	"Volumes":  { "/tmp": { } },
+	"WorkingDir": "/foo",
+	"ExposedPorts": { "22/tcp": { } }
+}

--- a/src/test/resources/docker/createHostConfigAll.json
+++ b/src/test/resources/docker/createHostConfigAll.json
@@ -1,0 +1,12 @@
+{
+    "Binds": [ "/tmp:/tmp" ],
+    "Links": [ "redis3:redis" ],
+    "PortBindings": { "22/tcp": [ { "HostIp" : "0.0.0.0", "HostPort": "11022" }] },
+    "Privileged":true,
+    "Dns": ["8.8.8.8"],
+    "DnsSearch": ["domain.com"],
+    "VolumesFrom": [ "parent", "other:ro" ],
+    "CapAdd": ["NET_ADMIN"],
+    "CapDrop": ["MKNOD"],
+    "RestartPolicy": { "Name": "on-failure", "MaximumRetryCount": 1 }
+}


### PR DESCRIPTION
in addition fixing #55, the following options can be set on the run configuration:
- hostname
- domainname
- user
- memory
- memorySwap
- entrypoint
- workingDir
- privileged
- dns
- dnsSearch
- capAdd
- capDrop
- restartPolicy
