### PR TITLE
Add custom network IP address property mappings

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -8,12 +8,6 @@ package io.fabric8.maven.docker;
  * the License.
  */
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.regex.Pattern;
-
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.PortMapping;
@@ -25,7 +19,10 @@ import io.fabric8.maven.docker.model.Container;
 import io.fabric8.maven.docker.service.QueryService;
 import io.fabric8.maven.docker.service.RunService;
 import io.fabric8.maven.docker.service.ServiceHub;
-import io.fabric8.maven.docker.util.*;
+import io.fabric8.maven.docker.util.PomLabel;
+import io.fabric8.maven.docker.util.StartOrderResolver;
+import io.fabric8.maven.docker.util.Timestamp;
+import io.fabric8.maven.docker.util.WaitUtil;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Execute;
@@ -33,6 +30,13 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.StringUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
 
 
 /**
@@ -369,6 +373,13 @@ public class StartMojo extends AbstractDockerMojo {
             String ip = container.getIPAddress();
             if (StringUtils.isNotEmpty(ip)) {
                 props.put(prefix + "ip", ip);
+            }
+
+            Map<String, String> nets = container.getCustomIPAddresses();
+            if (nets != null) {
+                for (Map.Entry<String, String> entry : nets.entrySet()) {
+                    props.put(prefix + addDot("net") + addDot(entry.getKey()) + "ip", entry.getValue());
+                }
             }
         }
     }

--- a/src/main/java/io/fabric8/maven/docker/model/Container.java
+++ b/src/main/java/io/fabric8/maven/docker/model/Container.java
@@ -47,6 +47,12 @@ public interface Container {
      */
     String getIPAddress();
 
+    /**
+     * Return IP Addresses of custom networks, mapped to the network name as the key.
+     * @return The mapping of network names to IP addresses, or null it none provided.
+     */
+    Map<String, String> getCustomIPAddresses();
+
     class PortBinding {
         private final String hostIp;
         private final Integer hostPort;

--- a/src/main/java/io/fabric8/maven/docker/model/ContainerDetails.java
+++ b/src/main/java/io/fabric8/maven/docker/model/ContainerDetails.java
@@ -1,10 +1,10 @@
 package io.fabric8.maven.docker.model;
 
-import java.util.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import javax.xml.bind.DatatypeConverter;
-
-import org.json.JSONObject;
+import java.util.*;
 
 
 public class ContainerDetails implements Container {
@@ -19,6 +19,7 @@ public class ContainerDetails implements Container {
     static final String NAME = "Name";
     static final String IP = "IPAddress";
     static final String NETWORK_SETTINGS = "NetworkSettings";
+    static final String NETWORKS = "Networks";
     static final String PORTS = "Ports";
     static final String SLASH = "/";
     static final String STATE = "State";
@@ -74,6 +75,29 @@ public class ContainerDetails implements Container {
             JSONObject networkSettings = json.getJSONObject(NETWORK_SETTINGS);
             if (!networkSettings.isNull(IP)) {
                 return networkSettings.getString(IP);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getCustomIPAddresses() {
+        if (json.has(NETWORK_SETTINGS) && !json.isNull(NETWORK_SETTINGS)) {
+            JSONObject networkSettings = json.getJSONObject(NETWORK_SETTINGS);
+            if (networkSettings.has(NETWORKS) && !networkSettings.isNull(NETWORKS)) {
+                JSONObject networks = networkSettings.getJSONObject(NETWORKS);
+                JSONArray keys = networks.names();
+
+                Map<String, String> results = new HashMap<>();
+                for (int i = 0; i < keys.length(); i++) {
+                    String key = keys.getString(i);
+                    JSONObject net = networks.getJSONObject(key);
+                    if (net.has(IP) && !net.isNull(IP)) {
+                        results.put(key, net.getString(IP));
+                    }
+                }
+
+                return results;
             }
         }
         return null;

--- a/src/main/java/io/fabric8/maven/docker/model/ContainersListElement.java
+++ b/src/main/java/io/fabric8/maven/docker/model/ContainersListElement.java
@@ -89,6 +89,12 @@ public class ContainersListElement implements Container {
     }
 
     @Override
+    public Map<String, String> getCustomIPAddresses() {
+        // IP address is not provided by container list action.
+        return null;
+    }
+
+    @Override
     public boolean isRunning() {
         String status = json.getString(STATUS);
         return status.toLowerCase().contains(UP);


### PR DESCRIPTION
This adds property mappings for custom networks, using the format: 
```
docker.container.<alias>.net.<name>.ip
```
It seems important when the build is running on a container, and tries to start other containers in order to use them as remote services for integration testing. In this case, the only way I've found success is by using a custom network created using:

```
    $ docker network create -d bridge ci-network
```

My Jenkins instance is running in its own docker container, so the bridge aspect allows me access to Jenkins. All the docker containers started by Jenkins will also need to use this custom network, I've found, and when the build needs to access them it can use the container's IP address on the custom network along with the ports from the EXPOSE line in the Dockerfile (not mapped ports).

This works for me, but I'm not sure I understand how to write tests for the patch I'm submitting. I've tried to match code formatting, but ended up just guessing at the rules. Please let me know if I've missed something that needs attention.