### PR TITLE
Handle properly when dockerFile and dockerFileDir also set

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -457,7 +457,14 @@ public class BuildImageConfiguration implements Serializable {
 
     // Initialize the dockerfile location and the build mode
     private void initDockerFileFile(Logger log) {
-        if (dockerFile != null) {
+        if (dockerFile != null && dockerFileDir != null) {
+            dockerFileFile = new File(dockerFile);
+            if (dockerFileFile.isAbsolute()) {
+                throw new IllegalArgumentException("<dockerFile> can not be absolute path if <dockerFileDir> also set.");
+            }
+            dockerFileFile = new File(dockerFileDir, dockerFile);
+            dockerFileMode = true;
+        } else if (dockerFile != null) {
             dockerFileFile = new File(dockerFile);
             dockerFileMode = true;
         } else if (dockerFileDir != null) {

--- a/src/test/java/io/fabric8/maven/docker/config/BuildImageConfigurationTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/BuildImageConfigurationTest.java
@@ -65,6 +65,26 @@ public class BuildImageConfigurationTest {
     }
 
     @Test
+    public void DockerfileDirAndDockerfileAlsoSet() {
+        BuildImageConfiguration config =
+            new BuildImageConfiguration.Builder().
+                dockerFileDir("/tmp/").
+                dockerFile("Dockerfile").build();
+        config.initAndValidate(logger);
+        assertTrue(config.isDockerFileMode());
+        assertEquals(config.getDockerFile(),new File("/tmp/Dockerfile"));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void DockerfileDirAndDockerfileAlsoSetButDockerfileIsAbsoluteExceptionThrown() {
+        BuildImageConfiguration config =
+            new BuildImageConfiguration.Builder().
+                dockerFileDir("/tmp/").
+                dockerFile("/Dockerfile").build();
+        config.initAndValidate(logger);
+    }
+
+    @Test
     public void deprecatedDockerfileDir() {
         AssemblyConfiguration assemblyConfig = new AssemblyConfiguration.Builder().dockerFileDir("src/docker").build();
         BuildImageConfiguration config =


### PR DESCRIPTION
When both parameter set the dockerFileDir was ignored because of the logic how to find the given dockerfile.
After the pull request when both parameter set docker-maven-plugin determine properly the location of the Dockerfile.