### PR TITLE
Do not thow exception for remove failures

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -413,7 +413,8 @@ public class DockerAccessWithHcClient implements DockerAccess {
 
             return response.getStatusCode() == HTTP_OK;
         } catch (IOException e) {
-            throw new DockerAccessException(e, "Unable to remove image [%s]", image);
+            log.warn( "Unable to remove image [%s]", image);
+            return false;
         }
     }
 


### PR DESCRIPTION
if the image we are removing does not exists should we throw a failure?  Our current maven workflow is:

```
          <goals>
                <goal>stop</goal>
                <goal>remove</goal>
                <goal>build</goal>
                <goal>start</goal>
            </goals>
```

First time we run the image doesn't exists, and since remove throws an exception we cannot proceed without changing the pom.
