### PR TITLE
Skip push

### DIFF
--- a/doc/manual/docker-push.md
+++ b/doc/manual/docker-push.md
@@ -11,3 +11,7 @@ with tag `1.5` to the registry `docker.test.org` at port
 `5000`. Security information (i.e. user and password) can be specified
 in multiple ways as described in section [Authentication](authentication.html).
 
+* **skipPush** (`docker.skipPush`)
+  If set to `true` the plugin won't push any images that have been built.
+
+

--- a/src/main/java/io/fabric8/maven/docker/PushMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/PushMojo.java
@@ -32,22 +32,24 @@ public class PushMojo extends AbstractDockerMojo {
     /** {@inheritDoc} */
     @Override
     public void executeInternal(ServiceHub hub) throws DockerAccessException, MojoExecutionException {
-        for (ImageConfiguration imageConfig : getResolvedImages()) {
-            BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
-            String name = imageConfig.getName();
-            if (buildConfig != null) {
-                String configuredRegistry = getConfiguredRegistry(imageConfig, pushRegistry);
-                AuthConfig authConfig = prepareAuthConfig(new ImageName(name), configuredRegistry, true);
+        if (!skipPush) {
+            for (ImageConfiguration imageConfig : getResolvedImages()) {
+                BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
+                String name = imageConfig.getName();
+                if (buildConfig != null) {
+                    String configuredRegistry = getConfiguredRegistry(imageConfig, pushRegistry);
+                    AuthConfig authConfig = prepareAuthConfig(new ImageName(name), configuredRegistry, true);
 
-                DockerAccess docker = hub.getDockerAccess();
+                    DockerAccess docker = hub.getDockerAccess();
 
-                long start = System.currentTimeMillis();
-                docker.pushImage(name, authConfig, configuredRegistry);
-                log.info("Pushed %s in %s", name, EnvUtil.formatDurationTill(start));
+                    long start = System.currentTimeMillis();
+                    docker.pushImage(name, authConfig, configuredRegistry);
+                    log.info("Pushed %s in %s", name, EnvUtil.formatDurationTill(start));
 
-                for (String tag : imageConfig.getBuildConfiguration().getTags()) {
-                    if (tag != null) {
-                        docker.pushImage(new ImageName(name,tag).getFullName(), authConfig, configuredRegistry);
+                    for (String tag : imageConfig.getBuildConfiguration().getTags()) {
+                        if (tag != null) {
+                            docker.pushImage(new ImageName(name, tag).getFullName(), authConfig, configuredRegistry);
+                        }
                     }
                 }
             }

--- a/src/main/java/io/fabric8/maven/docker/PushMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/PushMojo.java
@@ -26,6 +26,9 @@ public class PushMojo extends AbstractDockerMojo {
     @Parameter(property = "docker.push.registry")
     private String pushRegistry;
 
+    @Parameter(property="docker.skipPush", defaultValue="false")
+    private boolean skipPush;
+
     /** {@inheritDoc} */
     @Override
     public void executeInternal(ServiceHub hub) throws DockerAccessException, MojoExecutionException {


### PR DESCRIPTION
Allow skip push via global parameter like skipBuild and skipTags and skipRun. The docker.skip parameter doesn't really fits into my use case without some configuration nightmare.