### PR TITLE
Add support for setting dockerFile and dockerFileDir via maven properties

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -244,7 +244,10 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         List<ImageConfiguration> ret = new ArrayList<>();
         if (images != null) {
             for (ImageConfiguration image : images) {
-                ret.addAll(imageConfigResolver.resolve(image, project.getProperties()));
+                for (ImageConfiguration resolved : imageConfigResolver.resolve(image, project.getProperties())) {
+                    resolved.initAndValidate(log);
+                    ret.add(resolved);
+                }
             }
             verifyImageNames(ret);
         }

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -310,10 +310,9 @@ public class BuildImageConfiguration {
         }
 
         public Builder cmd(String cmd) {
-            if (config.cmd == null) {
-                config.cmd = new Arguments();
+            if (cmd != null) {
+                config.cmd = new Arguments(cmd);
             }
-            config.cmd.setShell(cmd);
             return this;
         }
         
@@ -337,10 +336,9 @@ public class BuildImageConfiguration {
         }
 
         public Builder entryPoint(String entryPoint) {
-            if (config.entryPoint == null) {
-                config.entryPoint = new Arguments();
+            if (entryPoint != null) {
+                config.entryPoint = new Arguments(entryPoint);
             }
-            config.entryPoint.setShell(entryPoint);
             return this;
         }
         

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -266,7 +266,9 @@ public class RunImageConfiguration {
         }
 
         public Builder cmd(String cmd) {
-            config.cmd = new Arguments(cmd);
+            if (cmd != null) {
+                config.cmd = new Arguments(cmd);
+            }
             return this;
         }
 
@@ -276,7 +278,9 @@ public class RunImageConfiguration {
         }
 
         public Builder entrypoint(String entrypoint) {
-            config.entrypoint = new Arguments(entrypoint);
+            if (entrypoint != null) {
+                config.entrypoint = new Arguments(entrypoint);
+            }
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -43,6 +43,8 @@ public enum ConfigKey {
     DOMAINNAME,
     DNS,
     DNS_SEARCH,
+    DOCKER_FILE,
+    DOCKER_FILE_DIR,
     ENTRYPOINT,
     ENV,
     ENV_PROPERTY_FILE,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -78,6 +78,8 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .maintainer(withPrefix(prefix, MAINTAINER, properties))
                 .workdir(withPrefix(prefix, WORKDIR, properties))
                 .skip(withPrefix(prefix, ConfigKey.SKIP_BUILD, properties))
+                .dockerFile(withPrefix(prefix, ConfigKey.DOCKER_FILE, properties))
+                .dockerFileDir(withPrefix(prefix, ConfigKey.DOCKER_FILE_DIR, properties))
                 .build();
     }
 


### PR DESCRIPTION
After upgrading to v0.15.1, I see the `docker.assembly.dockerFileDir` has been deprecated.  It would be nice to retain support for configuring via properties.

In addition, when the `BuildImageConfiguration` is resolved from properties, the `initAndValidate()` method needs to be called in order for the `dockerFileFile` and `dockerFileMode` to be set (`docker.assembly.dockerFileDir` no longer works).
