### PR TITLE
Removed restriction that port mappings are integers to support UDP

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
@@ -48,7 +48,7 @@ public class DockerFileBuilder {
     private List<AddEntry> addEntries = new ArrayList<>();
 
     // list of ports to expose and environments to use
-    private List<Integer> ports = new ArrayList<>();
+    private List<String> ports = new ArrayList<>();
 
     // list of RUN Commands to run along with image build see issue #191 on github
     private List<String> runCmds = new ArrayList<>();
@@ -201,11 +201,7 @@ public class DockerFileBuilder {
 
     private void addPorts(StringBuilder b) {
         if (ports.size() > 0) {
-            String[] portsS = new String[ports.size()];
-            int i = 0;
-            for (Integer port : ports) {
-                portsS[i++] = port.toString();
-            }
+            String[] portsS = ports.toArray(new String[]{});
             DockerFileKeyword.EXPOSE.addTo(b, portsS);
         }
     }
@@ -305,11 +301,7 @@ public class DockerFileBuilder {
         if (ports != null) {
             for (String port : ports) {
                 if (port != null) {
-                    try {
-                        this.ports.add(Integer.parseInt(port));
-                    } catch (NumberFormatException exp) {
-                        throw new IllegalArgumentException("Non numeric port " + port + " specified in port mapping",exp);
-                    }
+                    this.ports.add(port);
                 }
             }
         }


### PR DESCRIPTION
I have a need to expose UDP ports by adding a /udp at the end of the port mappings.  Making this a string allows the same capability one would normally put in a docker file.  

I don't know if we'd want to validate the port mapping form at build time or not... if so, I'd suggest reusing the logic in io.fabric8.maven.docker.access.PortMapping, as it is a more complete representation of what one can do.  
