### PR TITLE
launch docker-machine to get environment

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/DockerEnvironment.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerEnvironment.java
@@ -1,0 +1,267 @@
+package io.fabric8.maven.docker.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * launch docker-machine to obtain environment settings
+ */
+public class DockerEnvironment {
+
+    private final Map<String, String> env;
+    private final Logger log;
+
+    public DockerEnvironment(Logger log) throws MojoExecutionException {
+        this.log = log;
+
+        Map<String, Boolean> machines = new LsCommand().getMachines();
+        String machine = "default";
+        if (machines.isEmpty()) {
+            new CreateCommand();
+        } else {
+            if (!machines.containsKey(machine)) {
+                for (Map.Entry<String, Boolean> entry : machines.entrySet()) {
+                    machine = entry.getKey();
+                    if (entry.getValue()) {
+                        // choose first running machine
+                        break;
+                    }
+                }
+            }
+            if (!machines.get(machine)) {
+                // "default" or chosen machine may need to be started
+                new StartCommand(machine);
+            }
+        }
+
+        env = new EnvCommand(machine).getEnvironment();
+    }
+
+    public Map<String, String> getEnvironment() {
+        return env;
+    }
+
+    // docker-machine create --driver virtualbox default
+    // docker-machine env [default]
+    // docker-machine ls
+    abstract class DockerCommand {
+        private final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        void execute() throws MojoExecutionException {
+            final Process process = startDockerMachineProcess();
+            try {
+                closeOutputStream(process.getOutputStream());
+                Future<IOException> stderrFuture = startStreamPump(process.getErrorStream(), (line) -> {
+                    synchronized (log) {
+                        log.error(line);
+                    }
+                });
+
+                outputStreamPump(process.getInputStream());
+
+                stopStreamPump(stderrFuture);
+                checkProcessExit(process);
+            } catch (MojoExecutionException e) {
+                process.destroy();
+                throw e;
+            }
+        }
+
+        private void checkProcessExit(Process process) {
+            try {
+                executor.shutdown();
+                executor.awaitTermination(10, TimeUnit.SECONDS);
+                int rc = process.exitValue();
+                if (rc != 0) {
+                    log.info("docker-machine exited with status " + rc);
+                }
+            } catch (IllegalThreadStateException | InterruptedException e) {
+                process.destroy();
+            }
+        }
+
+        private void closeOutputStream(OutputStream outputStream) {
+            try {
+                outputStream.close();
+            } catch (IOException e) {
+                log.info("failed to close docker-machine output stream: " + e.getMessage());
+            }
+        }
+
+        private Process startDockerMachineProcess(String... args) throws MojoExecutionException {
+            try {
+                return Runtime.getRuntime().exec(getArgs());
+            } catch (IOException e) {
+                throw new MojoExecutionException("failed to start docker-machine", e);
+            }
+        }
+
+        protected abstract String[] getArgs();
+
+        private void outputStreamPump(final InputStream inputStream) throws MojoExecutionException {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));) {
+                for (;;) {
+                    String line = reader.readLine();
+                    if (line == null) {
+                        break;
+                    }
+                    processLine(line);
+                }
+            } catch (IOException e) {
+                throw new MojoExecutionException("failed to read docker-machine output", e);
+            }
+        }
+
+        protected void processLine(String line) {
+            log.info(line);
+        }
+
+        private Future<IOException> startStreamPump(final InputStream errorStream, Consumer<String> logLine) {
+            return executor.submit(new Callable<IOException>() {
+                @Override
+                public IOException call() {
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream));) {
+                        for (;;) {
+                            String line = reader.readLine();
+                            if (line == null) {
+                                break;
+                            }
+                            logLine.accept(line);
+                        }
+                        return null;
+                    } catch (IOException e) {
+                        return e;
+                    }
+                }
+            });
+        }
+
+        private void stopStreamPump(Future<IOException> future) throws MojoExecutionException {
+            try {
+                IOException e = future.get(2, TimeUnit.SECONDS);
+                if (e != null) {
+                    throw new MojoExecutionException("failed to read docker-machine error stream", e);
+                }
+            } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException | TimeoutException e) {
+                throw new MojoExecutionException("failed to stop docker-machine error stream", e);
+            }
+        }
+    }
+
+    private static final String SET_PREFIX = "SET ";
+    private static final int SET_PREFIX_LEN = SET_PREFIX.length();
+
+    // docker-machine env machine
+    class EnvCommand extends DockerCommand {
+
+        private final Map<String, String> env = new HashMap<>();
+        private final String machine;
+
+        public EnvCommand(String machine) throws MojoExecutionException {
+            this.machine = machine;
+            execute();
+        }
+
+        @Override
+        protected String[] getArgs() {
+            return new String[] { "docker-machine", "env", machine, "--shell", "cmd" };
+        }
+
+        @Override
+        protected void processLine(String line) {
+            log.verbose(line);
+            if (line.startsWith(SET_PREFIX)) {
+                setEnvironmentVariable(line.substring(SET_PREFIX_LEN));
+            }
+        }
+
+        // parse line like SET DOCKER_HOST=tcp://192.168.99.100:2376
+        private void setEnvironmentVariable(String setLine) {
+            int equals = setLine.indexOf('=');
+            if (equals < 0) {
+                return;
+            }
+            String name = setLine.substring(0, equals);
+            String value = setLine.substring(equals + 1);
+            log.info(name + "=" + value);
+            env.put(name, value);
+        }
+
+        public Map<String, String> getEnvironment() throws MojoExecutionException {
+            return env;
+        }
+    }
+
+    // docker-machine ls --format "{{.Name}} {{.State}}"
+    class LsCommand extends DockerCommand {
+
+        private final Map<String, Boolean> machines = new HashMap<>();
+
+        public LsCommand() throws MojoExecutionException {
+            execute();
+        }
+
+        @Override
+        protected String[] getArgs() {
+            return new String[] { "docker-machine", "ls", "--format", "{{.Name}} {{.State}}" };
+        }
+
+        @Override
+        protected void processLine(String line) {
+            log.verbose(line);
+            int space = line.indexOf(' ');
+            String machineName = line.substring(0, space);
+            String state = line.substring(space + 1);
+            machines.put(machineName, "Running".equalsIgnoreCase(state));
+        }
+
+        public Map<String, Boolean> getMachines() {
+            return machines;
+        }
+    }
+
+    // docker-machine create --driver virtualbox default
+    class CreateCommand extends DockerCommand {
+
+        public CreateCommand() throws MojoExecutionException {
+            execute();
+        }
+
+        @Override
+        protected String[] getArgs() {
+            return new String[] { "docker-machine", "create", "--driver", "virtualbox", "default" };
+        }
+    }
+
+    // docker-machine start machine
+    class StartCommand extends DockerCommand {
+        private final String machine;
+
+        public StartCommand(String machine) throws MojoExecutionException {
+            this.machine = machine;
+            execute();
+        }
+
+        @Override
+        protected String[] getArgs() {
+            return new String[] { "docker-machine", "start", machine };
+        }
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/util/DockerMachine.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerMachine.java
@@ -1,0 +1,67 @@
+package io.fabric8.maven.docker.util;
+
+import java.io.File;
+import java.util.Map;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import io.fabric8.maven.docker.AbstractDockerMojo;
+
+/**
+ * get environment from DockerMachine
+ */
+public class DockerMachine {
+
+    private final Logger log;
+    private final Map pluginContext;
+    
+    public DockerMachine(Logger log, Map pluginContext) {
+        this.log = log;
+        this.pluginContext = pluginContext;
+    }
+
+    // Check both, url and env DOCKER_HOST (first takes precedence)
+    public String extractUrl(String dockerHost) throws MojoExecutionException {
+        String connect = dockerHost != null ? dockerHost : getDockerMachineEnv("DOCKER_HOST");
+        if (connect == null) {
+            File unixSocket = new File("/var/run/docker.sock");
+            if (unixSocket.exists() && unixSocket.canRead() && unixSocket.canWrite()) {
+                connect = "unix:///var/run/docker.sock";
+            } else {
+                throw new IllegalArgumentException(
+                        "No url given, no DOCKER_HOST environment variable and no read/writable '/var/run/docker.sock'");
+            }
+        }
+        String protocol = connect.contains(":" + AbstractDockerMojo.DOCKER_HTTPS_PORT) ? "https:" : "http:";
+        return connect.replaceFirst("^tcp:", protocol);
+    }
+
+    public String getCertPath(String certPath) throws MojoExecutionException {
+        String path = certPath != null ? certPath : getDockerMachineEnv("DOCKER_CERT_PATH");
+        if (path == null) {
+            File dockerHome = new File(System.getProperty("user.home") + "/.docker");
+            if (dockerHome.isDirectory() && dockerHome.list(SuffixFileFilter.PEM_FILTER).length > 0) {
+                return dockerHome.getAbsolutePath();
+            }
+        }
+        return path;
+    }
+
+    public String getDockerMachineEnv(String key) throws MojoExecutionException {
+        String value = System.getenv(key);
+        if(value!=null) {
+            return value;
+        }
+
+        String pluginContextKey = getClass().getCanonicalName();
+        synchronized(pluginContext) {
+            @SuppressWarnings("unchecked")
+            Map<String,String> dockerEnv = (Map<String,String>)pluginContext.get(pluginContextKey);
+            if(dockerEnv==null) {
+                dockerEnv =  new DockerEnvironment(log).getEnvironment();
+                pluginContext.put(pluginContextKey, dockerEnv);
+            }
+            return dockerEnv.get(key);
+        }
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -1,11 +1,18 @@
 package io.fabric8.maven.docker.util;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.fabric8.maven.docker.AbstractDockerMojo;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
@@ -19,32 +26,6 @@ public class EnvUtil {
     public static final String MAVEN_PROPERTY_REGEXP = "\\s*\\$\\{\\s*([^}]+)\\s*}\\s*$";
 
     private EnvUtil() {}
-
-    // Check both, url and env DOCKER_HOST (first takes precedence)
-    public static String extractUrl(String dockerHost) {
-        String connect = dockerHost != null ? dockerHost : System.getenv("DOCKER_HOST");
-        if (connect == null) {
-            File unixSocket = new File("/var/run/docker.sock");
-            if (unixSocket.exists() && unixSocket.canRead() && unixSocket.canWrite()) {
-                connect = "unix:///var/run/docker.sock";
-            } else {
-                throw new IllegalArgumentException("No url given, no DOCKER_HOST environment variable and no read/writable '/var/run/docker.sock'");
-            }
-        }
-        String protocol = connect.contains(":" + AbstractDockerMojo.DOCKER_HTTPS_PORT) ? "https:" : "http:";
-        return connect.replaceFirst("^tcp:", protocol);
-    }
-    
-    public static String getCertPath(String certPath) {
-        String path = certPath != null ? certPath : System.getenv("DOCKER_CERT_PATH");
-        if (path == null) {
-            File dockerHome = new File(System.getProperty("user.home") + "/.docker");
-            if (dockerHome.isDirectory() && dockerHome.list(SuffixFileFilter.PEM_FILTER).length > 0) {
-                return dockerHome.getAbsolutePath();
-            }
-        }
-        return path;
-    }
 
     /**
      * Compare to version strings and return the larger version strings. This is used in calculating

--- a/src/test/java/integration/DockerAccessIT.java
+++ b/src/test/java/integration/DockerAccessIT.java
@@ -1,25 +1,37 @@
 package integration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.common.collect.Lists;
-import io.fabric8.maven.docker.access.*;
-import io.fabric8.maven.docker.util.AnsiLogger;
-import io.fabric8.maven.docker.util.EnvUtil;
-import io.fabric8.maven.docker.util.Logger;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
 import io.fabric8.maven.docker.AbstractDockerMojo;
+import io.fabric8.maven.docker.access.ContainerCreateConfig;
+import io.fabric8.maven.docker.access.ContainerHostConfig;
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.access.PortMapping;
 import io.fabric8.maven.docker.access.hc.DockerAccessWithHcClient;
 import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.model.Container.PortBinding;
-import org.junit.*;
-
-import static org.junit.Assert.*;
+import io.fabric8.maven.docker.util.AnsiLogger;
+import io.fabric8.maven.docker.util.DockerMachine;
+import io.fabric8.maven.docker.util.Logger;
 
 /*
  * if run from your ide, this test assumes you have configured the runner w/ the appropriate env variables
@@ -38,8 +50,10 @@ public class DockerAccessIT {
     private String containerId;
     private final DockerAccessWithHcClient dockerClient;
 
-    public DockerAccessIT() {
-        this.dockerClient = createClient(EnvUtil.extractUrl(null), new AnsiLogger(new SystemStreamLog(), true, true));
+    public DockerAccessIT() throws MojoExecutionException {
+        AnsiLogger logger = new AnsiLogger(new SystemStreamLog(), true, true);
+        String url = new DockerMachine(logger, new HashMap<>()).extractUrl(null);
+        this.dockerClient = createClient(url, logger);
     }
 
     @Before
@@ -79,10 +93,14 @@ public class DockerAccessIT {
 
     private DockerAccessWithHcClient createClient(String baseUrl, Logger logger) {
         try {
-            return new DockerAccessWithHcClient(AbstractDockerMojo.API_VERSION, baseUrl, EnvUtil.getCertPath(null), 20, logger);
+            String certPath = new DockerMachine(logger, new HashMap<>()).getCertPath(null);
+            return new DockerAccessWithHcClient(AbstractDockerMojo.API_VERSION, baseUrl, certPath, 20, logger);
         } catch (@SuppressWarnings("unused") IOException e) {
             // not using ssl, so not going to happen
             throw new RuntimeException();
+        } catch (MojoExecutionException e) {
+            logger.error(e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/integration/DockerMachineIT.java
+++ b/src/test/java/integration/DockerMachineIT.java
@@ -1,0 +1,24 @@
+package integration;
+
+import java.util.Map;
+
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.fabric8.maven.docker.util.AnsiLogger;
+import io.fabric8.maven.docker.util.DockerEnvironment;
+
+/*
+ * if run from your ide, this test assumes you have docker-machine installed
+ */
+//@Ignore
+public class DockerMachineIT {
+
+    @Test
+    public void testLaunchDockerMachine() throws Exception {
+        DockerEnvironment de = new DockerEnvironment(new AnsiLogger(new SystemStreamLog(), true, true));
+        Map<String, String> environment = de.getEnvironment();
+        Assert.assertTrue(environment.get("DOCKER_HOST") != null);
+    }
+}


### PR DESCRIPTION
If docker environment variables are not set, use docker-machine to get what should be the environment variables. 

* If no machine is available, create 'default' machine.
* otherwise, select a machine
 * If only one machine is available, use it.
 * If multiple machines available, 
    * prefer to use 'default' machine.
    * If no 'default' machine, use the first running machine. 
 * If selected machine is not running, start it.  
* query selected machine for environment variables.

Since this is a time consuming process, cache results for other mojo executions in same Maven session