### PR TITLE
Fixes for stop mojo

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StopMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StopMojo.java
@@ -95,15 +95,15 @@ public class StopMojo extends AbstractDockerMojo {
         //Do not fail if container is not found
         try {
             
-	        if (strategy == RunImageConfiguration.NamingStrategy.alias) {
+            if (strategy == RunImageConfiguration.NamingStrategy.alias) {
                 Container container = queryService.getContainer(image.getAlias());
-		        if (container !=  null) {
-	                containers = Collections.singletonList(container);
-		        }
-	        } else {
-	            containers = queryService.getContainersForImage(image.getName());
-	        }
-	        
+                if (container !=  null) {
+                    containers = Collections.singletonList(container);
+                }
+            } else {
+                containers = queryService.getContainersForImage(image.getName());
+            }
+            
             if(containers == null) {
                 containers = Collections.emptyList();
             }

--- a/src/main/java/io/fabric8/maven/docker/StopMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StopMojo.java
@@ -47,6 +47,13 @@ public class StopMojo extends AbstractDockerMojo {
      */
     @Parameter(property = "docker.autoCreateCustomNetworks", defaultValue = "false")
     protected boolean autoCreateCustomNetworks;
+    
+    @Parameter( property = "docker.allContainers", defaultValue = "false" )
+    private boolean allContainers;
+    
+    @Parameter( property = "docker.sledgeHammer", defaultValue = "false" )
+    private boolean sledgeHammer;
+    
 
     @Override
     protected void executeInternal(ServiceHub hub) throws MojoExecutionException, DockerAccessException {
@@ -72,7 +79,7 @@ public class StopMojo extends AbstractDockerMojo {
         Collection<Network> networksToRemove = getNetworksToRemove(queryService, pomLabel);
         for (ImageConfiguration image : getResolvedImages()) {
             for (Container container : getContainersToStop(queryService, image)) {
-                if (shouldStopContainer(container, pomLabel)) {
+                if (shouldStopContainer(container, pomLabel, image)) {
                     runService.stopContainer(container.getId(), image, keepContainer, removeVolumes);
                 }
             }
@@ -82,40 +89,56 @@ public class StopMojo extends AbstractDockerMojo {
 
     // If naming strategy is alias stop a container with this name, otherwise get all containers with this image's name
     private List<Container> getContainersToStop(QueryService queryService, ImageConfiguration image) throws DockerAccessException {
-        List<Container> containers;
+        List<Container> containers = Collections.emptyList();
         RunImageConfiguration.NamingStrategy strategy = image.getRunConfiguration().getNamingStrategy();
-        if (strategy == RunImageConfiguration.NamingStrategy.alias) {
-            Container container = queryService.getContainer(image.getAlias());
-            if (container !=  null) {
-                containers = Collections.singletonList(container);
-            } else {
+        
+        //Do not fail if container is not found
+        try {
+            
+	        if (strategy == RunImageConfiguration.NamingStrategy.alias) {
+                Container container = queryService.getContainer(image.getAlias());
+		        if (container !=  null) {
+	                containers = Collections.singletonList(container);
+		        }
+	        } else {
+	            containers = queryService.getContainersForImage(image.getName());
+	        }
+	        
+            if(containers == null) {
                 containers = Collections.emptyList();
             }
-        } else {
-            containers = queryService.getContainersForImage(image.getName());
+        } catch (Exception ex) {
+            log.warn("%s", ex.getMessage());
+            containers = Collections.emptyList();
         }
         return containers;
     }
 
-    private boolean shouldStopContainer(Container container, PomLabel pomLabel) {
+    private boolean shouldStopContainer(Container container, PomLabel pomLabel, ImageConfiguration image) {
         if (isStopAllContainers()) {
             return true;
         }
+        
+        RunImageConfiguration.NamingStrategy strategy = image.getRunConfiguration().getNamingStrategy();
+        
+        if (RunImageConfiguration.NamingStrategy.alias.equals(strategy)) {
+            if(container.getName().equals(image.getAlias())) {
+                return true;
+            }
+            return false;
+            
+        } else {
 
-        String key = pomLabel.getKey();
-        Map<String, String> labels = container.getLabels();
+            String key = pomLabel.getKey();
+            Map<String, String> labels = container.getLabels();
 
-        return labels.containsKey(key) && pomLabel.equals(new PomLabel(labels.get(key)));
+            return labels.containsKey(key) && pomLabel.equals(new PomLabel(labels.get(key)));
+        }
+        
     }
 
     private boolean isStopAllContainers() {
-        for (String prop : new String[] { "docker.allContainers", "docker.sledgeHammer" }) {
-            String val = System.getProperty(prop);
-            if (val != null && Boolean.valueOf(val)) {
-                return true;
-            }
-        }
-        return false;
+        return (allContainers || sledgeHammer);
     }
 
     private boolean invokedTogetherWithDockerStart() {
@@ -137,7 +160,7 @@ public class StopMojo extends AbstractDockerMojo {
                 if (network != null) {
                     customNetworks.add(network);
                     for (Container container : getContainersToStop(queryService, image)) {
-                        if (!shouldStopContainer(container, pomLabel)) {
+                        if (!shouldStopContainer(container, pomLabel, image)) {
                             // it's sill in use don't collect it
                             customNetworks.remove(network);
                         }


### PR DESCRIPTION
Fixed: stop containers based on naming strategy (should stop all containers based on alias if naming strategy is used)

Fixed: catch exception if container alias does not exists (previously it would throw exception now it just displays a warning)

Fixed: docker.allContainers, docker.sledgeHammer can be set from maven properties now (before only from system properties).