### PR TITLE
update samples aggregator pom; use build-nofork in lifecycles

### DIFF
--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -27,7 +27,7 @@
   <url>http://www.jolokia.org</url>
 
   <properties>
-    <docker.maven.plugin.version>0.17-SNAPSHOT</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.18-SNAPSHOT</docker.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -19,7 +19,7 @@
               <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
               <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
               <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
-              <package>org.apache.maven.plugins:maven-jar-plugin:jar,${project.groupId}:${project.artifactId}:build</package>
+              <package>org.apache.maven.plugins:maven-jar-plugin:jar,${project.groupId}:${project.artifactId}:build-nofork</package>
               <pre-integration-test>${project.groupId}:${project.artifactId}:start</pre-integration-test>
               <integration-test>org.apache.maven.plugins:maven-failsafe-plugin:integration-test</integration-test>
               <verify>${project.groupId}:${project.artifactId}:stop,org.apache.maven.plugins:maven-failsafe-plugin:verify</verify>
@@ -44,7 +44,7 @@
               <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
               <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
               <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
-              <package>org.apache.maven.plugins:maven-jar-plugin:jar,${project.groupId}:${project.artifactId}:build</package>
+              <package>org.apache.maven.plugins:maven-jar-plugin:jar,${project.groupId}:${project.artifactId}:build-nofork</package>
               <deploy>${project.groupId}:${project.artifactId}:push</deploy>
             </phases>
           </lifecycle>


### PR DESCRIPTION
The samples don't compile with current snapshot.
These two changes allow successful build/test