### PR TITLE
#374 Use assembly baseDirectory if it is provided

### DIFF
--- a/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyManagerTest.java
+++ b/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyManagerTest.java
@@ -1,10 +1,8 @@
 package org.jolokia.docker.maven.assembly;
 
-import java.io.File;
-import java.util.Arrays;
-
-import mockit.*;
-import org.apache.maven.monitor.logging.DefaultLog;
+import mockit.Injectable;
+import mockit.NonStrictExpectations;
+import mockit.Tested;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.assembly.AssemblerConfigurationSource;
 import org.apache.maven.plugin.assembly.InvalidAssemblerConfigurationException;
@@ -24,7 +22,10 @@ import org.jolokia.docker.maven.util.AnsiLogger;
 import org.jolokia.docker.maven.util.MojoParameters;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DockerAssemblyManagerTest {
 
@@ -48,11 +49,46 @@ public class DockerAssemblyManagerTest {
         BuildImageConfiguration buildConfig = new BuildImageConfiguration();
         AssemblyConfiguration assemblyConfig = buildConfig.getAssemblyConfiguration();
 
-        DockerFileBuilder builder = assemblyManager.createDockerFileBuilder(buildConfig, assemblyConfig);
+        DockerFileBuilder builder = assemblyManager.createDockerFileBuilder(buildConfig, assemblyConfig, null);
         String content = builder.content();
 
         assertFalse(content.contains("COPY"));
         assertFalse(content.contains("VOLUME"));
+    }
+
+    @Test
+    public void testAssembly_Basedir() {
+        AssemblyConfiguration assemblyConfig = new AssemblyConfiguration();
+        BuildImageConfiguration buildConfig = new BuildImageConfiguration.Builder().assembly(assemblyConfig).build();
+
+        DockerFileBuilder builder = assemblyManager.createDockerFileBuilder(buildConfig, assemblyConfig, null);
+        String content = builder.content();
+
+        assertTrue(content, content.contains("COPY maven /maven"));
+
+        assemblyConfig = new AssemblyConfiguration.Builder().basedir("/test").build();
+        buildConfig = new BuildImageConfiguration.Builder().assembly(assemblyConfig).build();
+
+        builder = assemblyManager.createDockerFileBuilder(buildConfig, assemblyConfig, null);
+        content = builder.content();
+
+        assertTrue(content, content.contains("COPY maven /test"));
+
+        Assembly assembly = new Assembly();
+
+        builder = assemblyManager.createDockerFileBuilder(buildConfig, assemblyConfig, assembly);
+        content = builder.content();
+
+        assertTrue(content, content.contains("COPY maven /test"));
+
+        assembly.setBaseDirectory("/newbasedir");
+
+        builder = assemblyManager.createDockerFileBuilder(buildConfig, assemblyConfig, assembly);
+        content = builder.content();
+
+        assertTrue(content, content.contains("COPY maven /newbasedir"));
+
+
     }
 
     @Test


### PR DESCRIPTION
Fix for #374.  If a use specifies a `baseDirectory` in the assembly.xml, it should take precedence over the `baseDir` specified in the build image config
