### PR TITLE
allow retries of a failed docker:push (resolves #508)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,12 +1,13 @@
 # ChangeLog
 
-* **0.15-SNAPSHOT** 
+* **0.15-SNAPSHOT**
   - Allow images to only be pulled once per build (useful for reactor projects) ([#504](https://github.com/fabric8io/docker-maven-plugin/issues/504))
+  - Allow retry of pushing a docker image in case of a 500 error ([#508](https://github.com/fabric8io/docker-maven-plugin/issues/508))
 
 * **0.15.10** (2016-07-19)
   - Don't do redirect when waiting on an HTTP port ([#499](https://github.com/fabric8io/docker-maven-plugin/issues/499))
   - Removed the container fetch limit of 100 and optimized getting containers by name and image ([#513](https://github.com/fabric8io/docker-maven-plugin/issues/513))
-  
+
 * **0.15.9** (2016-06-28)
   - Fixed issue when target directory does not exist yet ([#497](https://github.com/fabric8io/docker-maven-plugin/issues/497))
 

--- a/src/main/java/io/fabric8/maven/docker/PushMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/PushMojo.java
@@ -28,6 +28,9 @@ public class PushMojo extends AbstractDockerMojo {
     @Parameter(property = "docker.skip.push", defaultValue = "false")
     private boolean skipPush;
 
+    @Parameter(property = "docker.push.retries", defaultValue = "0")
+    private int retryCount;
+
     /**
      * {@inheritDoc}
      */
@@ -46,12 +49,12 @@ public class PushMojo extends AbstractDockerMojo {
                 DockerAccess docker = hub.getDockerAccess();
 
                 long start = System.currentTimeMillis();
-                docker.pushImage(name, authConfig, configuredRegistry);
+                docker.pushImage(name, authConfig, configuredRegistry, retryCount);
                 log.info("Pushed %s in %s", name, EnvUtil.formatDurationTill(start));
 
                 for (String tag : imageConfig.getBuildConfiguration().getTags()) {
                     if (tag != null) {
-                        docker.pushImage(new ImageName(name, tag).getFullName(), authConfig, configuredRegistry);
+                        docker.pushImage(new ImageName(name, tag).getFullName(), authConfig, configuredRegistry, retryCount);
                     }
                 }
             }

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -24,13 +24,13 @@ public interface DockerAccess {
      * Get the API version of the running server
      *
      * @return api version in the form "1.24"
-     * @throws DockerAccessException
+     * @throws DockerAccessException if the api version could not be obtained
      */
     String getServerApiVersion() throws DockerAccessException;
 
     /**
      * Inspect a container
-     * 
+     *
      * @param containerIdOrName container id or name
      * @return <code>ContainerDetails<code> representing the container or null if none could be found
      * @throws DockerAccessException if the container could not be inspected
@@ -117,7 +117,7 @@ public interface DockerAccess {
      * @param containerId container to copy into
      * @param archive local archive to copy into
      * @param targetPath target path to use
-     * @throws DockerAccessException
+     * @throws DockerAccessException if the archive could not be copied
      */
     void copyArchive(String containerId, File archive, String targetPath)
             throws DockerAccessException;
@@ -169,9 +169,10 @@ public interface DockerAccess {
      * @param image image name to push
      * @param authConfig authentication configuration
      * @param registry optional registry to which the image should be pushed.
+     * @param retries optional number of times the push should be retried on a 500 error
      * @throws DockerAccessException in case pushing fails
      */
-    void pushImage(String image, AuthConfig authConfig, String registry) throws DockerAccessException;
+    void pushImage(String image, AuthConfig authConfig, String registry, int retries) throws DockerAccessException;
 
     /**
      * Create an docker image from a given archive

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -24,6 +24,7 @@ import io.fabric8.maven.docker.model.NetworksListElement;
 import io.fabric8.maven.docker.util.*;
 import io.fabric8.maven.docker.access.hc.unix.UnixSocketClientBuilder;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
 import io.fabric8.maven.docker.access.hc.http.HttpClientBuilder;
 import org.json.JSONArray;
@@ -79,16 +80,16 @@ public class DockerAccessWithHcClient implements DockerAccess {
             throw new IllegalArgumentException("The docker access url '" + baseUrl + "' must contain a schema tcp:// or unix://");
         }
         if (uri.getScheme().equalsIgnoreCase("unix")) {
-            this.delegate =
-                    new ApacheHttpClientDelegate(new UnixSocketClientBuilder(uri.getPath(), maxConnections));
+            this.delegate = createHttpClient(new UnixSocketClientBuilder(uri.getPath(), maxConnections));
             this.urlBuilder = new UrlBuilder(DUMMY_BASE_URL, apiVersion);
         } else {
-            this.delegate = new ApacheHttpClientDelegate(new HttpClientBuilder(isSSL(baseUrl) ? certPath : null, maxConnections));
+            this.delegate = createHttpClient(new HttpClientBuilder(isSSL(baseUrl) ? certPath : null, maxConnections));
             this.urlBuilder = new UrlBuilder(baseUrl, apiVersion);
         }
     }
 
     /** {@inheritDoc} */
+    @Override
     public String getServerApiVersion() throws DockerAccessException {
         try {
             String url = urlBuilder.version();
@@ -333,14 +334,13 @@ public class DockerAccessWithHcClient implements DockerAccess {
     }
 
     @Override
-    public void pushImage(String image, AuthConfig authConfig, String registry)
+    public void pushImage(String image, AuthConfig authConfig, String registry, int retries)
             throws DockerAccessException {
         ImageName name = new ImageName(image);
         String pushUrl = urlBuilder.pushImage(name, registry);
         String temporaryImage = tagTemporaryImage(name, registry);
         try {
-            delegate.post(pushUrl, null, createAuthHeader(authConfig),
-                    createPullOrPushResponseHandler(), HTTP_OK);
+            pushImage(pushUrl, createAuthHeader(authConfig), createPullOrPushResponseHandler(), HTTP_OK, retries);
         } catch (IOException e) {
             throw new DockerAccessException(e, "Unable to push '%s'%s", image, (registry != null) ? " from registry '" + registry + "'" : "");
         } finally {
@@ -444,6 +444,10 @@ public class DockerAccessWithHcClient implements DockerAccess {
     public void shutdown() {
     }
 
+    ApacheHttpClientDelegate createHttpClient(ClientBuilder builder) throws IOException {
+        return new ApacheHttpClientDelegate(builder);
+    }
+
     // visible for testing?
     private HcChunkedResponseHandlerWrapper createBuildResponseHandler() {
         return new HcChunkedResponseHandlerWrapper(new BuildJsonResponseHandler(log));
@@ -459,6 +463,26 @@ public class DockerAccessWithHcClient implements DockerAccess {
             authConfig = AuthConfig.EMPTY_AUTH_CONFIG;
         }
         return Collections.singletonMap("X-Registry-Auth", authConfig.toHeaderValue());
+    }
+
+    private boolean isRetryableErrorCode(int errorCode) {
+        // there eventually could be more then one of this
+        return errorCode == HTTP_INTERNAL_ERROR;
+    }
+
+    private void pushImage(String url, Map<String, String> header, HcChunkedResponseHandlerWrapper handler, int status,
+            int retries) throws IOException {
+        for (int i = 0; i <= retries; i++) {
+            try {
+                delegate.post(url, null, header, handler, HTTP_OK);
+            } catch (HttpResponseException e) {
+                if (isRetryableErrorCode(e.getStatusCode()) && retries > 0) {
+                    log.warn("failed to push image to [{}], retrying...", url);
+                } else {
+                    throw e;
+                }
+            }
+        }
     }
 
     private String tagTemporaryImage(ImageName name, String registry) throws DockerAccessException {

--- a/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
@@ -1,0 +1,98 @@
+package io.fabric8.maven.docker.access.hc;
+
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.ResponseHandler;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.util.Logger;
+import mockit.Expectations;
+import mockit.Mocked;
+
+public class DockerAccessWithHcClientTest {
+
+    private AuthConfig authConfig;
+
+    private DockerAccessWithHcClient client;
+
+    private String imageName;
+
+    @Mocked
+    private ApacheHttpClientDelegate mockDelegate;
+
+    @Mocked
+    private Logger mockLogger;
+
+    private int pushRetries;
+
+    private String registry;
+
+    private Exception thrownException;
+
+    @Before
+    public void setup() throws IOException {
+        client = new DockerAccessWithHcClient("1.20", "tcp://1.2.3.4:2375", null, 1, mockLogger) {
+            @Override
+            ApacheHttpClientDelegate createHttpClient(ClientBuilder builder) throws IOException {
+                return mockDelegate;
+            }
+        };
+    }
+
+    @Test
+    public void testPushFailes_noRetry() throws Exception {
+        givenAnImageName("test");
+        givenThePushWillFail();
+        whenPushImage();
+        thenImageWasNotPushed();
+    }
+
+    @Test
+    public void testRetryPush() throws Exception {
+        givenAnImageName("test");
+        givenANumberOfRetries(1);
+        givenThePushWillFail();
+        whenPushImage();
+        thenImageWasPushed();
+    }
+
+    private void givenAnImageName(String imageName) {
+        this.imageName = imageName;
+    }
+
+    private void givenANumberOfRetries(int retries) {
+        this.pushRetries = retries;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void givenThePushWillFail() throws IOException {
+        new Expectations() {{
+            mockDelegate.post(anyString, null, (Map<String, String>) any, (ResponseHandler) any, 200);
+            result = new HttpResponseException(HTTP_INTERNAL_ERROR, "error");
+        }};
+    }
+
+    private void thenImageWasNotPushed() {
+        assertNotNull(thrownException);
+    }
+
+    private void thenImageWasPushed() {
+       assertNull(thrownException);
+    }
+
+    private void whenPushImage() {
+        try {
+            client.pushImage(imageName, authConfig, registry, pushRetries);
+        } catch (Exception e) {
+            thrownException = e;
+        }
+    }
+}


### PR DESCRIPTION
i went to update the docs to add the `retryCount` parameter and now i can't find them...