### PR TITLE
Making the assembly 'targetDir' parameter usable.

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
@@ -12,6 +12,7 @@ public class AssemblyConfiguration implements Serializable {
 
     /**
      * @parameter
+     * @deprecated Use {@link #targetDir} instead.
      */
     @Deprecated
     private String basedir;
@@ -20,6 +21,7 @@ public class AssemblyConfiguration implements Serializable {
      * New replacement for base directory which better reflects its
      * purpose
      */
+    @Parameter
     private String targetDir;
 
     /**


### PR DESCRIPTION
This is somewhat of a blind fix, so apologies for the waste of time if it's not actually useable.

I found that when executing the plugin, it would fail when attempting to set the `targetDir` variable, but not basedir. I'm assuming that's because targetDir isn't actually annotated as a parameter. I could be wrong.

I'm just working around the issue in my project at the moment, but I reckon if this is a quick fix for an oversight, I might as well submit it for inspection at the very least.