### PR TITLE
add docker machine support

### DIFF
--- a/samples/cargo-jolokia-demo/pom.xml
+++ b/samples/cargo-jolokia-demo/pom.xml
@@ -22,13 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.15-SNAPSHOT</version>
+    <version>0.15.7</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.fabric8</groupId>
   <artifactId>cargo-jolokia-demo</artifactId>
-  <version>0.15-SNAPSHOT</version>
 
   <url>http://www.jolokia.org</url>
 
@@ -78,6 +77,13 @@
         <version>${project.version}</version>
         <extensions>true</extensions>
         <configuration>
+        <machine>
+          <autoCreate>true</autoCreate>
+          <createOptions>
+            <virtualbox-memory>10000</virtualbox-memory>
+            <virtualbox-no-share></virtualbox-no-share>
+          </createOptions>
+        </machine>
           <images>
             <image>
               <name>${image}</name>

--- a/samples/data-jolokia-demo/pom.xml
+++ b/samples/data-jolokia-demo/pom.xml
@@ -28,7 +28,6 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>docker-jolokia-demo</artifactId>
-  <version>0.15.7</version>
   <!-- add custom lifecycle -->
   <packaging>docker</packaging>
 
@@ -83,9 +82,14 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>${project.version}</version>
         <extensions>true</extensions> <!-- enables using 'docker' packaging above -->
         <configuration>
+          <machine>
+            <createOptions>
+              <driver>virtualbox</driver>
+            </createOptions>
+          </machine>
+
           <watchInterval>500</watchInterval>
           <logDate>default</logDate>
           <verbose>true</verbose>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -27,7 +27,7 @@
   <url>http://www.jolokia.org</url>
 
   <properties>
-    <docker.maven.plugin.version>${project.version}</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.15-SNAPSHOT</docker.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
@@ -14,7 +14,6 @@ import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.*;
 import org.apache.maven.archiver.MavenArchiveConfiguration;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -35,9 +34,6 @@ abstract public class AbstractBuildSupportMojo extends AbstractDockerMojo {
 
     @Parameter
     private MavenArchiveConfiguration archive;
-
-    @Parameter(defaultValue = "${session}", readonly = true)
-    protected MavenSession session;
 
     @Component
     private MavenFileFilter mavenFileFilter;

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -27,6 +27,7 @@ import org.codehaus.plexus.context.Context;
 import org.codehaus.plexus.context.ContextException;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.config.MachineConfiguration;
 import io.fabric8.maven.docker.config.handler.ImageConfigResolver;
 import io.fabric8.maven.docker.log.LogDispatcher;
 import io.fabric8.maven.docker.log.LogOutputSpecFactory;
@@ -67,8 +68,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     protected Settings settings;
 
     // Current maven project
-    @Parameter(defaultValue= "${session}", readonly = true)
+    @Parameter(property= "session")
     protected MavenSession session;
+
+    // Current mojo execution
+    @Parameter(property= "mojoExecution")
+    protected MojoExecution execution;
 
     // Handler for external configurations
     @Component
@@ -149,6 +154,10 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
      */
     @Parameter
     private List<ImageConfiguration> images;
+
+    // Docker-machine configuration
+    @Parameter
+    private MachineConfiguration machine;
 
     // Images resolved with external image resolvers and hooks for subclass to
     // mangle the image configurations.
@@ -240,11 +249,26 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     private DockerAccess createDockerAccess(String minimalVersion) throws MojoExecutionException, MojoFailureException {
         DockerAccess access = null;
         if (isDockerAccessRequired()) {
-            String dockerUrl = EnvUtil.extractUrl(dockerHost);
+            boolean isDefaults = machine == null;
+            if (isDefaults) {
+                // create instance to resolve system defines
+                // docker.machine.name and docker.machine.autoCreate
+                machine = new MachineConfiguration();
+            }
+            isDefaults &= machine.resolveDefines(new PluginParameterExpressionEvaluator(session, execution), getLog());
+            log.debug(machine.toString());
+            if (isDefaults) {
+                // if no <machine> configuration and no system defines, do not
+                // use docker-machine
+                machine = null;
+            }
+
+            DockerMachine dockerMachine = new DockerMachine(log, machine);
+            String dockerUrl = dockerMachine.extractUrl(dockerHost);
             try {
                 String version =  minimalVersion != null ? minimalVersion : API_VERSION;
                 access = new DockerAccessWithHcClient("v" + version, dockerUrl,
-                                                      EnvUtil.getCertPath(certPath), maxConnections, log);
+                        dockerMachine.getCertPath(certPath), maxConnections, log);
                 access.start();
                 setDockerHostAddressProperty(dockerUrl);
             }

--- a/src/main/java/io/fabric8/maven/docker/config/MachineConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/MachineConfiguration.java
@@ -1,0 +1,105 @@
+package io.fabric8.maven.docker.config;
+
+import java.util.Map;
+
+import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Configuration;
+
+@Component(role = MachineConfiguration.class, instantiationStrategy = "per-lookup")
+public class MachineConfiguration {
+
+    /**
+     * Name of the docker-machine
+     * @parameter expression="${docker.machine.name}" default-value="default"
+     */
+    @Configuration("${docker.machine.name}")
+    private String name;
+
+    /**
+     * Should the docker-machine be created if it does not exist?
+     * @parameter expression="${docker.machine.autoCreate}" default-value="false"
+     */
+    @Configuration("${docker.machine.autoCreate}")
+    private Boolean autoCreate;
+
+    /**
+     * When creating a docker-machine, the map of createOptions for the driver.
+     * Do not include the '--' portion of the option name.  For options without values, leave the value text empty.
+     * e.g. --virtualbox-cpu-count 1 --virtualbox-no-share would be written as:<code>
+     * &lt;virtualbox-cpu-count&gt;1&lt;/virtualbox-cpu-count&gt;
+     * &lt;virtualbox-no-share/&gt;
+     * </code>
+     */
+    private Map<String, String> createOptions;
+
+    private boolean isDefaults = true;
+    private Map<String, String> env;
+    
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean getAutoCreate() {
+        return autoCreate;
+    }
+
+    public void setAutoCreate(Boolean autoCreate) {
+        this.autoCreate = autoCreate;
+    }
+
+    public Map<String, String> getCreateOptions() {
+        return createOptions;
+    }
+
+    public void setCreateOptions(Map<String, String> createOptions) {
+        this.createOptions = createOptions;
+    }
+
+    public Map<String, String> getEnv() {
+		return env;
+	}
+
+    public void setEnv(Map<String, String> env) {
+		this.env = env;
+	}
+
+    @Override
+    public String toString() {
+        return "MachineConfiguration [name=" + name + ", autoCreate=" + autoCreate + ", createOptions=" + createOptions + "]";
+    }
+
+    public boolean resolveDefines(PluginParameterExpressionEvaluator evaluator, Log log) {
+        name = resolveProperty(evaluator, log, String.class, name, "${docker.machine.name}", "default");
+        autoCreate = resolveProperty(evaluator, log, Boolean.class, autoCreate, "${docker.machine.autoCreate}", Boolean.FALSE);
+        return isDefaults;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T resolveProperty(PluginParameterExpressionEvaluator evaluator, Log log,
+            Class<T> type, T value, String expression, T defaultValue) {
+        if (value != null) {
+        	isDefaults = false;
+            return value;
+        }
+        try {
+            value = (T) evaluator.evaluate(expression, type);
+            if (value != null) {
+                if (!type.isInstance(value)) {
+                    String s = (String) value;
+                    return (T) (s.isEmpty() ? Boolean.TRUE : Boolean.valueOf(s));
+                }
+                isDefaults = false;
+                return value;
+            }
+        } catch (Exception ex) {
+            log.error(ex);
+        }
+        return defaultValue;
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/util/DockerEnvironment.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerEnvironment.java
@@ -1,0 +1,281 @@
+package io.fabric8.maven.docker.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import io.fabric8.maven.docker.config.MachineConfiguration;
+
+/**
+ * launch docker-machine to obtain environment settings
+ */
+public class DockerEnvironment {
+
+    private final Logger log;
+    private final MachineConfiguration machine;
+    private final Map<String, String> env;
+
+    public DockerEnvironment(Logger log, MachineConfiguration machine) throws MojoExecutionException {
+        this.log = log;
+        this.machine = machine;
+
+        Status status = new StatusCommand().getStatus();
+        switch (status) {
+        case DoesNotExist:
+            if (Boolean.TRUE == machine.getAutoCreate()) {
+                new CreateCommand().execute();
+            } else {
+                throw new MojoExecutionException(machine.getName() + " does not exist and docker.machine.autoCreate is false");
+            }
+            break;
+        case Running:
+            break;
+        case Stopped:
+            new StartCommand().execute();
+            break;
+        }
+        env = new EnvCommand().getEnvironment();
+    }
+
+    enum Status {
+        DoesNotExist, Running, Stopped
+    }
+
+    public Map<String, String> getEnvironment() {
+        return env;
+    }
+
+    abstract class DockerCommand {
+        private final ExecutorService executor = Executors.newFixedThreadPool(2);
+        int statusCode;
+
+        void execute() throws MojoExecutionException {
+            final Process process = startDockerMachineProcess();
+            try {
+                closeOutputStream(process.getOutputStream());
+                Future<IOException> stderrFuture = startStreamPump(process.getErrorStream());
+                outputStreamPump(process.getInputStream());
+
+                stopStreamPump(stderrFuture);
+                checkProcessExit(process);
+            } catch (MojoExecutionException e) {
+                process.destroy();
+                throw e;
+            }
+            if (statusCode != 0) {
+                throw new MojoExecutionException("docker-machine exited with status " + statusCode);
+            }
+        }
+
+        private void checkProcessExit(Process process) {
+            try {
+                executor.shutdown();
+                executor.awaitTermination(10, TimeUnit.SECONDS);
+                statusCode = process.exitValue();
+            } catch (IllegalThreadStateException | InterruptedException e) {
+                process.destroy();
+                statusCode = -1;
+            }
+        }
+
+        private void closeOutputStream(OutputStream outputStream) {
+            try {
+                outputStream.close();
+            } catch (IOException e) {
+                log.info("failed to close docker-machine output stream: " + e.getMessage());
+            }
+        }
+
+        private Process startDockerMachineProcess(String... args) throws MojoExecutionException {
+            try {
+                return Runtime.getRuntime().exec(getArgs());
+            } catch (IOException e) {
+                throw new MojoExecutionException("failed to start docker-machine", e);
+            }
+        }
+
+        protected abstract String[] getArgs();
+
+        private void outputStreamPump(final InputStream inputStream) throws MojoExecutionException {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));) {
+                for (;;) {
+                    String line = reader.readLine();
+                    if (line == null) {
+                        break;
+                    }
+                    processLine(line);
+                }
+            } catch (IOException e) {
+                throw new MojoExecutionException("failed to read docker-machine output", e);
+            }
+        }
+
+        protected void processLine(String line) {
+            log.info(line);
+        }
+
+        private Future<IOException> startStreamPump(final InputStream errorStream) {
+            return executor.submit(new Callable<IOException>() {
+                @Override
+                public IOException call() {
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream));) {
+                        for (;;) {
+                            String line = reader.readLine();
+                            if (line == null) {
+                                break;
+                            }
+                            synchronized (log) {
+                                log.error(line);
+                            }
+                        }
+                        return null;
+                    } catch (IOException e) {
+                        return e;
+                    }
+                }
+            });
+        }
+
+        private void stopStreamPump(Future<IOException> future) throws MojoExecutionException {
+            try {
+                IOException e = future.get(2, TimeUnit.SECONDS);
+                if (e != null) {
+                    throw new MojoExecutionException("failed to read docker-machine error stream", e);
+                }
+            } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException | TimeoutException e) {
+                throw new MojoExecutionException("failed to stop docker-machine error stream", e);
+            }
+        }
+    }
+
+    private static final String SET_PREFIX = "SET ";
+    private static final int SET_PREFIX_LEN = SET_PREFIX.length();
+
+    // docker-machine env <name>
+    class EnvCommand extends DockerCommand {
+
+        private final Map<String, String> env = new HashMap<>();
+
+        @Override
+        protected String[] getArgs() {
+            return new String[] { "docker-machine", "env", machine.getName(), "--shell", "cmd" };
+        }
+
+        @Override
+        protected void processLine(String line) {
+        	if(log.isDebugEnabled()) {
+        		log.verbose("%s", line);
+        	}
+            if (line.startsWith(SET_PREFIX)) {
+                setEnvironmentVariable(line.substring(SET_PREFIX_LEN));
+            }
+        }
+
+        // parse line like SET DOCKER_HOST=tcp://192.168.99.100:2376
+        private void setEnvironmentVariable(String line) {
+            int equals = line.indexOf('=');
+            if (equals < 0) {
+                return;
+            }
+            String name = line.substring(0, equals);
+            String value = line.substring(equals + 1);
+            log.info(name + "=" + value);
+            env.put(name, value);
+        }
+
+        public Map<String, String> getEnvironment() throws MojoExecutionException {
+            execute();
+            return env;
+        }
+    }
+
+    // docker-machine status <name>
+    class StatusCommand extends DockerCommand {
+
+        private Status status;
+        private String message;
+
+        @Override
+        protected String[] getArgs() {
+            return new String[] { "docker-machine", "status", machine.getName() };
+        }
+
+        @Override
+        protected void processLine(String line) {
+            log.verbose(line);
+            if ("Running".equals(line)) {
+                status = Status.Running;
+            } else if ("Stopped".equals(line)) {
+                status = Status.Stopped;
+            } else {
+                message = "Unknown status - " + line;
+            }
+        }
+
+        public Status getStatus() throws MojoExecutionException {
+            try {
+                execute();
+            }
+            catch(MojoExecutionException ex) {
+                if(statusCode==1) {
+                    status = Status.DoesNotExist;
+                }
+                else {
+                    throw ex;
+                }
+            }
+            if (message != null) {
+                throw new MojoExecutionException(message);
+            }
+            return status;
+        }
+    }
+
+    // docker-machine create --driver virtualbox <name>
+    class CreateCommand extends DockerCommand {
+
+        @Override
+        protected String[] getArgs() {
+            List<String> args = new ArrayList<>();
+            args.add("docker-machine");
+            args.add("create");
+            if (machine.getCreateOptions() != null) {
+                for (Map.Entry<String, String> entry : machine.getCreateOptions().entrySet()) {
+                    args.add("--" + entry.getKey());
+                    String value = entry.getValue();
+                    if (value != null && !value.isEmpty()) {
+                        args.add(value);
+                    }
+                }
+            }
+            args.add(machine.getName());
+            return args.toArray(new String[args.size()]);
+        }
+    }
+
+    // docker-machine start <name>
+    class StartCommand extends DockerCommand {
+
+        @Override
+        protected String[] getArgs() {
+            return new String[] { "docker-machine", "start", machine.getName() };
+        }
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/util/DockerMachine.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerMachine.java
@@ -1,0 +1,109 @@
+package io.fabric8.maven.docker.util;
+
+import java.io.File;
+import java.util.Map;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import io.fabric8.maven.docker.AbstractDockerMojo;
+import io.fabric8.maven.docker.config.MachineConfiguration;
+
+/**
+ * get environment from DockerMachine
+ */
+public class DockerMachine {
+
+    private final Logger log;
+    private final MachineConfiguration machine;
+
+    public DockerMachine(Logger log, MachineConfiguration machine) {
+        this.log = log;
+        this.machine = machine;
+    }
+
+    /**
+     * Get the docker host url.
+     * <ol>
+     * <li>From &lt;dockerHost&gt; configuration</li>
+     * <li>From &lt;machine&gt; configuration</li>
+     * <li>From DOCKER_HOST environment variable</li>
+     * <li>Default to /var/run/docker.sock</li>
+     * </ol>
+     * @param dockerHost The dockerHost configuration setting
+     * @return The docker host url
+     * @throws MojoExecutionException
+     */
+    public String extractUrl(String dockerHost) throws MojoExecutionException {
+        String connect = getUrl("DOCKER_HOST", dockerHost);
+        if (connect != null) {
+            String protocol = connect.contains(":" + AbstractDockerMojo.DOCKER_HTTPS_PORT) ? "https:" : "http:";
+            return connect.replaceFirst("^tcp:", protocol);
+        }
+        File unixSocket = new File("/var/run/docker.sock");
+        if (unixSocket.exists() && unixSocket.canRead() && unixSocket.canWrite()) {
+            return "unix:///var/run/docker.sock";
+        } 
+        throw new IllegalArgumentException("No <dockerHost> or <machine> given, no DOCKER_HOST environment variable, and no read/writable '/var/run/docker.sock'");
+    }
+    
+    /**
+     * Get the docker certificate location
+     * <ol>
+     * <li>From &lt;certPath&gt; configuration</li>
+     * <li>From &lt;machine&gt; configuration</li>
+     * <li>From DOCKER_CERT_PATH environment variable</li>
+     * <li>Default to ${user.home}/.docker</li>
+     * </ol>
+     * @param dockerHost The dockerHost configuration setting
+     * @return The docker certificate location, or null
+     * @throws MojoExecutionException
+     */
+    public String getCertPath(String certPath) throws MojoExecutionException {
+        String path = getUrl("DOCKER_CERT_PATH", certPath);
+        if (path == null) {
+            File dockerHome = new File(System.getProperty("user.home") + "/.docker");
+            if (dockerHome.isDirectory() && dockerHome.list(SuffixFileFilter.PEM_FILTER).length > 0) {
+                return dockerHome.getAbsolutePath();
+            }
+        }
+        return path;
+    }
+    
+    /**
+     * Get the option from the key
+     */
+    private String getUrl(String key, String value) throws MojoExecutionException {
+        if (value != null) {
+            return value;
+        }
+        value = getDockerMachineEnv(key);
+        if (value != null) {
+            return value;
+        }
+        return System.getenv(key);
+    }
+
+
+    /**
+     * Get a docker configuration value from the <machine> configuration section
+     * 
+     * @param key The configuration name
+     * @return The configuration value
+     * @throws MojoExecutionException
+     */
+    public String getDockerMachineEnv(String key) throws MojoExecutionException {
+		String value = System.getenv(key);
+		if (value != null) {
+			return value;
+		}
+		if (machine != null) {
+			Map<String, String> env = machine.getEnv();
+			if (env == null) {
+				env = new DockerEnvironment(log, machine).getEnvironment();
+				machine.setEnv(env);
+			}
+			return env.get(key);
+		}
+		return null;
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.fabric8.maven.docker.AbstractDockerMojo;
 import org.codehaus.plexus.util.StringUtils;
 
 import static java.util.concurrent.TimeUnit.*;
@@ -22,32 +21,6 @@ public class EnvUtil {
     public static final String MAVEN_PROPERTY_REGEXP = "\\s*\\$\\{\\s*([^}]+)\\s*}\\s*$";
 
     private EnvUtil() {}
-
-    // Check both, url and env DOCKER_HOST (first takes precedence)
-    public static String extractUrl(String dockerHost) {
-        String connect = dockerHost != null ? dockerHost : System.getenv("DOCKER_HOST");
-        if (connect == null) {
-            File unixSocket = new File("/var/run/docker.sock");
-            if (unixSocket.exists() && unixSocket.canRead() && unixSocket.canWrite()) {
-                connect = "unix:///var/run/docker.sock";
-            } else {
-                throw new IllegalArgumentException("No url given, no DOCKER_HOST environment variable and no read/writable '/var/run/docker.sock'");
-            }
-        }
-        String protocol = connect.contains(":" + AbstractDockerMojo.DOCKER_HTTPS_PORT) ? "https:" : "http:";
-        return connect.replaceFirst("^tcp:", protocol);
-    }
-    
-    public static String getCertPath(String certPath) {
-        String path = certPath != null ? certPath : System.getenv("DOCKER_CERT_PATH");
-        if (path == null) {
-            File dockerHome = new File(System.getProperty("user.home") + "/.docker");
-            if (dockerHome.isDirectory() && dockerHome.list(SuffixFileFilter.PEM_FILTER).length > 0) {
-                return dockerHome.getAbsolutePath();
-            }
-        }
-        return path;
-    }
 
     /**
      * Compare to version strings and return the larger version strings. This is used in calculating

--- a/src/test/java/integration/DockerMachineIT.java
+++ b/src/test/java/integration/DockerMachineIT.java
@@ -1,0 +1,32 @@
+package integration;
+
+import java.util.Map;
+
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.fabric8.maven.docker.config.MachineConfiguration;
+import io.fabric8.maven.docker.util.AnsiLogger;
+import io.fabric8.maven.docker.util.DockerEnvironment;
+
+/*
+ * if run from your ide, this test assumes you have docker-machine installed
+ */
+@Ignore
+public class DockerMachineIT {
+
+    @Test
+    public void testLaunchDockerMachine() throws Exception {
+        MachineConfiguration mc = new MachineConfiguration();
+        mc.setName("default");
+        mc.setAutoCreate(true);
+        mc.setCreateOptions(ImmutableMap.of("driver", "virtualbox"));
+        DockerEnvironment de = new DockerEnvironment(new AnsiLogger(new SystemStreamLog(), true, true), mc);
+        Map<String, String> environment = de.getEnvironment();
+        Assert.assertTrue(environment.get("DOCKER_HOST") != null);
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/util/DockerMachineTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/DockerMachineTest.java
@@ -1,0 +1,53 @@
+package io.fabric8.maven.docker.util;
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DockerMachineTest {
+
+    AnsiLogger logger = new AnsiLogger(new SystemStreamLog(), true, true);
+    DockerMachine machine = new DockerMachine(logger, null);
+
+    @Test
+    public void testGetUrlFromHostConfig() throws MojoExecutionException {
+        Assert.assertEquals("hostconfig", machine.extractUrl("hostconfig"));
+    }
+
+    @Test
+    public void testGetUrlFromEnvironment() throws MojoExecutionException {
+        String dockerHost = System.getenv("DOCKER_HOST");
+        if (dockerHost != null) {
+            Assert.assertEquals(dockerHost, machine.extractUrl(null));
+        } else {
+            try {
+                Assert.assertEquals("/var/run/docker.sock", machine.extractUrl(null));
+            } catch (IllegalArgumentException expectedIfNoUnixSocket) {
+            }
+        }
+    }
+
+    @Test
+    public void testGetCertPathFromCertConfig() throws MojoExecutionException {
+        Assert.assertEquals("certconfig", machine.getCertPath("certconfig"));
+    }
+
+    @Test
+    public void testGetCertPathFromEnvironment() throws MojoExecutionException {
+        String certPath = System.getenv("DOCKER_CERT_PATH");
+        if (certPath != null) {
+            Assert.assertEquals(certPath, machine.getCertPath(null));
+        } else {
+            String maybeUserDocker = machine.getCertPath(null);
+            if (maybeUserDocker != null) {
+                Assert.assertEquals(new File(System.getProperty("user.home"), ".docker").getAbsolutePath(),
+                        maybeUserDocker);
+            }
+        }
+    }
+
+    // any further testing requires a 'docker-machine' on the build host
+}


### PR DESCRIPTION
This pull request replaces https://github.com/fabric8io/docker-maven-plugin/pull/437.

Add a configuration section **&lt;machine&gt;** which configures use of docker-machine.  The precedence order of configuration is
1. **dockerHost** / **certPath**
2. **&lt;machine&gt;**
3. environment variables
4. fallbacks (`unix:///var/run/docker.sock` / `~/.docker/`)

**&lt;machine&gt;** has three sub-elements:
- **name** - the name of the docker-machine
- **autoCreate** - create the docker-machine if not present
- **creatOptions** -  the options used when creating a docker-machine

To use the **&lt;machine&gt;** element, docker-machine must be installed on the build host.
Before querying docker-machine for daemon values, the docker-machine will be started if necessary.