### PR TITLE
#264, update references to boot2docker to include docker-machine

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -170,8 +170,9 @@ The high-level design goals and initial motiviation fort this plugin are:
 * A flexible, **dynamic port mapping** from container to host
   ports so that truly isolated builds could be made. This should
   work on indirect setups with VMs like
-  [boot2docker](https://github.com/boot2docker/boot2docker) for
-  running on OS X.
+  [boot2docker](https://github.com/boot2docker/boot2docker) or
+  [docker-machine](https://docs.docker.com/machine/) for
+  running on OS X/Windows.
 
 * It should be possible to **pull images** on the fly to get
   self-contained and repeatable builds with the only requirement to

--- a/doc/manual/docker-start.md
+++ b/doc/manual/docker-start.md
@@ -283,7 +283,7 @@ the exporting container exposes these directories). The image must be also confi
 the full image name, an alias name like *service* can be used, too.
 
 Please note, that no relative paths are allowed. However, you can use Maven variables in the path specifications. This
-should even work for boot2docker:
+should even work for boot2docker/docker-machine:
 
 ````xml
 <volumes>

--- a/doc/manual/global-configuration.md
+++ b/doc/manual/global-configuration.md
@@ -22,7 +22,7 @@ parentheses.
   use to communicate with the server.
 * **certPath** (`docker.certPath`) Since 1.3.0 Docker remote API requires
   communication via SSL and authentication with certificates when used
-  with boot2docker. These
+  with boot2docker or docker-machine. These
   certificates are normally stored
   in `~/.docker/`. With this configuration the path can be set
   explicitly. If not set, the fallback is first taken from the


### PR DESCRIPTION
The documentation referring to the deprecated boot2docker software makes the plugin sound dated even though it works fine with docker-machine.  I think this pull request addresses the intent of issue #264 