### PR TITLE
#595 - Fix concurrency issue on log wait.

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -414,12 +414,12 @@ public class StartMojo extends AbstractDockerMojo {
     private WaitUtil.WaitChecker getLogWaitChecker(final String logPattern, final ServiceHub hub, final String  containerId) {
         return new WaitUtil.WaitChecker() {
 
-            boolean first = true;
-            LogGetHandle logHandle;
-            boolean detected = false;
+            private boolean first = true;
+            private LogGetHandle logHandle;
+            private volatile boolean detected = false;
 
             @Override
-            public synchronized boolean check() {
+            public boolean check() {
                 if (first) {
                     final Pattern pattern = Pattern.compile(logPattern);
                     log.debug("LogWaitChecker: Pattern to match '%s'",logPattern);


### PR DESCRIPTION
Removed the synchronized because the `check()` method will always performed by the same thread. The member `detected` was only partly covered by the original synchronized because it was written in an anonymous inner class (`LogCallback`) which was not part of the synchronized block.
This fix mark the `detected` flag as `volatile` to ensure that a write by an other thread calling the log callback will be propagate to the thread who calls the `check()` method.