### PR TITLE
Select always the last volume part after splitting at the colon.

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
@@ -139,7 +139,7 @@ public class ContainerCreateConfig {
         if (volume.contains(":")) {
             String[] parts = volume.split(":");
             if (parts.length > 1) {
-                return parts[1];
+                return parts[parts.length - 1];
             }
         }
         return volume;


### PR DESCRIPTION
On windows you may end with the following volume declaration:
c:\this\is\my\path:/data

When splitted on : and the second part is selected we end with \this\is\my\path which won't work.
By selecting the last part, we get the correct /data