### PR TITLE
Fixes bug where status was not being set on HttpConfiguration

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/WaitConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/WaitConfiguration.java
@@ -210,6 +210,7 @@ public class WaitConfiguration implements Serializable {
         private HttpConfiguration(String url, String method, String status) {
             this.url = url;
             this.method = method;
+            this.status = status;
         }
 
         public String getUrl() {


### PR DESCRIPTION
The status parameter in the `HttpConfiguration` constructor is ignored and results in a null status. This is not a problem when using an XML config such as below, because the fields are injected differently. 
```xml
<wait>
    <http>
        <url>http://localhost/status</url>
        <method>GET</method>
        <status>200</status>
    </http>
</wait>
```
Found this out when writing an `ExternalConfigHandler` which uses code to construct the `WaitConfiguration` object.