### PR TITLE
Refactor stream parsing to ensure safety.

### DIFF
--- a/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
@@ -1,0 +1,296 @@
+package io.fabric8.maven.docker.access.log;
+
+import com.google.common.base.Charsets;
+import io.fabric8.maven.docker.access.UrlBuilder;
+import io.fabric8.maven.docker.access.log.LogCallback;
+import io.fabric8.maven.docker.access.log.LogRequestor;
+import io.fabric8.maven.docker.access.util.RequestUtil;
+import io.fabric8.maven.docker.util.Timestamp;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class LogRequestorTest {
+    private static final String containerId = RandomStringUtils.randomAlphabetic(64);
+
+    @Mocked(stubOutClassInitialization = true)
+    final RequestUtil unused = null;
+
+    @Mocked
+    HttpResponse httpResponse;
+
+    @Mocked
+    UrlBuilder urlBuilder;
+
+    @Mocked
+    StatusLine statusLine;
+
+    @Mocked
+    HttpEntity httpEntity;
+
+    @Mocked
+    HttpUriRequest httpUriRequest;
+
+    @Mocked
+    LogCallback callback;
+
+    @Mocked
+    HttpClient client;
+
+    @Test
+    public void testEmptyMessage() throws Exception {
+        final Streams type = Streams.STDOUT;
+        final ByteBuffer headerBuffer = ByteBuffer.allocate(8);
+        headerBuffer.put((byte) type.type);
+        headerBuffer.putInt(4, 0);
+        final InputStream inputStream = new ByteArrayInputStream(headerBuffer.array());
+
+        setupMocks(inputStream);
+        new LogRequestor(client, urlBuilder, containerId, callback).fetchLogs();
+
+        new Verifications() {{
+            callback.log(type.type, (Timestamp) any, anyString);
+            times = 0;
+        }};
+    }
+
+    @Test
+    public void testStdoutMessage() throws Exception {
+        final Streams type = Streams.STDOUT;
+        final String message0 = RandomStringUtils.randomAlphanumeric(257);
+        final String message1 = "test test";
+        final String message2 = RandomStringUtils.randomAlphanumeric(666);
+
+        final ByteBuffer body = responseContent(type, message0, message1, message2);
+        final InputStream inputStream = new ByteArrayInputStream(body.array());
+
+        setupMocks(inputStream);
+        new LogRequestor(client, urlBuilder, containerId, callback).fetchLogs();
+
+        new Verifications() {{
+            callback.log(type.type, (Timestamp) any, message0);
+            callback.log(type.type, (Timestamp) any, message1);
+            callback.log(type.type, (Timestamp) any, message2);
+        }};
+    }
+
+    @Test
+    public void testAllStreams() throws Exception {
+        final Random rand = new Random();
+        final int upperBound = 1024;
+
+        final Streams type0 = Streams.STDIN;
+        final String msg0 = RandomStringUtils.randomAlphanumeric(rand.nextInt(upperBound));
+        final ByteBuffer buf0 = messageToBuffer(type0, msg0);
+
+        final Streams type1 = Streams.STDOUT;
+        final String msg1 = RandomStringUtils.randomAlphanumeric(rand.nextInt(upperBound));
+        final ByteBuffer buf1 = messageToBuffer(type1, msg1);
+
+        final Streams type2 = Streams.STDERR;
+        final String msg2 = RandomStringUtils.randomAlphanumeric(rand.nextInt(upperBound));
+        final ByteBuffer buf2 = messageToBuffer(type2, msg2);
+
+        final ByteBuffer body = combineBuffers(buf0, buf1, buf2);
+        final InputStream inputStream = new ByteArrayInputStream(body.array());
+
+        setupMocks(inputStream);
+        new LogRequestor(client, urlBuilder, containerId, callback).fetchLogs();
+
+        new Verifications() {{
+            callback.log(type0.type, (Timestamp) any, msg0);
+            callback.log(type1.type, (Timestamp) any, msg1);
+            callback.log(type2.type, (Timestamp) any, msg2);
+        }};
+    }
+
+    @Test
+    public void testGarbageMessage() throws Exception {
+        final Streams type = Streams.STDERR;
+        final ByteBuffer buf0 = messageToBuffer(type, "This is a test message");
+        final ByteBuffer buf1 = messageToBuffer(type, "This is another test message!");
+
+        // Add one extra byte to buf0.
+        int l0 = buf0.getInt(4);
+        buf0.putInt(4, l0 + 1);
+
+        // Set incorrect length in buf1.
+        int l1 = buf1.getInt(4);
+        buf1.putInt(4, l1 + 512);
+
+        final ByteBuffer messages = ByteBuffer.allocate(buf0.limit() + buf1.limit());
+        buf0.position(0);
+        buf1.position(0);
+        messages.put(buf0);
+        messages.put(buf1);
+
+        final InputStream inputStream = new ByteArrayInputStream(messages.array());
+
+        setupMocks(inputStream);
+
+        new LogRequestor(client, urlBuilder, containerId, callback).fetchLogs();
+
+        new Verifications() {{
+            // Should have called log() one time (for the first message). The message itself would
+            // have been incorrect, since we gave it the wrong buffer length. The second message
+            // fails to parse as the buffer runs out.
+            callback.log(type.type, (Timestamp) any, anyString);
+            times = 1;
+        }};
+    }
+
+    @Test
+    public void testMessageTooShort() throws Exception {
+        final Streams type = Streams.STDIN;
+        final ByteBuffer buf = messageToBuffer(type, "A man, a plan, a canal, Panama!");
+
+        // Set length too long so reading buffer overflows.
+        int l = buf.getInt(4);
+        buf.putInt(4, l + 1);
+
+        final InputStream inputStream = new ByteArrayInputStream(buf.array());
+        setupMocks(inputStream);
+
+        new LogRequestor(client, urlBuilder, containerId, callback).fetchLogs();
+
+        new Verifications() {{
+            // No calls to .log() should be made, as message parsing fails.
+            callback.log(type.type, (Timestamp) any, anyString);
+            times = 0;
+        }};
+    }
+
+    @Test
+    public void testMessageWithExtraBytes() throws Exception {
+        final Streams type = Streams.STDOUT;
+        final String message = "A man, a plan, a canal, Panama!";
+        final ByteBuffer buf = messageToBuffer(type, message);
+
+        // Set length too short so there is extra buffer left after reading.
+        int l = buf.getInt(4);
+        buf.putInt(4, l - 1);
+
+        final InputStream inputStream = new ByteArrayInputStream(buf.array());
+        setupMocks(inputStream);
+
+        new LogRequestor(client, urlBuilder, containerId, callback).fetchLogs();
+
+        assertThat("Entire InputStream read.", ((ByteArrayInputStream) inputStream).available(), equalTo(0));
+        new Verifications() {{
+            // .log() is only called once. The one byte that is left off is lost and never recorded.
+            callback.log(type.type, (Timestamp) any, message.substring(0, message.length() - 1));
+            times = 1;
+        }};
+    }
+
+    private void setupMocks(final InputStream inputStream) throws Exception {
+        new Expectations() {{
+            RequestUtil.newGet(anyString);
+            result = httpUriRequest;
+
+            client.execute((HttpUriRequest) any);
+            result = httpResponse;
+
+            httpResponse.getStatusLine();
+            result = statusLine;
+
+            statusLine.getStatusCode();
+            result = 200;
+
+            httpResponse.getEntity();
+            result = httpEntity;
+
+            httpEntity.getContent();
+            result = inputStream;
+        }};
+    }
+
+    private enum Streams {
+        STDIN(0),
+        STDOUT(1),
+        STDERR(2);
+
+        public final int type;
+
+        Streams(int type) {
+            this.type = type;
+        }
+    }
+
+    /**
+     * Create a bytebuffer with all the messages. Timestamps will be added to each one.
+     */
+    private static ByteBuffer responseContent(Streams stream, String... messages) throws Exception {
+        List<ByteBuffer> buffers = new ArrayList<>(messages.length);
+        for (String message : messages) {
+            buffers.add(messageToBuffer(stream, message));
+        }
+
+        ByteBuffer[] bufArray = new ByteBuffer[buffers.size()];
+        return combineBuffers(buffers.toArray(bufArray));
+    }
+
+    private static ByteBuffer combineBuffers(ByteBuffer... buffers) {
+        int length = 0;
+        for (ByteBuffer b : buffers) {
+            length += b.limit();
+        }
+
+        ByteBuffer result = ByteBuffer.allocate(length);
+        for (ByteBuffer b : buffers) {
+            b.position(0);
+            result = result.put(b);
+        }
+
+        return result;
+    }
+
+    /**
+     * Create a bytebuffer for a single string message. A timestamp will be added.
+     */
+    private static ByteBuffer messageToBuffer(Streams stream, String message) throws Exception {
+        String logMessage = logMessage(message);
+
+        CharsetEncoder encoder = Charsets.UTF_8.newEncoder();
+        ByteBuffer payload = encoder.encode(CharBuffer.wrap(logMessage.toCharArray()));
+        assert payload.order() == ByteOrder.BIG_ENDIAN;
+        int length = payload.limit();
+
+        ByteBuffer result = ByteBuffer.allocate(length + 8);
+        result.order(ByteOrder.BIG_ENDIAN);
+
+        result.put((byte) stream.type);
+        result.position(result.position() + 3);
+        result.putInt(length);
+        result.put(payload);
+
+        return result;
+    }
+
+    /**
+     * Create a new string from message that has a timestamp prefix.
+     */
+    private static String logMessage(String message) {
+        return String.format("[2015-08-05T12:34:56Z] %s", message);
+    }
+}


### PR DESCRIPTION
Use ByteBuffers and ByteStreams.readFully() to ensure buffers are correctly
filled. Previously, it was possible to read a partial header or partial message, because
[IOUtils.read][0] only "guarantees that it will read as many bytes as possible before giving
up". This means it could read all 8 bytes requested for the header or all N bytes
requested for message, but it could also read fewer bytes in which case it would end up
with a partial header or message.

[0]: https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/IOUtils.html#read(java.io.InputStream,%20byte[],%20int,%20int)

readStreamFrame() is inspired by and based on:

https://gist.github.com/dflemstr/9541193d141729b6c84d/e02c64c67826a2a4291eb1e950bef1e71999b8d3#file-dockerlogstream-java-L90-L115

#### Motivation

Using this configuration in pom.xml:

```maven-pom
            <plugin>
                <groupId>org.jolokia</groupId>
                <artifactId>docker-maven-plugin</artifactId>
                <version>0.13.2</version>
                <configuration>
                    <verbose>true</verbose>
                    <images>
                        <image>
                            <name>${docker.imageName}:${project.version}-${buildNumber}</name>
                            <alias>db-tag</alias>
                            <run>
                                <log>
                                    <prefix>DB-TAG</prefix>
                                </log>
                                <links>
                                    <link>postgres:postgres</link>
                                </links>
                                <env>
                                    <RDS_USERNAME>${docker-maven-plugin.POSTGRES_USER}
                                    </RDS_USERNAME>
                                    <RDS_PASSWORD>${docker-maven-plugin.POSTGRES_PASSWORD}
                                    </RDS_PASSWORD>
                                    <RDS_DB_NAME>${docker-maven-plugin.POSTGRES_DB}
                                    </RDS_DB_NAME>
                                </env>
                                <!-- Should match contents of .ebextentions/10_liquibase.config -->
                                <cmd>
                                    db tag
                                    --migrations /liquibase/db.changelog.yml
                                    /docker-it.yml
                                    ${project.artifactId}-${project.version}-${buildNumber}
                                </cmd>
                                <wait>
                                    <log>liquibase: Successfully released change log lock</log>
                                    <time>300000</time>
                                </wait>
                            </run>
                        </image>
                    </images>
                </configuration>
                <executions>
                    <execution>
                        <id>start</id>
                        <phase>pre-integration-test</phase>
                        <goals>
                            <goal>build</goal>
                            <goal>start</goal>
                        </goals>
                    </execution>
                    <execution>
                        <id>stop</id>
                        <phase>post-integration-test</phase>
                        <goals>
                            <goal>stop</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
```

About 50% of the time, the expected output from docker container would show up,
but the plugin would not recognize it and eventually timeout. An example log
snippet is:

```
/liquibase/db.changelog.initial.yml::15::thomasvandoren: ChangeSet /liquibase/db.changelog.initial.yml::15::thomasvandoren ran successfully in 3ms
DB-TAG> INFO  [2015-08-04 23:14:17,573] liquibase: Successfully released change log lock
Exception in thread "Thread-17" java.lang.IllegalArgumentException: Invalid format: "04T23:14:17.483Z" is malformed at "T23:14:17.483Z"
          at org.joda.time.format.DateTimeFormatter.parseDateTime(DateTimeFormatter.java:873)
          at org.jolokia.docker.maven.util.Timestamp.<init>(Timestamp.java:53)
          at org.jolokia.docker.maven.access.log.LogRequestor.callLogCallback(LogRequestor.java:142)
          at org.jolokia.docker.maven.access.log.LogRequestor.parseResponse(LogRequestor.java:121)
          at org.jolokia.docker.maven.access.log.LogRequestor.run(LogRequestor.java:97)
[ERROR] DOCKER> [thomasvandoren/test-repo:0.2-SNAPSHOT-1402d5319ddf30d2] "db-tag": Timeout after 300000 ms while waiting on on log out 'liquibase: Successfully released change log lock'
```

Other invalid format error messages that I observed include:

```
Exception in thread "Thread-13" java.lang.IllegalArgumentException: Invalid format: "?2015-08-05T20:33:12.280Z"
Exception in thread "Thread-16" java.lang.IllegalArgumentException: Invalid format: "02T02:04:28.607Z" is malformed at "T02:04:28.607Z"
Exception in thread "Thread-16" java.lang.IllegalArgumentException: Invalid format: ".000��"
```

There were also cases where no stack trace was printed, the expected line did
show up, but the plugin still timed out "waiting" for it. I'm not sure what failed in
those cases.

This all seems like potential corrupt byte buffer behavior to me, which led to
this change.

Signed-off-by: Thomas Van Doren <thomas.vandoren@gmail.com>

Related to: #259