### PR TITLE
Adding query arguments for the BuildImageConfiguration

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,13 +1,13 @@
 # ChangeLog
 
 * **0.17.1** (2016-10-28)
-  - Add initial Docker compose support ([#384](https://github.com/fabric8io/docker-maven-plugin/issues/384))
+  - Add initial [Docker compose](https://dmp.fabric8.io/#docker-compose) support ([#384](https://github.com/fabric8io/docker-maven-plugin/issues/384))
   - Made `docker:run` running in the foreground
   - Add lifecycle fork to package for `docker:build` and `docker:source` for ease of use. Introducher `docker:build-nofork` and `docker:source-nofork`
   - Removed lifecycle forks for all other Mojos ([#567](https://github.com/fabric8io/docker-maven-plugin/issues/567)) ([#599](https://github.com/fabric8io/docker-maven-plugin/issues/599))
   - Add new option `tarLongFileMode` for the assembly configuration to avoid warning for too long files ([#591](https://github.com/fabric8io/docker-maven-plugin/issues/591))
   - Add new option `tmpfs` for `<run>` to add mount pathes for temorary file systems ([#455](https://github.com/fabric8io/docker-maven-plugin/issues/455))
-  - Changed `docker.image` to `docker.filte` and `<image>` to `<filter>`. 
+  - Changed `docker.image` to `docker.filter` and `<image>` to `<filter>`. 
   
 For 0.17 the lifecycle handling of the plugins has changed slightly. All forks to the _initialize_ phase have been removed since they collide with certain setups. Instead a fork to the _package_ phase has been introduced for `docker:build` and `docker:source` to make it easier for them to be consumed on the commandline (because otherwise at least `package` has to be added as goal so that the assembly could be constructed from the artifacts built). If you have these goals bound to an `<execution>` please use `build-nofork` and `source-nofork` instead, otherwise the package phase will be called twice.
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+* **0.18.1** 
+  - Renamed `basedir` and `exportBasedir` in an `<assembly>` configuration to `targetDir` and `exportTargetDir` since this better reflects the purpose, i.e. the target in the Docker image to which the assembly is copied. The old name is still recognized but deprecated. 
+   
 * **0.17.2** (2016-11-3)
   - Fix issues with an empty Docker config file
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -5,6 +5,14 @@
   - Fix issue with log statements which use a single argument form
   - Fix bug in HTTP wait configuration when using an external property handler (#613)
   - Fix NPE for "docker:log" when the container to log has already been stopped (#612)
+  - Allow a protocol (tcp/udp) for the specification of a port (#610) 
+
+The following variables in the assembly configuration has been renamed for consistencies sake:
+ 
+ * `basedir` --> `targetDir`
+ * `expoetBasedir` --> `exportTargetDir`
+
+The old variable names are still accepted but will be removed for release 1.0
 
 * **0.17.2** (2016-11-3)
   - Fix issues with an empty Docker config file

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-* **0.18.1** 
+* **0.18.1** (2016-11-17)
   - Renamed `basedir` and `exportBasedir` in an `<assembly>` configuration to `targetDir` and `exportTargetDir` since this better reflects the purpose, i.e. the target in the Docker image to which the assembly is copied. The old name is still recognized but deprecated. 
   - Fix issue with log statements which use a single argument form
   - Fix bug in HTTP wait configuration when using an external property handler (#613)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -7,8 +7,11 @@
   - Removed lifecycle forks for all other Mojos (#567) (#599)
   - Add new option `tarLongFileMode` for the assembly configuration to avoid warning for too long files (#591)
   - Add new option `tmpfs` for `<run>` to add mount pathes for temorary file systems (#455)
+  - Changed `docker.image` to `docker.filte` and `<image>` to `<filter>`. 
   
 For 0.17 the lifecycle handling of the plugins has changed slightly. All forks to the _initialize_ phase have been removed since they collide with certain setups. Instead a fork to the _package_ phase has been introduced for `docker:build` and `docker:source` to make it easier for them to be consumed on the commandline (because otherwise at least `package` has to be added as goal so that the assembly could be constructed from the artifacts built). If you have these goals bound to an `<execution>` please use `build-nofork` and `source-nofork` instead, otherwise the package phase will be called twice.
+
+Also the treatment of the Maven property `docker.image` has changed. This was supposed to be used as a filter which caused a lot of confusion if people accidentally put their Docker image names into this property. Now the property has no special meaning anymore, and you can use `docker.filter` now for filtering out a specific images to build. For the same reason the top-level configuration element `<image>` has been renamed to `<filter>`. 
 
 * **0.16.9** (2016-10-23)
   - Removed (undocumented) property `docker.image.name` which could be used to be inserted as a `%a` specifier part in an image name.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+* **0.17.2** (2016-11-3)
+  - Fix issues with an empty Docker config file
+
 * **0.17.1** (2016-10-28)
   - Add initial [Docker compose](https://dmp.fabric8.io/#docker-compose) support ([#384](https://github.com/fabric8io/docker-maven-plugin/issues/384))
   - Made `docker:run` running in the foreground

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,7 +2,8 @@
 
 * **0.18.1** 
   - Renamed `basedir` and `exportBasedir` in an `<assembly>` configuration to `targetDir` and `exportTargetDir` since this better reflects the purpose, i.e. the target in the Docker image to which the assembly is copied. The old name is still recognized but deprecated. 
-   
+  - Fix issue with log statements which use a single argument form
+
 * **0.17.2** (2016-11-3)
   - Fix issues with an empty Docker config file
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -10,7 +10,7 @@
 The following variables in the assembly configuration has been renamed for consistencies sake:
  
  * `basedir` --> `targetDir`
- * `expoetBasedir` --> `exportTargetDir`
+ * `exportBasedir` --> `exportTargetDir`
 
 The old variable names are still accepted but will be removed for release 1.0
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,8 @@
 * **0.18.1** 
   - Renamed `basedir` and `exportBasedir` in an `<assembly>` configuration to `targetDir` and `exportTargetDir` since this better reflects the purpose, i.e. the target in the Docker image to which the assembly is copied. The old name is still recognized but deprecated. 
   - Fix issue with log statements which use a single argument form
+  - Fix bug in HTTP wait configuration when using an external property handler (#613)
+  - Fix NPE for "docker:log" when the container to log has already been stopped (#612)
 
 * **0.17.2** (2016-11-3)
   - Fix issues with an empty Docker config file

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,12 +1,12 @@
 # ChangeLog
 
-* **0.17.1** 
-  - Add initial Docker compose support (#384)
+* **0.17.1** (2016-10-28)
+  - Add initial Docker compose support ([#384](https://github.com/fabric8io/docker-maven-plugin/issues/384))
   - Made `docker:run` running in the foreground
   - Add lifecycle fork to package for `docker:build` and `docker:source` for ease of use. Introducher `docker:build-nofork` and `docker:source-nofork`
-  - Removed lifecycle forks for all other Mojos (#567) (#599)
-  - Add new option `tarLongFileMode` for the assembly configuration to avoid warning for too long files (#591)
-  - Add new option `tmpfs` for `<run>` to add mount pathes for temorary file systems (#455)
+  - Removed lifecycle forks for all other Mojos ([#567](https://github.com/fabric8io/docker-maven-plugin/issues/567)) ([#599](https://github.com/fabric8io/docker-maven-plugin/issues/599))
+  - Add new option `tarLongFileMode` for the assembly configuration to avoid warning for too long files ([#591](https://github.com/fabric8io/docker-maven-plugin/issues/591))
+  - Add new option `tmpfs` for `<run>` to add mount pathes for temorary file systems ([#455](https://github.com/fabric8io/docker-maven-plugin/issues/455))
   - Changed `docker.image` to `docker.filte` and `<image>` to `<filter>`. 
   
 For 0.17 the lifecycle handling of the plugins has changed slightly. All forks to the _initialize_ phase have been removed since they collide with certain setups. Instead a fork to the _package_ phase has been introduced for `docker:build` and `docker:source` to make it easier for them to be consumed on the commandline (because otherwise at least `package` has to be added as goal so that the assembly could be constructed from the artifacts built). If you have these goals bound to an `<execution>` please use `build-nofork` and `source-nofork` instead, otherwise the package phase will be called twice.

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.0.5</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <version>0.18-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
+
   <name>docker-maven-plugin</name>
   <description>Docker Maven Plugin</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.18-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>docker-maven-plugin</name>

--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -13,12 +13,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.2</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-custom-net</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -13,12 +13,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-custom-net</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
 
   <build>
     <plugins>

--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -13,12 +13,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-custom-net</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
 
   <build>
     <plugins>

--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -13,12 +13,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-custom-net</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
 
   <build>
     <plugins>

--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -13,12 +13,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-custom-net</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/samples/data-jolokia-demo/pom.xml
+++ b/samples/data-jolokia-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.2</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-jolokia-demo</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
   <!-- add custom lifecycle -->
   <packaging>docker</packaging>
 

--- a/samples/data-jolokia-demo/pom.xml
+++ b/samples/data-jolokia-demo/pom.xml
@@ -444,7 +444,7 @@
                     <from>jboss/wildfly:8.2.0.Final</from>
                     <assembly>
                       <user>jboss:jboss:jboss</user>
-                      <basedir>/opt/jboss/wildfly/standalone/deployments</basedir>
+                      <targetDir>/opt/jboss/wildfly/standalone/deployments</targetDir>
                       <descriptor>assembly.xml</descriptor>
                     </assembly>
                   </build>

--- a/samples/data-jolokia-demo/pom.xml
+++ b/samples/data-jolokia-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-jolokia-demo</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
   <!-- add custom lifecycle -->
   <packaging>docker</packaging>
 

--- a/samples/data-jolokia-demo/pom.xml
+++ b/samples/data-jolokia-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-jolokia-demo</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
   <!-- add custom lifecycle -->
   <packaging>docker</packaging>
 

--- a/samples/data-jolokia-demo/pom.xml
+++ b/samples/data-jolokia-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-jolokia-demo</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
   <!-- add custom lifecycle -->
   <packaging>docker</packaging>
 

--- a/samples/data-jolokia-demo/pom.xml
+++ b/samples/data-jolokia-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-jolokia-demo</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
   <!-- add custom lifecycle -->
   <packaging>docker</packaging>
 

--- a/samples/docker-compose-demo/pom.xml
+++ b/samples/docker-compose-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-compose-demo</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/samples/docker-compose-demo/pom.xml
+++ b/samples/docker-compose-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-compose-demo</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/samples/docker-compose-demo/pom.xml
+++ b/samples/docker-compose-demo/pom.xml
@@ -28,27 +28,51 @@
 
   <artifactId>docker-compose-demo</artifactId>
   <version>0.17-SNAPSHOT</version>
-  <!-- add custom lifecycle -->
-  <packaging>docker</packaging>
 
   <url>http://www.jolokia.org</url>
 
   <properties>
     <server.version>7</server.version>
     <server.name>tomcat</server.name>
-    <image>fabric8/${server.name}-${server.version}:latest</image>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-war</artifactId>
+      <version>1.3.5</version>
+      <type>war</type>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <extensions>true</extensions> <!-- enables using 'docker' packaging above -->
         <configuration>
           <images>
-            <!-- Use docker-compose -->
             <image>
+            <alias>jolokia-war</alias>
+              <!-- Data image containing jolokia.war -->
+              <name>${project.groupId}/${project.artifactId}:latest</name>
+              <!-- <build> the image-->
+              <build>
+                <assembly>
+                  <inline>
+                    <id>jolokia</id>
+                    <dependencySets>
+                      <dependencySet>
+                        <includes>
+                          <include>org.jolokia:jolokia-war</include>
+                        </includes>
+                        <outputDirectory>.</outputDirectory>
+                        <outputFileNameMapping>jolokia.war</outputFileNameMapping>
+                      </dependencySet>
+                    </dependencySets>
+                  </inline>
+                </assembly>
+              </build>
+              <!-- The <run> part is taken from compose -->
               <external>
                 <type>compose</type>
               </external>

--- a/samples/docker-compose-demo/pom.xml
+++ b/samples/docker-compose-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.2</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-compose-demo</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/samples/docker-compose-demo/pom.xml
+++ b/samples/docker-compose-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-compose-demo</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/samples/docker-compose-demo/pom.xml
+++ b/samples/docker-compose-demo/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>docker-compose-demo</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/samples/docker-compose-demo/src/main/docker/docker-compose.yml
+++ b/samples/docker-compose-demo/src/main/docker/docker-compose.yml
@@ -1,9 +1,6 @@
 version: "2"
 services:
-  data:
-    build:
-      context: .
-    image: "${project.groupId}/${project.artifactId}:latest"
+  jolokia-war:
     labels:
       "dmp.type": "example"
       "dmp.value": "100$$"
@@ -19,4 +16,4 @@ services:
         hard: 2048
         soft: 1024
     volumes_from:
-      - data
+      - jolokia-war

--- a/samples/dockerignore/pom.xml
+++ b/samples/dockerignore/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.2</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-dockerignore</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/dockerignore/pom.xml
+++ b/samples/dockerignore/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-dockerignore</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/dockerignore/pom.xml
+++ b/samples/dockerignore/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-dockerignore</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/dockerignore/pom.xml
+++ b/samples/dockerignore/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-dockerignore</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/dockerignore/pom.xml
+++ b/samples/dockerignore/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-dockerignore</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/healthcheck/pom.xml
+++ b/samples/healthcheck/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-healthcheck</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
 
 
   <build>

--- a/samples/healthcheck/pom.xml
+++ b/samples/healthcheck/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-healthcheck</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
 
 
   <build>

--- a/samples/healthcheck/pom.xml
+++ b/samples/healthcheck/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-healthcheck</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
 
 
   <build>

--- a/samples/healthcheck/pom.xml
+++ b/samples/healthcheck/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-healthcheck</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
 
 
   <build>

--- a/samples/healthcheck/pom.xml
+++ b/samples/healthcheck/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.2</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-healthcheck</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
 
 
   <build>

--- a/samples/multi-wait/pom.xml
+++ b/samples/multi-wait/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-sample-multi-wait</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
   <!-- Sample exhibiting connection error described in https://github.com/fabric8io/docker-maven-plugin/issues/574 -->
  <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/samples/multi-wait/pom.xml
+++ b/samples/multi-wait/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-sample-multi-wait</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
   <!-- Sample exhibiting connection error described in https://github.com/fabric8io/docker-maven-plugin/issues/574 -->
  <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.2</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/samples/multi-wait/pom.xml
+++ b/samples/multi-wait/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-sample-multi-wait</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
   <!-- Sample exhibiting connection error described in https://github.com/fabric8io/docker-maven-plugin/issues/574 -->
  <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/samples/multi-wait/pom.xml
+++ b/samples/multi-wait/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-sample-multi-wait</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
   <!-- Sample exhibiting connection error described in https://github.com/fabric8io/docker-maven-plugin/issues/574 -->
  <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/samples/multi-wait/pom.xml
+++ b/samples/multi-wait/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-sample-multi-wait</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
   <!-- Sample exhibiting connection error described in https://github.com/fabric8io/docker-maven-plugin/issues/574 -->
  <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/samples/net/pom.xml
+++ b/samples/net/pom.xml
@@ -16,12 +16,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-net</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
 
   <profiles>
     <profile>

--- a/samples/net/pom.xml
+++ b/samples/net/pom.xml
@@ -16,12 +16,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.2</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-net</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
 
   <profiles>
     <profile>

--- a/samples/net/pom.xml
+++ b/samples/net/pom.xml
@@ -16,12 +16,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-net</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
 
   <profiles>
     <profile>

--- a/samples/net/pom.xml
+++ b/samples/net/pom.xml
@@ -16,12 +16,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-net</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
 
   <profiles>
     <profile>

--- a/samples/net/pom.xml
+++ b/samples/net/pom.xml
@@ -16,12 +16,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-net</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
 
   <profiles>
     <profile>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>dmp-sample-parent</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
   <packaging>pom</packaging>
 
   <url>http://www.jolokia.org</url>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>dmp-sample-parent</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <url>http://www.jolokia.org</url>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>dmp-sample-parent</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <url>http://www.jolokia.org</url>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>dmp-sample-parent</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
   <packaging>pom</packaging>
 
   <url>http://www.jolokia.org</url>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>dmp-sample-parent</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
   <packaging>pom</packaging>
 
   <url>http://www.jolokia.org</url>

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.18.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-properties</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.18.1</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-properties</artifactId>
-  <version>0.18.1</version>
+  <version>0.18-SNAPSHOT</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17-SNAPSHOT</version>
+    <version>0.17.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-properties</artifactId>
-  <version>0.17-SNAPSHOT</version>
+  <version>0.17.1</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.1</version>
+    <version>0.17.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-properties</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -28,7 +28,7 @@
           <images>
             <image>
               <external>
-                <type>props</type>
+                <type>properties</type>
                 <prefix>postgres.docker</prefix>
               </external>
             </image>

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.17.2</version>
+    <version>0.18-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-sample-properties</artifactId>
-  <version>0.17.2</version>
+  <version>0.18-SNAPSHOT</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -67,9 +67,9 @@ the URL is:
 . `//./pipe/docker_engine` if it is a readable named pipe (Windows)
 | `docker.host`
 
-| *image*
-| In order to temporarily restrict the operation of plugin goals this configuration option can be used. Typically this will be set via the system property `docker.image` when Maven is called. The value can be a single image name (either its alias or full name) or it can be a comma separated list with multiple image names. Any name which doesn't refer an image in the configuration will be ignored.
-| `docker.image`
+| *filter*
+| In order to temporarily restrict the operation of plugin goals this configuration option can be used. Typically this will be set via the system property `docker.filter` when Maven is called. The value can be a single image name (either its alias or full name) or it can be a comma separated list with multiple image names. Any name which doesn't refer an image in the configuration will be ignored.
+| `docker.filter`
 
 | *logDate*
 | Date format which is used for printing out container logs. This configuration can be overwritten by individual run configurations and described below. The format is described in <<loggging,Logging>>.

--- a/src/main/asciidoc/inc/build/_assembly.adoc
+++ b/src/main/asciidoc/inc/build/_assembly.adoc
@@ -1,7 +1,8 @@
 
 The `<assembly>` element within `<build>` is has an XML struture and defines how build artifacts and other files can enter the Docker image.
 
-.Assembly Configuration
+[[config-image-build-assembly]]
+.Assembly Configuration (<<config-image, <image> >> : <<config-image-build, <build> >>)
 [cols="1,5"]
 |===
 | Element | Description
@@ -9,17 +10,17 @@ The `<assembly>` element within `<build>` is has an XML struture and defines how
 | *basedir*
 | Directory under which the files and artifacts contained in the assembly will be copied within the container. The default value for this is `/maven`.
 
-| *inline*
+| <<build-assembly-descriptor, *inline*>>
 | Inlined assembly descriptor as described in <<build-assembly-descriptor,Assembly Descriptor>> below.
 
-| *descriptor*
+| <<build-assembly-descriptor, *descriptor*>>
 | Path to an assembly descriptor file, whose format is described  <<build-assembly-descriptor,Assembly Descriptor>> below.
 
-| *descriptorRef*
+| <<build-assembly-descriptor-refs, *descriptorRef*>>
 | Alias to a predefined assembly descriptor. The available aliases are also described in <<build-assembly-descriptor,Assembly Descriptor>> below.
 
 | *dockerFileDir*
-| Directory containing an external Dockerfile. _This option is deprecated, please use <dockerfiledir> directly in the <build> section.
+| Directory containing an external Dockerfile. _This option is deprecated, please use <dockerfiledir> directly in the <build> section_.
 
 | *exportBasedir*
 | Specification whether the `basedir` should be exported as a volume.  This value is `true` by default except in the case the `basedir` is set to the container root (`/`). It is also `false` by default when a base image is used with `from` since exporting makes no sense in this case and will waste disk space unnecessarily.
@@ -83,12 +84,13 @@ used (no need to distinguish multiple descriptors)
 Also you can inline the assembly description with a `inline` description
 directly into the pom file. Adding the proper namespace even allows for
 IDE autocompletion. As an example, refer to the profile `inline` in
-the `data-jolokia-demo`'s pom.xml.
+the `data-jolokia-demo` 's pom.xml.
 
 Alternatively `descriptorRef` can be used with the name of a
 predefined assembly descriptor. The following symbolic names can be
 used for `descriptorRef`:
 
+[[build-assembly-descriptor-refs]]
 .Predefined Assembly Descriptors
 [cols="1,3"]
 |===

--- a/src/main/asciidoc/inc/build/_assembly.adoc
+++ b/src/main/asciidoc/inc/build/_assembly.adoc
@@ -7,7 +7,7 @@ The `<assembly>` element within `<build>` is has an XML struture and defines how
 |===
 | Element | Description
 
-| *basedir*
+| *targetDir*
 | Directory under which the files and artifacts contained in the assembly will be copied within the container. The default value for this is `/maven`.
 
 | <<build-assembly-descriptor, *inline*>>
@@ -22,8 +22,8 @@ The `<assembly>` element within `<build>` is has an XML struture and defines how
 | *dockerFileDir*
 | Directory containing an external Dockerfile. _This option is deprecated, please use <dockerfiledir> directly in the <build> section_.
 
-| *exportBasedir*
-| Specification whether the `basedir` should be exported as a volume.  This value is `true` by default except in the case the `basedir` is set to the container root (`/`). It is also `false` by default when a base image is used with `from` since exporting makes no sense in this case and will waste disk space unnecessarily.
+| *exportTargetDir*
+| Specification whether the `targetDir` should be exported as a volume.  This value is `true` by default except in the case the `targetDir` is set to the container root (`/`). It is also `false` by default when a base image is used with `from` since exporting makes no sense in this case and will waste disk space unnecessarily.
 
 | *ignorePermissions*
 | Specification if existing file permissions should be ignored
@@ -120,9 +120,9 @@ used for `descriptorRef`:
          .....
 ----
 
-will add the created artifact with the name `${project.build.finalName}.${artifact.extension}` and all jar dependencies in the the `baseDir` (which is `/maven` by default).
+will add the created artifact with the name `${project.build.finalName}.${artifact.extension}` and all jar dependencies in the the `targetDir` (which is `/maven` by default).
 
-All declared files end up in the configured `basedir` (or `/maven` by default) in the created image.
+All declared files end up in the configured `targetDir` (or `/maven` by default) in the created image.
 
 If the assembly references the artifact to build with this pom, it is required that the `package` phase is included in the run. This happens either automatically when the `{plugin}:build` target is called, or when `{plugin}:build-nofork` is bound to an execution phase in the plugin configuration. By default `{plugin}:build-nofork` is bound to the `install`
 phase).

--- a/src/main/asciidoc/inc/build/_assembly.adoc
+++ b/src/main/asciidoc/inc/build/_assembly.adoc
@@ -52,7 +52,7 @@ assembly configuration
 | *tarLongFileMode*
 | Sets the TarArchiver behaviour on file paths with more than 100 characters length. Valid values are: "warn"(default), "fail", "truncate", "gnu", "posix", "posix_warn" or "omit"
 
-| *user*
+| [[config-image-build-assembly-user]] *user*
 | User and/or group under which the files should be added. The user must already exist in the base image.
 
 It has the general format `user[:group[:run-user]]`. The user and group can be given either as numeric user- and group-id or as names. The group id is optional.

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -18,6 +18,12 @@ which should be used when building the image with an external Dockerfile which u
 This argument is ignored when no external Dockerfile is used. Build args can also be specified as properties as
 described in <<build-buildargs,Build Args>>
 
+| *buildOptions*
+| Map specifying the build options to provide to the docker daemon when building the image. These options map to the ones listed as query parameters in the
+https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#build-image-from-a-dockerfile[Docker Remote API] and are restricted to simple options
+(e.g.: memory, shmsize). Use the respective configuration options for build options natively supported by the build configuration (like `nocache`).
+The key-value syntax is the same as when defining Maven properties (or `labels` or `env`).
+
 | *cleanup*
 | Cleanup dangling (untagged) images after each build (including any containers created from them). Default is `try` which tries to remove the old image, but doesn't fail the build if this is not possible because e.g. the image is still used by a running container. Use `remove` if you want to fail the build and `none` if no cleanup is requested.
 
@@ -109,6 +115,10 @@ remote API.
   <volumes>
     <volume>/path/to/expose</volume>
   </volumes>
+  <buildOptions>
+    <!-- 2GB -->
+    <shmsize>2147483648</shmsize>
+  </buildOptions>
 
   <entryPoint>
     <!-- exec form for ENTRYPOINT -->

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -121,7 +121,7 @@ remote API.
 
   <assembly>
     <mode>dir</mode>
-    <basedir>/opt/demo</basedir>
+    <targetDir>/opt/demo</targetDir>
     <descriptor>assembly.xml</descriptor>
   </assembly>
 </build>

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -3,15 +3,16 @@ All build relevant configuration is contained in the `<build>` section
 of an image configuration. In addition to `<dockerFileDir>` and
 `<dockerFile>` the following configuration options are available:
 
-.Build configuration
+[[config-image-build]]
+.Build configuration (<<config-image, <image> >>)
 [cols="1,5"]
 |===
 | Element | Description
 
-| *assembly*
+| <<config-image-build-assembly, *assembly*>>
 | specifies the assembly configuration as described in <<build-assembly,Build Assembly>>
 
-| *buildArgs*
+| <<config-image-build-buildargs, *buildArgs*>>
 | Map specifying the value of https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables-build-arg[Docker build args]
 which should be used when building the image with an external Dockerfile which uses build arguments. The key-value syntax is the same as when defining Maven properties (or `labels` or `env`).
 This argument is ignored when no external Dockerfile is used. Build args can also be specified as properties as
@@ -20,16 +21,16 @@ described in <<build-buildargs,Build Args>>
 | *cleanup*
 | Cleanup dangling (untagged) images after each build (including any containers created from them). Default is `try` which tries to remove the old image, but doesn't fail the build if this is not possible because e.g. the image is still used by a running container. Use `remove` if you want to fail the build and `none` if no cleanup is requested.
 
-| *cmd*
+| <<misc-startup, *cmd*>>
 | A command to execute by default (i.e. if no command is provided when a container for this image is started). See <<misc-startup,Startup Arguments>> for details.
 
 | *compression*
 | The compression mode how the build archive is transmitted to the docker daemon (`{plugin}:build`) and how docker build archives are attached to this build as sources (`{plugin}:source`). The value can be `none` (default), `gzip` or `bzip2`.
 
-| *entryPoint*
+| <<misc-startup, *entryPoint*>>
 | An entrypoint allows you to configure a container that will run as an executable. See <<misc-startup,Startup Arguments>> for details.
 
-| *env*
+| <<misc-env, *env*>>
 | The environments as described in <<misc-env,Setting Environment Variables and Labels>>.
 
 | [[build-config-from]]*from*
@@ -51,10 +52,10 @@ endif::[]
 
 A provided `<from>` takes precedence over the name given here. This tag is useful for extensions of this plugin like the https://maven.fabric8.io[fabric8-maven-plugin] which can evaluate the additional information given here.
 
-| *healthCheck*
+| <<build-healthcheck, *healthCheck*>>
 a| Definition of a health check as described in <<build-healthcheck, Healthcheck>>
 
-| *labels*
+| <<misc-env, *labels*>>
 | Labels  as described in <<misc-env,Setting Environment Variables and Labels>>.
 
 | *maintainer*

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -68,7 +68,7 @@ a| Definition of a health check as described in <<build-healthcheck, Healthcheck
 | if set to true then it will compress all the `runCmds` into a single `RUN` directive so that only one image layer is created.
 
 | *ports*
-| The exposed ports which is a list of `<port>` elements, one for each port to expose.
+| The exposed ports which is a list of `<port>` elements, one for each port to expose. The format can be either pure numerical ("8080") or with the protocol attached ("8080/tcp"),
 
 | *runCmds*
 | Commands to be run during the build process. It contains *run* elements which are passed to the shell. The run commands are inserted right after the assembly and after *workdir* in to the Dockerfile. This tag is not to be confused with the `<run>` section for this image which specifies the runtime behaviour when starting containers.

--- a/src/main/asciidoc/inc/external/_docker_compose.adoc
+++ b/src/main/asciidoc/inc/external/_docker_compose.adoc
@@ -5,15 +5,27 @@ This plugin supports als configuration via a  https://docs.docker.com/compose/[d
 [source,xml]
 ----
 <image>
-  <external>
-     <type>compose</type> <!--1-->
-     <basedir>src/main/docker</prefix> <!--2-->
+  <alias>webapp</alias> <!--1-->
+  <name>fabric8/compose-demo:latest</name>
+
+  <external> <!--2-->
+     <type>compose</type> <!--3-->
+     <basedir>src/main/docker</prefix> <!--4-->
      <composeFile>docker-compose.yml</composeFile>
   </external>
+
+  <build> <!--5-->
+    <assembly>....</assembly>
+  </build>
+  <run>...</run>
+  <watch>...</watch>
 </image>
 ----
-<1> The type for the external configuration provider must be set to **compose**
-<2> Additional configuration where to find the compose file
+<1> The alias of the image is used as correlation key mapping to a service in the Docker Compose file
+<2> An `<external>` configuration handler needs to be used for Docker Compose support
+<3> The type for the external configuration provider must be set to **compose**
+<4> Additional configuration for the handler where to find the compose file
+<5> Extra `<build>`, `<run>` and `<watch>` configuration can be provided which are used as default configuration for the Docker compose service `webapp` (as specified with the alias)
 
 The following options can be provided:
 
@@ -31,13 +43,13 @@ The following options can be provided:
 | `docker-compose.yml`
 
 | *ignoreBuild*
-| Ignore the compos file's `build:` section and use the plugin's build configuration exclusively.
+| Ignore the compose file's `build:` section and use the plugin's build configuration exclusively.
 | `false`
 |===
 
 The Docker Compose file can contain variables as described in the https://docs.docker.com/compose/compose-file/#/variable-substitution[Docker Compose documentation]. These are substituted with Maven project properties. Please note, when the `docker-compose.yml` with variables is to be used with the `docker-compose` CLI command, that these variables must also be valid environment variables (i.e. must not contain a `.`).
 
-In addition to the `docker-compose.yml` you can add all known options for <<build-configuration,<build> >>, <<start-configuration,<run> >> and <<watch-configuration,<watch> >> configuration elements which are then used as defaults and are overwritten by the configuration defined in the `docker-compose.yml` file.
+In addition to the `docker-compose.yml` you can add all known options for <<build-configuration,<build> >>, <<start-configuration,<run> >> and <<watch-configuration,<watch> >> configuration elements which are then used as defaults and are overwritten by the configuration defined in the `docker-compose.yml` file. The merging between the XML configuration and the information found in `docker-compose.yml` is correlated via the `<alias>` name. E.g. if the XML image configuration is aliased with `webapp` then its is used as a default configuration for a Docker Compose _service_ name `webapp`. All other services defined in the compose file are left untouched.
 
 === Limitations
 

--- a/src/main/asciidoc/inc/external/_docker_compose.adoc
+++ b/src/main/asciidoc/inc/external/_docker_compose.adoc
@@ -10,7 +10,7 @@ This plugin supports als configuration via a  https://docs.docker.com/compose/[d
 
   <external> <!--2-->
      <type>compose</type> <!--3-->
-     <basedir>src/main/docker</prefix> <!--4-->
+     <basedir>src/main/docker</basedir> <!--4-->
      <composeFile>docker-compose.yml</composeFile>
   </external>
 

--- a/src/main/asciidoc/inc/external/_docker_compose.adoc
+++ b/src/main/asciidoc/inc/external/_docker_compose.adoc
@@ -20,6 +20,8 @@ The following options can be provided:
 .Docker compose configuration
 [cols="1,5,1"]
 |===
+| Element | Description | Default
+
 | *basedir*
 | Basedir where to find the compose file and which is also used as the current directory when examing the compose file
 | `${basedir}/src/main/docker`
@@ -27,9 +29,13 @@ The following options can be provided:
 | *composeFile*
 | Name of the compose file to use
 | `docker-compose.yml`
+
+| *ignoreBuild*
+| Ignore the compos file's `build:` section and use the plugin's build configuration exclusively.
+| `false`
 |===
 
-The Docker Compose file can containe variables as described in the https://docs.docker.com/compose/compose-file/#/variable-substitution[Docker Compose documentation]. These are substituted with Maven project properties. Please note, when the `docker-compose.yml` with variables is to be used with the `docker-compose` CLI command, that these variables must also be valid environment variables (i.e. must not contain a `.`).
+The Docker Compose file can contain variables as described in the https://docs.docker.com/compose/compose-file/#/variable-substitution[Docker Compose documentation]. These are substituted with Maven project properties. Please note, when the `docker-compose.yml` with variables is to be used with the `docker-compose` CLI command, that these variables must also be valid environment variables (i.e. must not contain a `.`).
 
 In addition to the `docker-compose.yml` you can add all known options for <<build-configuration,<build> >>, <<start-configuration,<run> >> and <<watch-configuration,<watch> >> configuration elements which are then used as defaults and are overwritten by the configuration defined in the `docker-compose.yml` file.
 

--- a/src/main/asciidoc/inc/image/_configuration.adoc
+++ b/src/main/asciidoc/inc/image/_configuration.adoc
@@ -1,4 +1,5 @@
 
+[[config-image]]
 .Image Configuration
 [cols="1,5"]
 |===
@@ -13,18 +14,18 @@ repository _name_. This can include registry and tag parts, but also placeholder
 identifying the image within this configuration. This is used when
 linking images together or for specifying it with the global *image* configuration element.
 
-| *registry*
+| <<registry, *registry*>>
 | Registry to use for this image. If the `name` already contains a registry this takes precedence. See <<registry,Registry handling>> for more details.
 
-| *build*
+| <<config-image-build, *build*>>
 | Element which contains all the configuration aspects when doing a <<{plugin}:build>>. This element can be omitted if the image is only pulled from a registry e.g. as support for integration tests like database images.
 
 ifeval::["{plugin}" == "docker"]
-| *run*
+| <<config-image-run, *run*>>
 | Element which describe how containers should be
 created and run when <<{plugin}:start>> is called. If this image is only used a _data container_ (i.e. is supposed only to be mounted as a volume) for exporting artifacts via volumes this section can be missing.
 
-| *external*
+| <<external-configuration, *external*>>
 | Specification of external configuration as an alternative to this XML based configuration with `<run>` and `<build>`. It contains a `<type>` element specifying the handler for getting the configuration. See <<external-configuration,External configuration>> for details.
 endif::[]
 |===
@@ -53,4 +54,3 @@ When specifying the name you can use several placeholders which are replaced dur
 | *%t*
 | If the project version ends with `-SNAPSHOT` this placeholder resolves to `snapshot-<timestamp>` where timestamp has the date format `yyMMdd-HHmmss-SSSS` (eg `snapshot-`). This feature is especially useful during development in oder to avoid conflicts when images are to be updated which are still in use. You need to take care yourself of cleaning up old images afterwards, though.
 |===
-

--- a/src/main/asciidoc/inc/start/_configuration.adoc
+++ b/src/main/asciidoc/inc/start/_configuration.adoc
@@ -19,8 +19,8 @@ In addition to the <<global-configuration>>, this goal supports the following gl
 
 The `<run>` configuration element knows the following sub elements:
 
-[[start-run-configuration]]
-.Run configuration
+[[config-image-run]]
+.Run configuration (<<config-image, <image> >>)
 [cols="1,5"]
 |===
 | Element | Description
@@ -31,7 +31,7 @@ The `<run>` configuration element knows the following sub elements:
 | *capDrop*
 | List of `drop` elements to specify kernel parameters to remove from the container.
 
-| *cmd*
+| <<misc-startup, *cmd*>>
 | Command which should be executed at the end of the container's startup. If not given, the image's default command is used. See <<misc-startup, Startup Arguments>> for details.
 
 | *domainname*
@@ -46,7 +46,7 @@ The `<run>` configuration element knows the following sub elements:
 | *entrypoint*
 | Entry point for the container. See <<misc-startup, Startup Arguments] for details.
 
-| *env*
+| <<misc-env, *env*>>
 | Environment variables as subelements which are set during startup of the container. They are specified in the typical maven property format as described <<misc-env,Environment and Labels>>.
 
 | *envPropertyFile*
@@ -61,13 +61,13 @@ The `<run>` configuration element knows the following sub elements:
 | *hostname*
 | Hostname of the container
 
-| *labels*
+| <<misc-env, *labels*>>
 | Labels which should be attached to the  container. They are specified in the typical maven property format as described in <<misc-env,Environment and Labels>>.
 
-| *links*
+| <<start-links, *links*>>
 | Network links for connecting containers together as described in  <<start-links, Network Links>>.
 
-| *log*
+| <<start-logging, *log*>>
 | Log configuration for whether and how log messages from the running containers should be printed. This also can configure the https://docs.docker.com/engine/admin/logging/overview[log driver] to use. See <<start-logging,Logging>> for a detailed description.
 
 | *memory*
@@ -82,20 +82,20 @@ a| Naming strategy for how the container name is created:
 * *none* : uses randomly assigned names from docker (default)
 * *alias* : uses the `alias` specified in the `image` configuration. An error is thrown, if a container already exists with this name.
 
-| *network*
-| <<network-configuration, Network configuration>> for your container.
+| <<network-configuration, *network*>>
+| Network configuration for your container.
 
-| *portPropertyFile*
+| <<start-port-mapping *portPropertyFile*>>
 | File path into which the mapped port properties are written. The format of this file and its purpose are also described in <<start-port-mapping,Port mapping>>
 
-| *ports*
+| <<start-port-mapping, *ports*>>
 | <<start-port-mapping,Port mappings>> for exposing container ports to host ports.
 
 | *privileged*
 | If `true` give container full access to host
 
-| *restartPolicy*
-| <<start-restart,Restart Policy>>
+| <<start-restart, *restartPolicy*>>
+| Restart Policy
 
 | *securityOpts*
 | List of `<opt>` elements to specify kernel security options to add to the container. See below for an example.
@@ -121,10 +121,10 @@ See below for an example.
 | *user*
 | User used inside the container
 
-| *volumes*
-| Volume configuration for binding to host directories and from other containers. See <<start-volumes,Volumes>> for details.
+| <<start-volumes, *volumes*>>
+| Volume configuration for binding to host directories and from other containers. See Volumes for details.
 
-| *wait*
+| <<start-wait, *wait*>>
 | Condition which must be fulfilled for the startup to complete. See <<start-wait,Wait>> for all possible ways to wait for a startup condition.
 
 | *workingDir*

--- a/src/main/asciidoc/inc/start/_network.adoc
+++ b/src/main/asciidoc/inc/start/_network.adoc
@@ -12,7 +12,8 @@ a| The network mode, which can be one of the following values:
 * *bridge* : Bridged mode with the default Docker bridge (default)
 * *host* : Share the Docker host network interfaces
 * *container* : Connect to the network of the specified container. The name of the container is taken from the `<name>` element.
-* *custom* : Use a custom network which must be created before with `docker network create`. This is available for Docker 1.9 and newer. For more about the networking options please refer to the https://docs.docker.com/engine/userguide/networking/work-with-networks[Docker documentation].
+* *custom* : Use a custom network, which must be created before using `docker network create`. Alternatively you can set the ```docker.autoCreateCustomNetworks``` <<global-configuration, global configuration>> parameter to ```true``` to automatically create custom networks. Custom networks are available for Docker 1.9 and newer. For more about the networking options please refer to the https://docs.docker.com/engine/userguide/networking/work-with-networks[Docker documentation].
+
 * *none* : No network will be setup.
 
 | *name*

--- a/src/main/asciidoc/inc/start/_overview.adoc
+++ b/src/main/asciidoc/inc/start/_overview.adoc
@@ -21,6 +21,6 @@ By default container specific properties are exposed as Maven properties. These 
 | Internal IP address of the container in the specified custom network. This works only for custom networks.
 |===
 
-Instead of the `<alias>` a fixed property key can be configured in the image's <<start-run-configuration, <run> >> configuration with the option `exposedPropertyKey`.
+Instead of the `<alias>` a fixed property key can be configured in the image's <<config-image-run, <run> >> configuration with the option `exposedPropertyKey`.
 
 For example the Maven property `docker.container.tomcat.ip` would hold the Docker internal IP for a container with an alias "tomcat". You can set the global configuration *exposeContainerInfo* to an empty string to not expose container information that way or to a string for an other prefix than `docker.container`.

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -131,10 +131,10 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     /**
      * Whether to restrict operation to a single image. This can be either
      * the image or an alias name. It can also be comma separated list.
-     * This parameter is typically set via the command line.
+     * This parameter has to be set via the command line s system property.
      */
-    @Parameter(property = "docker.image")
-    private String image;
+    @Parameter(property = "docker.filter")
+    private String filter;
 
     // Default registry to use if no registry is specified
     @Parameter(property = "docker.registry")
@@ -251,7 +251,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
                         return imageConfigResolver.resolve(image, project, session);
                     }
                 },
-            image,                   // A filter which image to process
+           filter,                   // A filter which image to process
             this);                     // customizer (can be overwritten by a subclass)
 
         // Initialize configuration and detect minimal API version

--- a/src/main/java/io/fabric8/maven/docker/LogsMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/LogsMojo.java
@@ -52,7 +52,9 @@ public class LogsMojo extends AbstractDockerMojo {
                 }
             } else {
                 Container container = queryService.getLatestContainerForImage(imageName);
-                doLogging(logDispatcher, image, container.getId());
+                if (container != null) {
+                    doLogging(logDispatcher, image, container.getId());
+                }
             }
         }
         if (follow) {

--- a/src/main/java/io/fabric8/maven/docker/WatchMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/WatchMojo.java
@@ -35,8 +35,6 @@ import io.fabric8.maven.docker.util.MojoParameters;
 import io.fabric8.maven.docker.util.StartOrderResolver;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Execute;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.StringUtils;
@@ -114,7 +112,7 @@ public class WatchMojo extends AbstractBuildSupportMojo {
                 if (imageConfig.getBuildConfiguration() != null &&
                     imageConfig.getBuildConfiguration().getAssemblyConfiguration() != null) {
                     if (watcher.isCopy()) {
-                        String containerBaseDir = imageConfig.getBuildConfiguration().getAssemblyConfiguration().getBasedir();
+                        String containerBaseDir = imageConfig.getBuildConfiguration().getAssemblyConfiguration().getTargetDir();
                         schedule(createCopyWatchTask(hub, watcher, mojoParameters, containerBaseDir),interval);
                         tasks.add("copying artifacts");
                     }

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -183,10 +183,12 @@ public interface DockerAccess {
      * @param dockerfileName filename of the Dockerfile within the archive or <code>null</code> for the default Dockerfile
      * @param forceRemove whether to remove intermediate containers
      * @param noCache whether to use cache when building the image
-     * @param buildArgs buildArgs to add then building the image. Can be <code>null</code> for no build args.    @throws DockerAccessException if docker host reports an error during building of an image
+     * @param buildArgs buildArgs to add then building the image. Can be <code>null</code> for no build args.
+     * @param buildOptions buildOptions additional query arguments to add when building the image. Can be <code>null</code>.
+     * @throws DockerAccessException if docker host reports an error during building of an image
      */
     void buildImage(String image, File dockerArchive, String dockerfileName, boolean forceRemove, boolean noCache,
-                    Map<String, String> buildArgs) throws DockerAccessException;
+                    Map<String, String> buildArgs, Map<String, String> buildOptions) throws DockerAccessException;
 
     /**
      * Alias an image in the repository with a complete new name. (Note that this maps to a Docker Remote API 'tag'

--- a/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
@@ -20,7 +20,7 @@ public final class UrlBuilder {
         this.baseUrl = stripSlash(baseUrl);
     }
 
-    public String buildImage(String image, String dockerfileName, boolean forceRemove, boolean noCache, Map<String, String> buildArgs) {
+    public String buildImage(String image, String dockerfileName, boolean forceRemove, boolean noCache, Map<String, String> buildArgs, Map<String, String> buildOptions) {
 
         Builder urlBuilder = u("build")
             .p("t", image)
@@ -28,6 +28,11 @@ public final class UrlBuilder {
             .p("nocache", noCache);
         if (buildArgs != null && !buildArgs.isEmpty()) {
             urlBuilder.p("buildargs", new JSONObject(buildArgs).toString());
+        }
+        if (buildOptions != null && !buildOptions.isEmpty()) {
+            for (String key : buildOptions.keySet()) {
+                urlBuilder.p(key, buildOptions.get(key));
+            }
         }
         if (dockerfileName != null) {
             urlBuilder.p("dockerfile",dockerfileName);

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -234,9 +234,9 @@ public class DockerAccessWithHcClient implements DockerAccess {
 
     @Override
     public void buildImage(String image, File dockerArchive, String dockerfileName, boolean forceRemove, boolean noCache,
-            Map<String, String> buildArgs) throws DockerAccessException {
+                           Map<String, String> buildArgs, Map<String, String> buildOptions) throws DockerAccessException {
         try {
-            String url = urlBuilder.buildImage(image, dockerfileName, forceRemove, noCache, buildArgs);
+            String url = urlBuilder.buildImage(image, dockerfileName, forceRemove, noCache, buildArgs, buildOptions);
             delegate.post(url, dockerArchive, createBuildResponseHandler(), HTTP_OK);
         } catch (IOException e) {
             throw new DockerAccessException(e, "Unable to build image [%s]", image);

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -309,9 +309,9 @@ public class DockerAssemblyManager {
         }
         if (assemblyConfig != null) {
             builder.add(ASSEMBLY_NAME, "")
-                   .basedir(assemblyConfig.getBasedir())
+                   .basedir(assemblyConfig.getTargetDir())
                    .assemblyUser(assemblyConfig.getUser())
-                   .exportBasedir(assemblyConfig.exportBasedir());
+                   .exportBasedir(assemblyConfig.exportTargetDir());
         } else {
             builder.exportBasedir(false);
         }

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -311,9 +311,9 @@ public class DockerAssemblyManager {
             builder.add(ASSEMBLY_NAME, "")
                    .basedir(assemblyConfig.getTargetDir())
                    .assemblyUser(assemblyConfig.getUser())
-                   .exportBasedir(assemblyConfig.exportTargetDir());
+                   .exportTargetDir(assemblyConfig.exportTargetDir());
         } else {
-            builder.exportBasedir(false);
+            builder.exportTargetDir(false);
         }
 
         builder.baseImage(buildConfig.getFrom());

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
@@ -239,7 +239,7 @@ public class DockerFileBuilder {
         if (ports.size() > 0) {
             String[] portsS = new String[ports.size()];
             int i = 0;
-            for(String port : portsS) {
+            for(String port : ports) {
             	portsS[i++] = validatePortExposure(port);
             }
             DockerFileKeyword.EXPOSE.addTo(b, portsS);

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
@@ -36,7 +36,7 @@ public class DockerFileBuilder {
     private Arguments entryPoint;
     private Arguments cmd;
 
-    private Boolean exportBasedir = null;
+    private Boolean exportTargetDir = null;
 
     // User under which the files should be added
     private String assemblyUser;
@@ -259,7 +259,7 @@ public class DockerFileBuilder {
 	}
 
     private void addVolumes(StringBuilder b) {
-        if (exportBasedir != null ? exportBasedir : baseImage == null) {
+        if (exportTargetDir != null ? exportTargetDir : baseImage == null) {
             addVolume(b, basedir);
         }
 
@@ -371,8 +371,8 @@ public class DockerFileBuilder {
         return this;
     }
 
-    public DockerFileBuilder exportBasedir(Boolean exportBasedir) {
-        this.exportBasedir = exportBasedir;
+    public DockerFileBuilder exportTargetDir(Boolean exportTargetDir) {
+        this.exportTargetDir = exportTargetDir;
         return this;
     }
 

--- a/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
@@ -11,7 +11,7 @@ public class AssemblyConfiguration implements Serializable {
     private static final String DEFAULT_BASE_DIR = "/maven";
 
     /**
-     * @parameter
+     * @deprecated Use 'targetDir' instead
      */
     @Deprecated
     private String basedir;
@@ -20,29 +20,26 @@ public class AssemblyConfiguration implements Serializable {
      * New replacement for base directory which better reflects its
      * purpose
      */
+    @Parameter
     private String targetDir;
 
-    /**
-     * @parameter
-     */
+    @Parameter
     private String descriptor;
 
-    /**
-     * @parameter
-     */
+    @Parameter
     private Assembly inline;
 
-    /**
-     * @parameter
-     */
+    @Parameter
     private String descriptorRef;
 
     /**
-     * @parameter
      * @deprecated Use {@link BuildImageConfiguration#dockerFileDir} instead
      */
+    @Parameter
+    @Deprecated
     private String dockerFileDir;
 
+    // use 'exportTargetDir' instead
     @Deprecated
     private Boolean exportBasedir;
 
@@ -55,24 +52,18 @@ public class AssemblyConfiguration implements Serializable {
     private Boolean exportTargetDir;
 
     /**
-     * @paramter default-value="false"
      * @deprecated use permissionMode == ignore instead.
      */
+    @Parameter
     private Boolean ignorePermissions;
 
-    /**
-     * @parameter
-     */
+    @Parameter
     private AssemblyMode mode;
 
-    /**
-     * @parameter
-     */
+    @Parameter
     private String user;
 
-    /**
-     * @parameter
-     */
+    @Parameter
     private String tarLongFileMode;
 
     public Boolean exportTargetDir() {
@@ -149,8 +140,8 @@ public class AssemblyConfiguration implements Serializable {
             return isEmpty ? null : config;
         }
 
-        public Builder basedir(String baseDir) {
-            config.basedir = set(baseDir);
+        public Builder targetDir(String targetDir) {
+            config.targetDir = set(targetDir);
             return this;
         }
 
@@ -239,5 +230,5 @@ public class AssemblyConfiguration implements Serializable {
          * Ignore permission when using an assembly mode of "dir"
          */
         ignore
-        }
+    }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
@@ -81,7 +81,7 @@ public class AssemblyConfiguration implements Serializable {
         } else if (exportBasedir != null) {
             return exportBasedir;
         } else {
-            return Boolean.TRUE;
+            return null;
         }
     }
 

--- a/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
@@ -4,6 +4,7 @@ package io.fabric8.maven.docker.config;
 import java.io.Serializable;
 
 import org.apache.maven.plugin.assembly.model.Assembly;
+import org.apache.maven.plugins.annotations.Parameter;
 
 public class AssemblyConfiguration implements Serializable {
 
@@ -12,7 +13,14 @@ public class AssemblyConfiguration implements Serializable {
     /**
      * @parameter
      */
+    @Deprecated
     private String basedir;
+
+    /**
+     * New replacement for base directory which better reflects its
+     * purpose
+     */
+    private String targetDir;
 
     /**
      * @parameter
@@ -35,10 +43,16 @@ public class AssemblyConfiguration implements Serializable {
      */
     private String dockerFileDir;
 
-    /**
-     * @parameter default-value="true"
-     */
+    @Deprecated
     private Boolean exportBasedir;
+
+    /**
+     * Whether the target directory should be
+     * exported.
+     *
+     */
+    @Parameter
+    private Boolean exportTargetDir;
 
     /**
      * @paramter default-value="false"
@@ -61,17 +75,21 @@ public class AssemblyConfiguration implements Serializable {
      */
     private String tarLongFileMode;
 
+    public Boolean exportTargetDir() {
+        return
+            exportBasedir != null ? exportBasedir :
+                (exportTargetDir != null ? exportTargetDir : Boolean.TRUE);
+    }
+
     /**
      * @parameter default-value="keep"
      */
     private PermissionMode permissions;
 
-    public Boolean exportBasedir() {
-        return exportBasedir;
-    }
-
-    public String getBasedir() {
-        return basedir != null ? basedir : DEFAULT_BASE_DIR;
+    public String getTargetDir() {
+        return
+            basedir != null ? basedir :
+                (targetDir != null ? targetDir : DEFAULT_BASE_DIR);
     }
 
     public Assembly getInline() {

--- a/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
@@ -76,21 +76,29 @@ public class AssemblyConfiguration implements Serializable {
     private String tarLongFileMode;
 
     public Boolean exportTargetDir() {
-        return
-            exportBasedir != null ? exportBasedir :
-                (exportTargetDir != null ? exportTargetDir : Boolean.TRUE);
+        if (exportTargetDir != null) {
+            return exportTargetDir;
+        } else if (exportBasedir != null) {
+            return exportBasedir;
+        } else {
+            return Boolean.TRUE;
+        }
+    }
+
+    public String getTargetDir() {
+        if (targetDir != null) {
+            return targetDir;
+        } else if (basedir != null) {
+            return basedir;
+        } else {
+            return DEFAULT_BASE_DIR;
+        }
     }
 
     /**
      * @parameter default-value="keep"
      */
     private PermissionMode permissions;
-
-    public String getTargetDir() {
-        return
-            basedir != null ? basedir :
-                (targetDir != null ? targetDir : DEFAULT_BASE_DIR);
-    }
 
     public Assembly getInline() {
         return inline;

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -144,6 +144,11 @@ public class BuildImageConfiguration implements Serializable {
      */
     private BuildTarArchiveCompression compression = BuildTarArchiveCompression.none;
 
+    /**
+     * @parameter
+     */
+    private Map<String,String> buildOptions;
+
     // Path to Dockerfile to use, initialized lazily ....
     File dockerFileFile;
     private boolean dockerFileMode;
@@ -233,6 +238,10 @@ public class BuildImageConfiguration implements Serializable {
 
     public BuildTarArchiveCompression getCompression() {
         return compression;
+    }
+
+    public Map<String, String> getBuildOptions() {
+        return buildOptions;
     }
 
     public Arguments getEntryPoint() {
@@ -409,6 +418,11 @@ public class BuildImageConfiguration implements Serializable {
             if (skip != null) {
                 config.skip = Boolean.valueOf(skip);
             }
+            return this;
+        }
+
+        public Builder buildOptions(Map<String,String> buildOptions) {
+            config.buildOptions = buildOptions;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfiguration.java
@@ -4,19 +4,24 @@ import java.util.*;
 
 public class DockerComposeConfiguration {
 
-    private String basedir;
-    private String composeFile;
-
+    private final String basedir;
+    private final String composeFile;
+    private final boolean ignoreBuild;
     public DockerComposeConfiguration(Map<String, String> config) {
         basedir = config.containsKey("basedir") ? config.get("basedir") : "src/main/docker";
         composeFile = config.containsKey("composeFile") ? config.get("composeFile") : "docker-compose.yml";
+        ignoreBuild = config.containsKey("ignoreBuild") ? Boolean.parseBoolean(config.get("ignoreBuilder")) : false;
     }
 
-    public String getBasedir() {
+    String getBasedir() {
         return basedir;
     }
 
-    public String getComposeFile() {
+    String getComposeFile() {
         return composeFile;
+    }
+
+    public boolean isIgnoreBuild() {
+        return ignoreBuild;
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -36,6 +36,7 @@ public enum ConfigKey {
     ASSEMBLY_MODE("assembly.mode"),
     ASSEMBLY_TARLONGFILEMODE("assembly.tarLongFileMode"),
     BIND,
+    BUILD_OPTIONS,
     CAP_ADD,
     CAP_DROP,
     CLEANUP,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -85,6 +85,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .maintainer(withPrefix(prefix, MAINTAINER, properties))
                 .workdir(withPrefix(prefix, WORKDIR, properties))
                 .skip(withPrefix(prefix, SKIP_BUILD, properties))
+                .buildOptions(mapWithPrefix(prefix, BUILD_OPTIONS, properties))
                 .dockerFile(withPrefix(prefix, DOCKER_FILE, properties))
                 .dockerFileDir(withPrefix(prefix, DOCKER_FILE_DIR, properties))
                 .user(withPrefix(prefix, USER, properties))

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -142,7 +142,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
 
     private AssemblyConfiguration extractAssembly(String prefix, Properties properties) {
         return new AssemblyConfiguration.Builder()
-                .basedir(withPrefix(prefix, ASSEMBLY_BASEDIR, properties))
+                .targetDir(withPrefix(prefix, ASSEMBLY_BASEDIR, properties))
                 .descriptor(withPrefix(prefix, ASSEMBLY_DESCRIPTOR, properties))
                 .descriptorRef(withPrefix(prefix, ASSEMBLY_DESCRIPTOR_REF, properties))
                 .dockerFileDir(withPrefix(prefix, ASSEMBLY_DOCKER_FILE_DIR, properties))

--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -66,7 +66,7 @@ public class BuildService {
                              dockerArchive,
                              getDockerfileName(buildConfig),
                              cleanupMode.isRemove(),
-                             noCache, mergedBuildMap);
+                             noCache, mergedBuildMap, buildConfig.getBuildOptions());
         log.info("%s: Built image %s",imageConfig.getDescription(), newImageId);
 
         if (oldImageId != null && !oldImageId.equals(newImageId)) {
@@ -103,9 +103,10 @@ public class BuildService {
 
     // ===============================================================
 
-    private String doBuildImage(String imageName, File dockerArchive, String dockerfileName, boolean cleanUp, boolean noCache, Map<String, String> buildArgs)
+    private String doBuildImage(String imageName, File dockerArchive, String dockerfileName, boolean cleanUp, boolean noCache, Map<String, String> buildArgs,
+                                Map<String,String> buildOptions)
         throws DockerAccessException, MojoExecutionException {
-        docker.buildImage(imageName, dockerArchive, dockerfileName, cleanUp, noCache, buildArgs);
+        docker.buildImage(imageName, dockerArchive, dockerfileName, cleanUp, noCache, buildArgs, buildOptions);
         return queryService.getImageId(imageName);
     }
 

--- a/src/main/java/io/fabric8/maven/docker/util/AnsiLogger.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AnsiLogger.java
@@ -67,7 +67,7 @@ public class AnsiLogger implements Logger {
     /** {@inheritDoc} */
     public void debug(String message, Object ... params) {
         if (isDebugEnabled()) {
-            log.debug(prefix + String.format(message, params));
+            log.debug(prefix + format(message, params));
         }
     }
 
@@ -79,7 +79,7 @@ public class AnsiLogger implements Logger {
     /** {@inheritDoc} */
     public void verbose(String message, Object ... params) {
         if (verbose) {
-            log.info(ansi().fgBright(BLACK).a(prefix).a(String.format(message,params)).reset().toString());
+            log.info(ansi().fgBright(BLACK).a(prefix).a(format(message, params)).reset().toString());
         }
     }
 
@@ -221,7 +221,20 @@ public class AnsiLogger implements Logger {
     private String colored(String message, Ansi.Color color, boolean addPrefix, Object ... params) {
         Ansi ansi = ansi().fg(color);
         String msgToPrint = addPrefix ? prefix + message : message;
-        return ansi.a(String.format(evaluateEmphasis(msgToPrint, color), params)).reset().toString();
+        return ansi.a(format(evaluateEmphasis(msgToPrint, color), params)).reset().toString();
+    }
+
+    // Use parameters when given, otherwise we use the string directly
+    private String format(String message, Object[] params) {
+        if (params.length == 0) {
+            return message;
+        } else if (params.length == 1 && params[0] instanceof Throwable) {
+            // We print only the message here since breaking exception will bubble up
+            // anyway
+            return message + ": " + params[0].toString();
+        } else {
+            return String.format(message, params);
+        }
     }
 
     // Emphasize parts encloses in "[[*]]" tags

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -76,10 +76,8 @@
     <!-- Components typically detected by annotations, but moved here because of
          https://github.com/codehaus-plexus/plexus-containers/issues/4 -->
     <component>
-      <role>io.fabric8.maven.docker.config.handler.ExternalConfigHandler</role>
-      <role-hint>default</role-hint>
+      <role>io.fabric8.maven.docker.config.handler.compose.DockerComposeConfigHandler</role>
       <implementation>io.fabric8.maven.docker.config.handler.compose.DockerComposeConfigHandler</implementation>
-      <description></description>
       <requirements>
         <requirement>
           <role>org.apache.maven.shared.filtering.MavenReaderFilter</role>
@@ -89,10 +87,8 @@
       <isolated-realm>false</isolated-realm>
     </component>
     <component>
-      <role>io.fabric8.maven.docker.config.handler.ExternalConfigHandler</role>
-      <role-hint>default</role-hint>
+      <role>io.fabric8.maven.docker.config.handler.property.PropertyConfigHandler</role>
       <implementation>io.fabric8.maven.docker.config.handler.property.PropertyConfigHandler</implementation>
-      <description></description>
       <isolated-realm>false</isolated-realm>
     </component>
   </components>

--- a/src/test/java/integration/DockerAccessIT.java
+++ b/src/test/java/integration/DockerAccessIT.java
@@ -60,7 +60,7 @@ public class DockerAccessIT {
     @Ignore
     public void testBuildImage() throws DockerAccessException {
         File file = new File("src/test/resources/integration/busybox-test.tar");
-        dockerClient.buildImage(IMAGE_TAG, file, null, false, false, Collections.<String, String>emptyMap());
+        dockerClient.buildImage(IMAGE_TAG, file, null, false, false, Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap());
         assertTrue(hasImage(IMAGE_TAG));
 
         testRemoveImage(IMAGE_TAG);

--- a/src/test/java/integration/DockerAccessWinIT.java
+++ b/src/test/java/integration/DockerAccessWinIT.java
@@ -66,7 +66,7 @@ public class DockerAccessWinIT {
     @Ignore
     public void testBuildImage() throws DockerAccessException {
         File file = new File("src/test/resources/integration/busybox-test.tar");
-        dockerClient.buildImage(IMAGE_TAG, file, null, false, false, Collections.<String, String>emptyMap());
+        dockerClient.buildImage(IMAGE_TAG, file, null, false, false, Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap());
         assertTrue(hasImage(IMAGE_TAG));
 
         testRemoveImage(IMAGE_TAG);

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
@@ -136,8 +136,8 @@ public class DockerFileBuilderTest {
     public void testExportBaseDir() {
         assertTrue(new DockerFileBuilder().basedir("/export").content().contains("/export"));
         assertFalse(new DockerFileBuilder().baseImage("java").basedir("/export").content().contains("/export"));
-        assertTrue(new DockerFileBuilder().baseImage("java").exportBasedir(true).basedir("/export").content().contains("/export"));
-        assertFalse(new DockerFileBuilder().baseImage("java").exportBasedir(false).basedir("/export").content().contains("/export"));
+        assertTrue(new DockerFileBuilder().baseImage("java").exportTargetDir(true).basedir("/export").content().contains("/export"));
+        assertFalse(new DockerFileBuilder().baseImage("java").exportTargetDir(false).basedir("/export").content().contains("/export"));
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/config/ImageConfigResolverTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/ImageConfigResolverTest.java
@@ -24,6 +24,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationExce
 import org.codehaus.plexus.util.ReflectionUtils;
 import io.fabric8.maven.docker.config.handler.ImageConfigResolver;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -39,7 +40,7 @@ public class ImageConfigResolverTest {
     @Before
     public void setUp() throws Exception {
         resolver = new ImageConfigResolver();
-        ReflectionUtils.setVariableValueInObject(resolver, "handlers", Collections.singletonList(new TestHandler(3)));
+        ReflectionUtils.setVariableValueInObject(resolver, "propertyConfigHandler", new TestHandler(3));
         resolver.initialize();
     }
 

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -262,6 +262,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         validateEnv(buildConfig.getEnv());
         validateLabels(buildConfig.getLabels());
         validateArgs(buildConfig.getArgs());
+        validateBuildOptions(buildConfig.getBuildOptions());
         /*
          * validate only the descriptor is required and defaults are all used, 'testAssembly' validates
          * all options can be set
@@ -281,6 +282,10 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
     private void validateLabels(Map<String, String> labels) {
         assertEquals("Hello\"World",labels.get("com.acme.label"));
+    }
+
+    private void validateBuildOptions(Map<String,String> buildOptions) {
+        assertEquals("2147483648", buildOptions.get("shmsize"));
     }
 
     protected void validateRunConfiguration(RunImageConfiguration runConfig) {
@@ -383,6 +388,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
             k(ConfigKey.ENV) + ".HOME", "/Users/roland",
             k(ConfigKey.ARGS) + ".PROXY", "http://proxy",
             k(ConfigKey.LABELS) + ".com.acme.label", "Hello\"World",
+            k(ConfigKey.BUILD_OPTIONS) + ".shmsize", "2147483648",
             k(ConfigKey.ENV_PROPERTY_FILE), "/tmp/envProps.txt",
             k(ConfigKey.EXTRA_HOSTS) + ".1", "localhost:127.0.0.1",
             k(ConfigKey.FROM), "image",

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -132,7 +132,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         AssemblyConfiguration config = configs.get(0).getBuildConfiguration().getAssemblyConfiguration();
         assertEquals("user", config.getUser());
         assertEquals("project", config.getDescriptorRef());
-        assertFalse(config.exportBasedir());
+        assertFalse(config.exportTargetDir());
         assertTrue(config.isIgnorePermissions());
     }
 
@@ -268,10 +268,10 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
          */
         AssemblyConfiguration assemblyConfig = buildConfig.getAssemblyConfiguration();
 
-        assertEquals("/maven", assemblyConfig.getBasedir());
+        assertEquals("/maven", assemblyConfig.getTargetDir());
         assertEquals("assembly.xml", assemblyConfig.getDescriptor());
         assertNull(assemblyConfig.getUser());
-        assertNull(assemblyConfig.exportBasedir());
+        assertNull(assemblyConfig.exportTargetDir());
         assertFalse(assemblyConfig.isIgnorePermissions());
     }
 

--- a/src/test/java/io/fabric8/maven/docker/service/BuildServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildServiceTest.java
@@ -117,7 +117,7 @@ public class BuildServiceTest {
             docker.buildImage(withEqual(imageConfig.getName()),
                               withEqual(new File("docker-build.tar")),
                               (String) withNull(),
-                              anyBoolean, anyBoolean, (Map) any);
+                              anyBoolean, anyBoolean, (Map) any, (Map) any);
         }};
     }
 
@@ -135,7 +135,7 @@ public class BuildServiceTest {
 
     private void whenBuildImage(boolean cleanup, boolean nocache) throws DockerAccessException, MojoExecutionException {
         new Expectations() {{
-            docker.buildImage(withEqual(imageConfig.getName()), (File) any, (String) withNull(), anyBoolean, anyBoolean, (Map) any);
+            docker.buildImage(withEqual(imageConfig.getName()), (File) any, (String) withNull(), anyBoolean, anyBoolean, (Map) any, (Map) any);
         }};
         if (cleanup) {
             new Expectations() {{

--- a/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
@@ -2,16 +2,14 @@ package io.fabric8.maven.docker.util;
 
 import java.util.*;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import org.junit.runner.RunWith;
 
-import static junitparams.JUnitParamsRunner.$;
 import static org.junit.Assert.*;
 
 /**
@@ -117,7 +115,7 @@ public class EnvUtilTest {
 
     private Object parametersForVersionChecks() {
         return $(
-            $( null, null, null, false),
+            $(null, null, null, false),
             $("1.10", null, "1.10", true),
             $(null, "1.10", "1.10", false),
             $("1.22", "1.10", "1.22", true),
@@ -126,7 +124,7 @@ public class EnvUtilTest {
             $("1.23.1", "1.23", "1.23.1", true),
             $("1.25", "1.25.1", "1.25.1", false),
             $("1.23.1", "2.0", "2.0", false)
-         );
+                );
     }
 
 
@@ -153,7 +151,5 @@ public class EnvUtilTest {
         return ret;
     }
 
-
-
-
+    private Object $(Object ... o) { return o; }
 }

--- a/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
@@ -2,17 +2,23 @@ package io.fabric8.maven.docker.util;
 
 import java.util.*;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import org.junit.runner.RunWith;
 
+import static junitparams.JUnitParamsRunner.$;
 import static org.junit.Assert.*;
 
 /**
  * @author roland
  * @since 14.10.14
  */
+@RunWith(JUnitParamsRunner.class)
 public class EnvUtilTest {
 
 
@@ -42,20 +48,22 @@ public class EnvUtilTest {
     }
 
     @Test
-    public void splitOnSpace() {
-        Object[] data = new Object[] {
-                "bla blub", new String[] { "bla", "blub"},
-                "bla\\ blub", new String[] {"bla blub"},
-                "bla blub\\ blubber", new String[] { "bla", "blub blubber"}
-        };
-        for (int i = 0; i < data.length; i += 2) {
-            String[] result = EnvUtil.splitOnSpaceWithEscape((String) data[i]);
-            String[] expected = (String[]) data[i+1];
-            assertEquals(expected.length, result.length);
-            for (int j = 0; j < expected.length; j++) {
-                assertEquals(expected[j],result[j]);
-            }
+    @TestCaseName("{method}: input \"{0}\" splits to {1}")
+    @Parameters
+    public void splitOnSpace(String input, String[] expected) {
+        String[] result = EnvUtil.splitOnSpaceWithEscape(input);
+        assertEquals(expected.length, result.length);
+        for (int j = 0; j < expected.length; j++) {
+            assertEquals(expected[j],result[j]);
         }
+    }
+
+    private Object parametersForSplitOnSpace() {
+        return $(
+            $("bla blub", new String[] { "bla", "blub"}),
+            $("bla\\ blub", new String[] {"bla blub"}),
+            $("bla blub\\ blubber", new String[] { "bla", "blub blubber"})
+                );
     }
 
     @Test
@@ -83,38 +91,44 @@ public class EnvUtilTest {
     }
 
     @Test
-    public void mavenPropertyExtract() {
-        String[] data = {
-                "${var1}", "var1",
-                "${  var2}", "var2",
-                " ${ var3}  ", "var3",
-                "nonvar", null,
-                "${nonvar", null
-        };
-        for (int i = 0; i < data.length; i +=2) {
-            assertEquals(data[i+1],EnvUtil.extractMavenPropertyName(data[i]));
-        }
+    @TestCaseName("{method}: expression {0} => variable {1}")
+    @Parameters
+    public void mavenPropertyExtract(String expression, String varName) {
+        assertEquals(varName,EnvUtil.extractMavenPropertyName(expression));
+    }
 
+    private Object parametersForMavenPropertyExtract() {
+        return $(
+            $("${var1}", "var1"),
+            $("${  var2}", "var2"),
+            $(" ${ var3}  ", "var3"),
+            $("nonvar", null),
+            $("${nonvar", null)
+                );
     }
 
     @Test
-    public void versionChecks() {
-        Object[] data = {
-            null, null, null, false,
-            "1.10", null, "1.10", true,
-            null, "1.10", "1.10", false,
-            "1.22", "1.10", "1.22", true,
-            "1.10", "1.25", "1.25", false,
-            "1.23", "1.23", "1.23", true,
-            "1.23.1", "1.23", "1.23.1", true,
-            "1.25", "1.25.1", "1.25.1", false,
-            "1.23.1", "2.0", "2.0", false
-        };
-        for (int i = 0; i < data.length; i+=4) {
-            assertEquals(data[i+2],EnvUtil.extractLargerVersion((String) data[i],(String) data[i+1]));
-            assertEquals(data[i+3],EnvUtil.greaterOrEqualsVersion((String) data[i],(String) data[i+1]));
-        }
+    @TestCaseName("{method}: max({0},{1}) = {2}, {0} >= {1} ? {3}")
+    @Parameters
+    public void versionChecks(String versionA, String versionB, String largerVersion, boolean isGreaterOrEquals) {
+        assertEquals(largerVersion,EnvUtil.extractLargerVersion(versionA,versionB));
+        assertEquals(isGreaterOrEquals, EnvUtil.greaterOrEqualsVersion(versionA,versionB));
     }
+
+    private Object parametersForVersionChecks() {
+        return $(
+            $( null, null, null, false),
+            $("1.10", null, "1.10", true),
+            $(null, "1.10", "1.10", false),
+            $("1.22", "1.10", "1.22", true),
+            $("1.10", "1.25", "1.25", false),
+            $("1.23", "1.23", "1.23", true),
+            $("1.23.1", "1.23", "1.23.1", true),
+            $("1.25", "1.25.1", "1.25.1", false),
+            $("1.23.1", "2.0", "2.0", false)
+         );
+    }
+
 
     @Test
     public void fixupPath() throws Exception {


### PR DESCRIPTION
The changes within this PullRequest allow adding arbitrary "simple" queryArguments to the Docker daemon build REST interface (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/build-image-from-a-dockerfile).

Currently no changes have been performed to docs/tests other than fixing compile errors. If the changes within this PullRequest are acceptable I will extend and squash it.