### PR TITLE
Lots of warnings are displayed when assembly.mode is tar or tgz when building on windows

### DIFF
--- a/src/main/asciidoc/inc/build/_assembly.adoc
+++ b/src/main/asciidoc/inc/build/_assembly.adoc
@@ -48,6 +48,9 @@ assembly configuration
 
 `keep` is the default value.
 
+| *tarLongFileMode*
+| Sets the TarArchiver behaviour on file paths with more than 100 characters length. Valid values are: "warn"(default), "fail", "truncate", "gnu", "posix", "posix_warn" or "omit"
+
 | *user*
 | User and/or group under which the files should be added. The user must already exist in the base image.
 

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyConfigurationSource.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyConfigurationSource.java
@@ -245,7 +245,7 @@ public class DockerAssemblyConfigurationSource implements AssemblerConfiguration
     // X
     @Override
     public String getTarLongFileMode() {
-        return "warn";
+        return assemblyConfig.getTarLongFileMode() == null ? "warn" : assemblyConfig.getTarLongFileMode();
     }
 
     // X

--- a/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
@@ -55,6 +55,11 @@ public class AssemblyConfiguration {
     private String user;
 
     /**
+     * @parameter
+     */
+    private String tarLongFileMode;
+
+    /**
      * @parameter default-value="keep"
      */
     private PermissionMode permissions;
@@ -89,6 +94,10 @@ public class AssemblyConfiguration {
 
     public AssemblyMode getMode() {
         return mode != null ? mode : AssemblyMode.dir;
+    }
+
+    public String getTarLongFileMode() {
+        return tarLongFileMode;
     }
 
     public Boolean isIgnorePermissions() {
@@ -165,6 +174,11 @@ public class AssemblyConfiguration {
                 config.mode = AssemblyMode.valueOf(mode.toLowerCase());
                 isEmpty = false;
             }
+            return this;
+        }
+
+        public Builder tarLongFileMode(String tarLongFileMode) {
+            config.tarLongFileMode = set(tarLongFileMode);
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -34,6 +34,7 @@ public enum ConfigKey {
     ASSEMBLY_DOCKER_FILE_DIR("assembly.dockerFileDir"),
     ASSEMBLY_USER("assembly.user"),
     ASSEMBLY_MODE("assembly.mode"),
+    ASSEMBLY_TARLONGFILEMODE("assembly.tarLongFileMode"),
     BIND,
     CAP_ADD,
     CAP_DROP,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -144,6 +144,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .permissions(withPrefix(prefix, ASSEMBLY_PERMISSIONS, properties))
                 .user(withPrefix(prefix, ASSEMBLY_USER, properties))
                 .mode(withPrefix(prefix, ASSEMBLY_MODE, properties))
+                .tarLongFileMode(withPrefix(prefix, ASSEMBLY_TARLONGFILEMODE, properties))
                 .build();
     }
 


### PR DESCRIPTION
Addressing issue #591 