### PR TITLE
Adding general user command

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -262,7 +262,8 @@ public class DockerAssemblyManager {
                         .labels(buildConfig.getLabels())
                         .expose(buildConfig.getPorts())
                         .run(buildConfig.getRunCmds())
-                        .volumes(buildConfig.getVolumes());
+                        .volumes(buildConfig.getVolumes())
+                        .user(buildConfig.getUser());
         if (buildConfig.getMaintainer() != null) {
             builder.maintainer(buildConfig.getMaintainer());
         }
@@ -272,7 +273,7 @@ public class DockerAssemblyManager {
         if (assemblyConfig != null) {
             builder.add(ASSEMBLY_NAME, "")
                    .basedir(assemblyConfig.getBasedir())
-                   .user(assemblyConfig.getUser())
+                   .assemblyUser(assemblyConfig.getUser())
                    .exportBasedir(assemblyConfig.exportBasedir());
         } else {
             builder.exportBasedir(false);

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
@@ -37,6 +37,9 @@ public class DockerFileBuilder {
     private Boolean exportBasedir = null;
 
     // User under which the files should be added
+    private String assemblyUser;
+
+    // User to run as
     private String user;
 
     // List of files to add. Source and destination follow except that destination
@@ -103,7 +106,15 @@ public class DockerFileBuilder {
         addCmd(b);
         addEntryPoint(b);
 
+        addUser(b);
+
         return b.toString();
+    }
+
+    private void addUser(StringBuilder b) {
+        if ( user != null) {
+            DockerFileKeyword.USER.addTo(b, user);
+        }
     }
 
     private void addWorkdir(StringBuilder b) {
@@ -135,11 +146,11 @@ public class DockerFileBuilder {
     }
 
     private void addEntries(StringBuilder b) {
-        if (user != null) {
+        if (assemblyUser != null) {
             String tmpDir = createTempDir();
             copyAddEntries(b,tmpDir);
 
-            String[] userParts = StringUtils.split(user, ":");
+            String[] userParts = StringUtils.split(assemblyUser, ":");
             String userArg = userParts.length > 1 ? userParts[0] + ":" + userParts[1] : userParts[0];
             String chmod = "chown -R " + userArg + " " + tmpDir + " && cp -rp " + tmpDir + "/* / && rm -rf " + tmpDir;
             if (userParts.length > 2) {
@@ -272,6 +283,11 @@ public class DockerFileBuilder {
 
     public DockerFileBuilder entryPoint(Arguments entryPoint) {
         this.entryPoint = entryPoint;
+        return this;
+    }
+
+    public DockerFileBuilder assemblyUser(String assemblyUser) {
+        this.assemblyUser = assemblyUser;
         return this;
     }
 

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -118,6 +118,9 @@ public class BuildImageConfiguration {
      */
     private Arguments cmd;
 
+    /** @parameter */
+    private String user;
+
     /**
      * @parameter
      */
@@ -222,6 +225,10 @@ public class BuildImageConfiguration {
 
     public List<String> getRunCmds() {
         return runCmds;
+    }
+
+    public String getUser() {
+      return user;
     }
 
     public Map<String, String> getArgs() {
@@ -343,7 +350,12 @@ public class BuildImageConfiguration {
             config.entryPoint.setShell(entryPoint);
             return this;
         }
-        
+
+        public Builder user(String user) {
+            config.user = user;
+            return this;
+        }
+
         public Builder skip(String skip) {
             if (skip != null) {
                 config.skip = Boolean.valueOf(skip);

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -78,6 +78,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .maintainer(withPrefix(prefix, MAINTAINER, properties))
                 .workdir(withPrefix(prefix, WORKDIR, properties))
                 .skip(withPrefix(prefix, ConfigKey.SKIP_BUILD, properties))
+                .user(withPrefix(prefix, USER, properties))
                 .build();
     }
 

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
@@ -96,14 +96,24 @@ public class DockerFileBuilderTest {
     }
 
     @Test
-    public void testUserWithChown() {
-        String dockerFile = new DockerFileBuilder().user("jboss:jboss:jboss")
+    public void testAssemblyUserWithChown() {
+        String dockerFile = new DockerFileBuilder().assemblyUser("jboss:jboss:jboss")
                                                    .add("a","a/nested").add("b","b/deeper/nested").content();
         String EXPECTED_REGEXP = "chown\\s+-R\\s+jboss:jboss\\s+([^\\s]+)"
                                  + "\\s+&&\\s+cp\\s+-rp\\s+\\1/\\*\\s+/\\s+&&\\s+rm\\s+-rf\\s+\\1";
         Pattern pattern = Pattern.compile(EXPECTED_REGEXP);
         assertTrue(pattern.matcher(dockerFile).find());
     }
+
+    @Test
+    public void testUser() {
+        String dockerFile = new DockerFileBuilder().assemblyUser("jboss:jboss:jboss").user("bob")
+                                                   .add("a","a/nested").add("b","b/deeper/nested").content();
+        String EXPECTED_REGEXP = "USER bob$";
+        Pattern pattern = Pattern.compile(EXPECTED_REGEXP);
+        assertTrue(pattern.matcher(dockerFile).find());
+    }
+
 
     @Test
     public void testExportBaseDir() {


### PR DESCRIPTION
Just allowing for changing user during assembly creation does not allow for commands to have executed prior to using the "USER" tag.. In my use case I was calling "adduser <user>" in a RUN command but since the RUN commands don't execute until after the assembly is unpacked if you need to have files owned by a specific user you'd need to have mutliple containers and layer this in..

this patch adds a generalized "user" tag which goes at the end of the Dockerfile.