### PR TITLE
Avoid auto-pulling 'scratch' image

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
@@ -104,7 +104,7 @@ abstract public class AbstractBuildSupportMojo extends AbstractDockerMojo {
         } else {
             fromImage = extractBaseFromConfiguration(buildConfig);
         }
-        if (fromImage != null) {
+        if (fromImage != null && !DockerAssemblyManager.SCRATCH_IMAGE.equals(fromImage)) {
             String pullRegistry =
                 EnvUtil.findRegistry(new ImageName(fromImage).getRegistry(), this.pullRegistry, registry);
             checkImageWithAutoPull(hub, fromImage, pullRegistry, true);

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -43,6 +43,7 @@ import java.util.List;
 public class DockerAssemblyManager {
 
     public static final String DEFAULT_DATA_BASE_IMAGE = "busybox:latest";
+    public static final String SCRATCH_IMAGE = "scratch";
 
     // Assembly name used also as build directory within outputBuildDir
     public static final String ASSEMBLY_NAME = "maven";


### PR DESCRIPTION
Since version 1.5.0, Docker interprets the Dockerfile instruction `FROM scratch` as a special case indicating a no-base image.
This implies that there is no more an image named 'scratch'.
Building an image from a Dockerfile with `FROM scratch` currently
causes the error:
`Unable to pull 'scratch:latest': 'scratch' is a reserved name (Internal Server Error: 500)`
Avoid auto-pulling 'scratch' image.