### PR TITLE
Clarify log message when removing old image

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -72,7 +72,7 @@ public class BuildService {
         if (oldImageId != null && !oldImageId.equals(newImageId)) {
             try {
                 docker.removeImage(oldImageId, true);
-                log.info("%s: Removed image ", imageConfig.getDescription(), oldImageId);
+                log.info("%s: Removed old image %s", imageConfig.getDescription(), oldImageId);
             } catch (DockerAccessException exp) {
                 if (cleanupMode == CleanupMode.TRY_TO_REMOVE) {
                     log.warn("%s: %s (old image)%s", imageConfig.getDescription(), exp.getMessage(),


### PR DESCRIPTION
When building an image, the log messages are slightly confusing:

> [INFO] DOCKER> [mydata] "data": Built image sha256:04512
> [INFO] DOCKER> [mydata] "data": Removed image 


This sounds like the image gets deleted immediately after being built. In fact, it's only the previous version that is deleted.

With this change, the message is now

> [INFO] DOCKER> [mydata] "data": Removed old image sha256:e0bea