### PR TITLE
- parallel StartMojo

### DIFF
--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -31,6 +31,7 @@
           <logDate>default</logDate>
           <verbose>true</verbose>
           <autoPull>always</autoPull>
+          <startParallel>true</startParallel>
           <images>
             <image>
               <alias>box1</alias>
@@ -62,6 +63,9 @@
                   <name>test-network</name>
                   <alias>box2</alias>
                 </network>
+                <dependsOn>
+                  <dependsOn>box1</dependsOn>
+                </dependsOn>
                 <namingStrategy>none</namingStrategy>
                 <cmd>
                   <exec>

--- a/src/main/asciidoc/inc/_docker-start.adoc
+++ b/src/main/asciidoc/inc/_docker-start.adoc
@@ -29,6 +29,11 @@ include::start/_links.adoc[]
 
 include::start/_network.adoc[]
 
+[[start-depends-on]]
+=== Depends-On
+
+include::start/_depends-on.adoc[]
+
 [[start-restart]]
 === Restart Policy
 

--- a/src/main/asciidoc/inc/start/_configuration.adoc
+++ b/src/main/asciidoc/inc/start/_configuration.adoc
@@ -1,4 +1,20 @@
+In addition to the <<global-configuration>>, this goal supports the following global configuration options.
 
+.Start options
+[cols="1,5,1"]
+|===
+| Element | Description | Property
+
+| *showLogs*
+| In order to switch on globally the logs *showLogs* can be used as global configuration (i.e. outside of `<images>`). If set it will print out all standard
+ output and standard error messages for all containers started. As value the images for which logs should be shown can be given as a comma separated list.
+ This is probably most useful when used from the command line as system property `docker.showLogs`.
+| `docker.showLogs`
+| *startParallel*
+| Starts docker images in parallel while dependencies expressed as <<start-links,Link>> or <<start-depends-on,dependsOn>> are respected. This option can significantly reduce the startup time because independent containers do not need to wait for each other.
+| `docker.startParallel`
+
+|===
 
 The `<run>` configuration element knows the following sub elements:
 

--- a/src/main/asciidoc/inc/start/_depends-on.adoc
+++ b/src/main/asciidoc/inc/start/_depends-on.adoc
@@ -1,0 +1,15 @@
+Custom networks do not provide a mechanism like `<links>` to express strong links between containers. They are normally not required because docker ensures that all containers within the same custom network can eventually resolve each other via DNS.
+
+Your containers should preferably be able to deal with temporarily unresolvable dependencies but in some cases it is helpful to be able to rely the availability of other infrastructure containers.
+
+The `<dependsOn>` configuration can be used to expresses custom network dependencies between your containers. `docker:start` will ensure that all dependencies a container depends on are completely started (fulfilling all `<wait>` conditions) before the depending container is started.
+
+
+.Example
+[source,xml]
+----
+<dependsOn>
+    <dependsOn>postgres</dependsOn>
+    <dependsOn>logstash</dependsOn>
+</dependsOn>
+----

--- a/src/main/asciidoc/inc/start/_links.adoc
+++ b/src/main/asciidoc/inc/start/_links.adoc
@@ -27,6 +27,6 @@ DB_PORT_5432_TCP_ADDR=172.17.0.5
 
 If you wish to link to existing containers not managed by the plugin, you may do so by specifying the container name obtained via `docker ps` in the configuration.
 
-Please note that the link behaviour also depends on the network mode selected. Links as described are referred to by Docker as _legacy links_ and might vanish in the future. For custom networks no environments variables are set and links create merely network aliases for the linked container.
+Please note that the link behaviour also depends on the network mode selected. Links as described are referred to by Docker as _legacy links_ and might vanish in the future. For custom networks no environments variables are set and links create merely network aliases for the linked container. To express start order dependencies using custom networks refer to the <<start-depends-on,dependsOn>> configuration.
 
 For a more detailed documentation for the new link handling please refer to the https://docs.docker.com/engine/userguide/networking/work-with-networks/#linking-containers-in-user-defined-networks[Docker network documentation]

--- a/src/main/asciidoc/inc/start/_overview.adoc
+++ b/src/main/asciidoc/inc/start/_overview.adoc
@@ -1,6 +1,6 @@
 
 [[start-overview]]
-This goal creates and starts docker containers. This goals evaluates the configuration's `<run>` section of all given (and enabled images). In order to switch on globally the logs *showLogs* can be used as global configuration (i.e. outside of `<images>`). If set it will print out all standard output and standard error messages for all containers started. As value the images for which logs should be shown can be given as a comma separated list. This is probably most useful when used from the command line as system property `docker.showLogs`.
+This goal creates and starts docker containers. This goals evaluates the configuration's `<run>` section of all given (and enabled images).
 
 Also you can specify `docker.follow` as system property so that the `{plugin}:start` will never return but block until CTRL-C is pressed. That similar to the option `-i` for `docker run`. This will automatically switch on `showLogs` so that you can see what is happening within the container. Also, after stopping with CTRL-C, the container is stopped (but not removed so that you can make postmortem analysis).
 

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -8,6 +8,7 @@ package io.fabric8.maven.docker;
  * the License.
  */
 
+import com.google.common.util.concurrent.MoreExecutors;
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.PortMapping;
@@ -32,10 +33,21 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 
@@ -56,6 +68,9 @@ public class StartMojo extends AbstractDockerMojo {
 
     @Parameter(property = "docker.skip.run", defaultValue = "false")
     private boolean skipRun;
+
+    @Parameter(property = "docker.startParallel", defaultValue = "false")
+    private boolean startParallel;
 
     // whether to block during to start. Set it via System property docker.follow
     private boolean follow;
@@ -86,6 +101,16 @@ public class StartMojo extends AbstractDockerMojo {
     @Parameter
     protected String portPropertyFile;
 
+    private static final class StartedContainerImage {
+        public final ImageConfiguration imageConfig;
+        public final String containerId;
+
+        private StartedContainerImage(ImageConfiguration imageConfig, String containerId) {
+            this.imageConfig = imageConfig;
+            this.containerId = containerId;
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -97,18 +122,22 @@ public class StartMojo extends AbstractDockerMojo {
         }
         getPluginContext().put(CONTEXT_KEY_START_CALLED, true);
 
-        Properties projProperties = project.getProperties();
+        final Properties projProperties = project.getProperties();
         this.follow = Boolean.valueOf(System.getProperty("docker.follow", "false"));
 
         QueryService queryService = hub.getQueryService();
-        RunService runService = hub.getRunService();
+        final RunService runService = hub.getRunService();
 
-        LogDispatcher dispatcher = getLogDispatcher(hub);
+        final LogDispatcher dispatcher = getLogDispatcher(hub);
         PortMapping.PropertyWriteHelper portMappingPropertyWriteHelper = new PortMapping.PropertyWriteHelper(portPropertyFile);
 
         boolean success = false;
-        PomLabel pomLabel = getPomLabel();
+        final PomLabel pomLabel = getPomLabel();
+
         try {
+
+            final Queue<ImageConfiguration> imagesWaitingToStart = new ArrayDeque<>();
+
             for (StartOrderResolver.Resolvable resolvable : runService.getImagesConfigsInOrder(queryService, getResolvedImages())) {
                 final ImageConfiguration imageConfig = (ImageConfiguration) resolvable;
 
@@ -117,34 +146,111 @@ public class StartMojo extends AbstractDockerMojo {
 
                 String imageName = imageConfig.getName();
                 checkImageWithAutoPull(hub, imageName,
-                                       getConfiguredRegistry(imageConfig,pullRegistry),imageConfig.getBuildConfiguration() == null);
+                        getConfiguredRegistry(imageConfig, pullRegistry), imageConfig.getBuildConfiguration() == null);
 
                 RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
-                PortMapping portMapping = runService.getPortMapping(runConfig, projProperties);
                 NetworkConfig config = runConfig.getNetworkingConfig();
                 if (autoCreateCustomNetworks && config.isCustomNetwork()) {
                     runService.createCustomNetworkIfNotExistant(config.getCustomNetwork());
                 }
-
-                String containerId = runService.createAndStartContainer(imageConfig, portMapping, pomLabel, projProperties);
-
-                if (showLogs(imageConfig)) {
-                    dispatcher.trackContainerLog(containerId,
-                                                 serviceHubFactory.getLogOutputSpecFactory().createSpec(containerId, imageConfig));
-                }
-
-                portMappingPropertyWriteHelper.add(portMapping, runConfig.getPortPropertyFile());
-
-                // Wait if requested
-                waitIfRequested(hub,imageConfig, projProperties, containerId);
-                WaitConfiguration waitConfig = runConfig.getWaitConfiguration();
-                if (waitConfig != null && waitConfig.getExec() != null && waitConfig.getExec().getPostStart() != null) {
-                    runService.execInContainer(containerId, waitConfig.getExec().getPostStart(), imageConfig);
-                }
-
-                // Expose container info as properties
-                exposeContainerProps(hub.getQueryService(), containerId,imageConfig.getAlias());
+                imagesWaitingToStart.add(imageConfig);
             }
+
+            final Set<String> startedContainers = new HashSet<>();
+
+            final ExecutorService executorService;
+            if (startParallel) {
+                executorService = Executors.newCachedThreadPool();
+            } else {
+                executorService = MoreExecutors.newDirectExecutorService();
+            }
+            final ExecutorCompletionService<StartedContainerImage> startingContainers = new ExecutorCompletionService<>(executorService);
+
+            while (!imagesWaitingToStart.isEmpty()) {
+                final List<ImageConfiguration> startableImages = new ArrayList<>();
+
+                for (ImageConfiguration imageWaitingToStart : imagesWaitingToStart) {
+                    if (startedContainers.containsAll(imageWaitingToStart.getDependencies())) {
+                        startableImages.add(imageWaitingToStart);
+                    }
+                }
+
+                for (final ImageConfiguration startableImage : startableImages) {
+
+                    final RunImageConfiguration runConfig = startableImage.getRunConfiguration();
+                    final PortMapping portMapping = runService.getPortMapping(runConfig, projProperties);
+
+                    startingContainers.submit(new Callable<StartedContainerImage>() {
+                        @Override
+                        public StartedContainerImage call() throws Exception {
+                            final String containerId = runService.createAndStartContainer(startableImage, portMapping, pomLabel, projProperties);
+
+                            if (showLogs(startableImage)) {
+                                dispatcher.trackContainerLog(containerId,
+                                        serviceHubFactory.getLogOutputSpecFactory().createSpec(containerId, startableImage));
+                            }
+
+                            // Wait if requested
+                            waitIfRequested(hub,startableImage, projProperties, containerId);
+                            WaitConfiguration waitConfig = runConfig.getWaitConfiguration();
+                            if (waitConfig != null && waitConfig.getExec() != null && waitConfig.getExec().getPostStart() != null) {
+                                runService.execInContainer(containerId, waitConfig.getExec().getPostStart(), startableImage);
+                            }
+
+                            return new StartedContainerImage(startableImage, containerId);
+                        }
+                    });
+                    imagesWaitingToStart.remove(startableImage);
+                }
+
+
+                final Future<StartedContainerImage> imageStartResult = startingContainers.take();
+                try {
+                    final StartedContainerImage startedContainerImage = imageStartResult.get();
+                    final String containerId = startedContainerImage.containerId;
+                    final ImageConfiguration imageConfig = startedContainerImage.imageConfig;
+                    final RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
+                    final PortMapping portMapping = runService.getPortMapping(runConfig, projProperties);
+
+
+                    startedContainers.add(startedContainerImage.imageConfig.getAlias());
+
+                    portMappingPropertyWriteHelper.add(portMapping, runConfig.getPortPropertyFile());
+                    // Expose container info as properties
+                    exposeContainerProps(hub.getQueryService(), containerId, imageConfig.getAlias());
+
+                } catch (ExecutionException e) {
+                    try {
+                        if (e.getCause() instanceof RuntimeException) {
+                            throw (RuntimeException)e.getCause();
+                        } else if (e.getCause() instanceof IOException) {
+                            throw (IOException)e.getCause();
+                        } else if (e.getCause() instanceof InterruptedException) {
+                            throw (InterruptedException)e.getCause();
+                        } else {
+                            throw new RuntimeException("Start-Job failed with unexpected exception: "+e.getCause().getMessage(), e.getCause());
+                        }
+                    } finally {
+                        executorService.shutdown();
+                        try {
+                            executorService.awaitTermination(10, TimeUnit.SECONDS);
+                        } catch (InterruptedException ie) {
+                            log.warn("ExecutorService did not shutdown correctly. Enforcing shutdown now!");
+                            executorService.shutdownNow();
+                        }
+                    }
+                }
+            }
+
+            if (!executorService.isShutdown()) {
+                executorService.shutdown();
+                try {
+                    executorService.awaitTermination(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    log.warn("ExecutorService did not shutdown normally.");
+                }
+            }
+
             if (follow) {
                 runService.addShutdownHookForStoppingContainers(keepContainer, removeVolumes, autoCreateCustomNetworks);
                 wait();

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -81,6 +81,7 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable {
             addVolumes(runConfig, ret);
             addLinks(runConfig, ret);
             addContainerNetwork(runConfig, ret);
+            addDependsOn(runConfig, ret);
         }
         return ret;
     }
@@ -109,6 +110,15 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable {
         String alias = config.getContainerAlias();
         if (alias != null) {
             ret.add(alias);
+        }
+    }
+
+    private void addDependsOn(RunImageConfiguration runConfig, List<String> ret) {
+        // Only used in required networks.
+        if (runConfig.getDependsOn() != null && runConfig.getNetworkingConfig().isCustomNetwork()) {
+            for (String[] link : EnvUtil.splitOnLastColon(runConfig.getDependsOn())) {
+                ret.add(link[0]);
+            }
         }
     }
 

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -36,6 +36,10 @@ public class RunImageConfiguration {
     @Parameter
     private String domainname;
 
+    // container domain name
+    @Parameter
+    private List<String> dependsOn;
+
     // container entry point
     @Parameter
     private Arguments entrypoint;
@@ -169,6 +173,10 @@ public class RunImageConfiguration {
 
     public String getDomainname() {
         return domainname;
+    }
+
+    public List<String> getDependsOn() {
+        return dependsOn;
     }
 
     public String getUser() {
@@ -387,6 +395,11 @@ public class RunImageConfiguration {
 
         public Builder network(NetworkConfig networkConfig) {
             config.network = networkConfig;
+            return this;
+        }
+
+        public Builder dependsOn(List<String> dependsOn) {
+            config.dependsOn = dependsOn;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -41,6 +41,7 @@ public enum ConfigKey {
     NOCACHE,
     OPTIMISE,
     CMD,
+    DEPENDS_ON,
     DOMAINNAME,
     DNS,
     DNS_SEARCH,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -93,6 +93,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .securityOpts(listWithPrefix(prefix, SECURITY_OPTS, properties))
                 .cmd(withPrefix(prefix, CMD, properties))
                 .dns(listWithPrefix(prefix, DNS, properties))
+                .dependsOn(listWithPrefix(prefix, DEPENDS_ON, properties))
                 .net(withPrefix(prefix, NET, properties))
                 .network(extractNetworkConfig(prefix, properties))
                 .dnsSearch(listWithPrefix(prefix, DNS_SEARCH, properties))


### PR DESCRIPTION
that respects dependencies and starts all containers in parallel as soon as all dependencies are resolved. This can greatly improve startup time if the waits that you use are mostly io- or sleep related.

My current use-case: Starting 5-8 different applications on tomcats and wait until each of them is fully operational and ready for e2e tests (including hazelcast cluster convergence and JPA h2 initialization).

This feature reduced my regular startup-time from ~5:00 minutes to 1:23.

This is a POC that adds an `ExecutionService` and `ExecutorCompletionService` to the `StartMojo`. The nonParallel configuration simply falls back to a guava SameThreadExecutionService.

The Parallel start is configurable (`docker.startParallel`, disabled by default).

This PR adds another imageRunConfiguration property `dependsOn` (naming from docker-compose) which is the link-equivalent to express inter container dependencies in docker custom networks (it delays the start of a container until all of its dependent containers are started (inclusive wait)). 

There might be some concurrency bugs lurking around (I saw that most of the DockerAccess state is synchronized). Especially the ordered shutdown is a bit tricky (especially it would be great if we could shutdown the executor by not starting new tasks but also not stopping tasks that are running).

I am open for feedback :)
