### PR TITLE
Add support for "Docker for Windows"

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/DockerConnectionDetector.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerConnectionDetector.java
@@ -47,8 +47,12 @@ public class DockerConnectionDetector {
         File unixSocket = new File("/var/run/docker.sock");
         if (unixSocket.exists() && unixSocket.canRead() && unixSocket.canWrite()) {
             return "unix:///var/run/docker.sock";
-        } 
-        throw new IllegalArgumentException("No <dockerHost> or <machine> given, no DOCKER_HOST environment variable, and no read/writable '/var/run/docker.sock'");
+        }        
+        File windowsPipe = new File("//./pipe/docker_engine");
+        if(windowsPipe.exists()) {
+        	return "npipe:////./pipe/docker_engine";
+        }        
+        throw new IllegalArgumentException("No <dockerHost> or <machine> given, no DOCKER_HOST environment variable, and no read/writable '/var/run/docker.sock' or '//./pipe/docker_engine'");
     }
     
     /**

--- a/src/main/java/io/fabric8/maven/docker/access/hc/ApacheHttpClientDelegate.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/ApacheHttpClientDelegate.java
@@ -22,8 +22,15 @@ public class ApacheHttpClientDelegate {
     private final CloseableHttpClient httpClient;
 
     public ApacheHttpClientDelegate(ClientBuilder clientBuilder) throws IOException {
+    	this(clientBuilder, true);
+    }
+    
+    public ApacheHttpClientDelegate(ClientBuilder clientBuilder, boolean pooled) throws IOException {
         this.clientBuilder = clientBuilder;
-        this.httpClient = clientBuilder.buildPooledClient();
+        if(pooled)
+        	this.httpClient = clientBuilder.buildPooledClient();
+        else
+        	this.httpClient = clientBuilder.buildBasicClient();
     }
 
     public CloseableHttpClient createBasicClient()  {

--- a/src/main/java/io/fabric8/maven/docker/access/hc/win/NamedPipe.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/win/NamedPipe.java
@@ -1,0 +1,308 @@
+package io.fabric8.maven.docker.access.hc.win;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.Charset;
+
+import io.fabric8.maven.docker.util.Logger;
+
+final class NamedPipe extends Socket {
+
+	// Logging
+    private final Logger log;
+	//for development purposes
+	private final static boolean DEBUG = false;
+	
+    private final Object connectLock = new Object();
+    private volatile boolean inputShutdown, outputShutdown;
+
+    private String socketPath;
+    private volatile SocketAddress socketAddress;
+    private RandomAccessFile namedPipe;
+
+    private FileChannel channel;
+        
+    public NamedPipe(Logger log) throws IOException {
+    	this.log = log;
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint) throws IOException {
+        connect(endpoint, 0);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        if (timeout < 0) {
+            throw new IllegalArgumentException("Timeout may not be negative: " + timeout);
+        }
+
+        if (!(endpoint instanceof NpipeSocketAddress)) {
+            throw new IllegalArgumentException("Unsupported address type: " + endpoint.getClass().getName());
+        }
+
+        this.socketAddress = endpoint;
+        this.socketPath = ((NpipeSocketAddress) endpoint).path();
+
+        synchronized (connectLock) {
+        	this.namedPipe = new RandomAccessFile(socketPath, "rw");
+        	this.channel = this.namedPipe.getChannel();
+        }
+    }
+
+    @Override
+    public void bind(SocketAddress bindpoint) throws IOException {
+        throw new SocketException("Bind is not supported");
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+        return null;
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public int getPort() {
+        return -1;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return -1;
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        return socketAddress;
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        return null;
+    }
+
+    @Override
+    public SocketChannel getChannel() {
+        return null;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        if (inputShutdown) {
+            throw new SocketException("Socket input is shutdown");
+        }
+
+        return new FilterInputStream(Channels.newInputStream(channel)) {
+        	
+        	@Override
+        	public int read(byte[] b, int off, int len) throws IOException {
+        		int readed = super.read(b, off, len);
+        		if(DEBUG)
+            		log.info("RESPONSE %s", new String(b, off, len, Charset.forName("UTF-8")));
+        		return readed;
+        	}
+        	
+            @Override
+            public void close() throws IOException {
+                shutdownInput();
+            }
+        };
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        if (outputShutdown) {
+            throw new SocketException("Socket output is shutdown");
+        }
+
+        return new FilterOutputStream(Channels.newOutputStream(channel)) {
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+            	if(DEBUG)
+            		log.info("REQUEST %s", new String(b, off, len, Charset.forName("UTF-8")));
+                out.write(b, off, len);
+            }
+
+            @Override
+            public void close() throws IOException {
+                shutdownOutput();
+            }
+        };
+    }
+
+    @Override
+    public void sendUrgentData(int data) throws IOException {
+        throw new SocketException("Urgent data not supported");
+    }
+
+    @Override
+    public void setSoTimeout(int timeout) {
+    }
+
+    @Override
+    public int getSoTimeout() throws SocketException {
+    	return 0;
+    }
+
+    @Override
+    public void setSendBufferSize(int size) throws SocketException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Send buffer size must be positive: " + size);
+        }
+
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public synchronized int getSendBufferSize() throws SocketException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        throw new UnsupportedOperationException("Getting the send buffer size is not supported");
+    }
+
+    @Override
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Receive buffer size must be positive: " + size);
+        }
+
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public synchronized int getReceiveBufferSize() throws SocketException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        throw new UnsupportedOperationException("Getting the receive buffer size is not supported");
+    }
+
+    @Override
+    public void setKeepAlive(boolean on) throws SocketException {
+    }
+
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+    	return true;
+    }
+
+    @Override
+    public void setTrafficClass(int tc) throws SocketException {
+        if (tc < 0 || tc > 255) {
+            throw new IllegalArgumentException("Traffic class is not in range 0 -- 255: " + tc);
+        }
+
+        if (isClosed()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public int getTrafficClass() throws SocketException {
+        throw new UnsupportedOperationException("Getting the traffic class is not supported");
+    }
+
+    @Override
+    public void setReuseAddress(boolean on) throws SocketException {
+        // just ignore
+    }
+
+    @Override
+    public boolean getReuseAddress() throws SocketException {
+        throw new UnsupportedOperationException("Getting the SO_REUSEADDR option is not supported");
+    }
+
+    @Override
+    public void close() throws IOException {
+    	if(isClosed())
+    		return;
+        channel.close();
+        inputShutdown = true;
+        outputShutdown = true;
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        inputShutdown = true;
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        outputShutdown = true;
+    }
+
+    @Override
+    public String toString() {
+        if (isConnected()) {
+            return "WindowsPipe[addr=" + this.socketPath + ']';
+        }
+
+        return "WindowsPipe[unconnected]";
+    }
+
+    @Override
+    public boolean isConnected() {
+        return !isClosed();
+    }
+
+    @Override
+    public boolean isBound() {
+        return false;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return channel != null && !channel.isOpen();
+    }
+
+    @Override
+    public boolean isInputShutdown() {
+        return inputShutdown;
+    }
+
+    @Override
+    public boolean isOutputShutdown() {
+        return outputShutdown;
+    }
+
+    @Override
+    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+        // no-op
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/hc/win/NamedPipeClientBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/win/NamedPipeClientBuilder.java
@@ -1,0 +1,63 @@
+package io.fabric8.maven.docker.access.hc.win;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import io.fabric8.maven.docker.access.hc.ClientBuilder;
+import io.fabric8.maven.docker.util.Logger;
+
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.impl.client.*;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+public class NamedPipeClientBuilder implements ClientBuilder {
+
+	// Logging
+    private final Logger log;
+    
+    private final int maxConnections;
+    private final Registry<ConnectionSocketFactory> registry;
+    private final DnsResolver dnsResolver;
+
+    public NamedPipeClientBuilder(String namedPipePath, int maxConnections, Logger log) {
+        this.maxConnections = maxConnections;
+        this.log = log;
+        registry = buildRegistry(namedPipePath);
+        dnsResolver = nullDnsResolver();        
+    }
+
+    @Override
+    public CloseableHttpClient buildPooledClient() {
+        final HttpClientBuilder httpBuilder = HttpClients.custom();
+        final PoolingHttpClientConnectionManager manager = new PoolingHttpClientConnectionManager(registry, dnsResolver);
+        manager.setDefaultMaxPerRoute(maxConnections);
+        httpBuilder.setConnectionManager(manager);
+        return httpBuilder.build();
+    }
+
+    @Override
+    public CloseableHttpClient buildBasicClient() throws IOException {
+        BasicHttpClientConnectionManager manager = new BasicHttpClientConnectionManager(registry, null, null, dnsResolver);
+        return HttpClients.custom().setConnectionManager(manager).build();
+    }
+
+    private Registry<ConnectionSocketFactory> buildRegistry(String path) {
+        final RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder.create();
+        registryBuilder.register("npipe", new WindowsConnectionSocketFactory(path, log));
+        return registryBuilder.build();
+    }
+
+    private  DnsResolver nullDnsResolver() {
+        return new DnsResolver() {
+            @Override
+            public InetAddress[] resolve(final String host) throws UnknownHostException {
+                return new InetAddress[] {null};
+            }
+        };
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/hc/win/NpipeSocketAddress.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/win/NpipeSocketAddress.java
@@ -1,0 +1,36 @@
+package io.fabric8.maven.docker.access.hc.win;
+
+public class NpipeSocketAddress extends java.net.SocketAddress {
+    
+	private static final long serialVersionUID = 1L;
+	
+	private String path;
+
+    NpipeSocketAddress() {
+    }
+
+    public NpipeSocketAddress(java.io.File path) {
+        this.path = path.getPath();
+    }
+    
+    int length() {
+        return path.length();
+    }
+
+    public String path() {
+        return path;
+    }
+
+    @Override
+    public String toString() {
+        return "[ path=" + path + "]";
+    }
+
+    @Override
+    public boolean equals(Object _other) {
+        if (!(_other instanceof NpipeSocketAddress)) return false;
+
+        NpipeSocketAddress other = (NpipeSocketAddress)_other;
+        return path.equals(other.path);
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/hc/win/WindowsConnectionSocketFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/win/WindowsConnectionSocketFactory.java
@@ -1,0 +1,37 @@
+package io.fabric8.maven.docker.access.hc.win;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import org.apache.http.HttpHost;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+import io.fabric8.maven.docker.util.Logger;
+
+final class WindowsConnectionSocketFactory implements ConnectionSocketFactory {
+
+	// Logging
+    private final Logger log;
+    private final File windowsPipeFile;
+
+    public WindowsConnectionSocketFactory(String unixSocketPath, Logger log) {
+        this.windowsPipeFile = new File(unixSocketPath);
+        this.log = log;
+    }
+
+    @Override
+    public Socket createSocket(HttpContext context) throws IOException {
+        return new NamedPipe(log);
+    }
+
+    @Override
+    public Socket connectSocket(int connectTimeout, Socket sock, HttpHost host, InetSocketAddress remoteAddress,
+            InetSocketAddress localAddress, HttpContext context)
+            throws IOException {
+        sock.connect(new NpipeSocketAddress(windowsPipeFile), connectTimeout);
+        return sock;
+    }
+}

--- a/src/test/java/integration/DockerAccessWinIT.java
+++ b/src/test/java/integration/DockerAccessWinIT.java
@@ -1,25 +1,35 @@
 package integration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
 
-import com.google.common.collect.Lists;
-import io.fabric8.maven.docker.AbstractDockerMojo;
-import io.fabric8.maven.docker.access.*;
-import io.fabric8.maven.docker.access.hc.DockerAccessWithHcClient;
-import io.fabric8.maven.docker.config.Arguments;
-import io.fabric8.maven.docker.config.DockerMachineConfiguration;
-import io.fabric8.maven.docker.model.Container.PortBinding;
-import io.fabric8.maven.docker.util.AnsiLogger;
-import io.fabric8.maven.docker.util.Logger;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import com.google.common.collect.Lists;
+
+import io.fabric8.maven.docker.AbstractDockerMojo;
+import io.fabric8.maven.docker.access.ContainerCreateConfig;
+import io.fabric8.maven.docker.access.ContainerHostConfig;
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.access.DockerConnectionDetector;
+import io.fabric8.maven.docker.access.PortMapping;
+import io.fabric8.maven.docker.access.hc.DockerAccessWithHcClient;
+import io.fabric8.maven.docker.config.Arguments;
+import io.fabric8.maven.docker.model.Container.PortBinding;
+import io.fabric8.maven.docker.util.AnsiLogger;
+import io.fabric8.maven.docker.util.Logger;
 
 /*
  * if run from your ide, this test assumes you have configured the runner w/ the appropriate env variables
@@ -27,7 +37,7 @@ import static org.junit.Assert.*;
  * it also assumes that 'removeImage' does what it's supposed to do as it's used in test setup.
  */
 @Ignore
-public class DockerAccessIT {
+public class DockerAccessWinIT {
 
     private static final String CONTAINER_NAME = "integration-test";
     private static final String IMAGE = "busybox:buildroot-2014.02";
@@ -38,15 +48,14 @@ public class DockerAccessIT {
     private String containerId;
     private final DockerAccessWithHcClient dockerClient;
 
-    public DockerAccessIT() throws IOException {
+    public DockerAccessWinIT() throws IOException {
         AnsiLogger logger = new AnsiLogger(new SystemStreamLog(), true, true);
         String url = createDockerConnectionDetector(logger).extractUrl(null);
         this.dockerClient = createClient(url, logger);
     }
 
     private DockerConnectionDetector createDockerConnectionDetector(Logger logger) {
-        DockerMachineConfiguration machine = new DockerMachineConfiguration("default","false");
-        return new DockerConnectionDetector(logger, machine);
+        return new DockerConnectionDetector(logger, null);
     }
 
     @Before
@@ -87,7 +96,7 @@ public class DockerAccessIT {
     private DockerAccessWithHcClient createClient(String baseUrl, Logger logger) {
         try {
             String certPath = createDockerConnectionDetector(logger).getCertPath(null);
-            return new DockerAccessWithHcClient("v" + AbstractDockerMojo.API_VERSION, baseUrl, certPath, 20, logger);
+            return new DockerAccessWithHcClient("v" + AbstractDockerMojo.API_VERSION, baseUrl, certPath, 1, logger);
         } catch (@SuppressWarnings("unused") IOException e) {
             // not using ssl, so not going to happen
             logger.error(e.getMessage());

--- a/src/test/java/io/fabric8/maven/docker/access/DockerConnectionDetectorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/DockerConnectionDetectorTest.java
@@ -25,7 +25,12 @@ public class DockerConnectionDetectorTest {
         String dockerHost = System.getenv("DOCKER_HOST");
         if (dockerHost != null) {
             Assert.assertEquals(dockerHost.replaceFirst("^tcp:/",""), machine.extractUrl(null).replaceFirst("^https?:/",""));
-        } else {
+        } else if(System.getProperty("os.name").equalsIgnoreCase("Windows 10")) {
+        	try {
+                Assert.assertEquals("npipe:////./pipe/docker_engine", machine.extractUrl(null));
+            } catch (IllegalArgumentException expectedIfNoUnixSocket) {
+            }
+        } else {        	
             try {
                 Assert.assertEquals("unix:///var/run/docker.sock", machine.extractUrl(null));
             } catch (IllegalArgumentException expectedIfNoUnixSocket) {

--- a/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
@@ -40,7 +40,7 @@ public class DockerAccessWithHcClientTest {
 
     @Before
     public void setup() throws IOException {
-        client = new DockerAccessWithHcClient("1.20", "tcp://1.2.3.4:2375", null, 1, mockLogger) {
+        client = new DockerAccessWithHcClient("v1.20", "tcp://1.2.3.4:2375", null, 1, mockLogger) {
             @Override
             ApacheHttpClientDelegate createHttpClient(ClientBuilder builder) throws IOException {
                 return mockDelegate;


### PR DESCRIPTION
This PR adds support for new Docker for Windows on Windows 10 (not docker toolbox, see https://docs.docker.com/engine/installation/windows/). This version of docker exposes api through windows named pipe //./pipe/docker_engine. Currently yours maven plugin don't support this condition. 

I added support for it, it's work at my machine, but you must set new configuration property "docker.machine.ignoreEmpty" to true, because windows docker don't expose any docker machine after installation. 