### PR TITLE
Clarify log message when waiting for URL

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/WaitConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/WaitConfiguration.java
@@ -11,6 +11,15 @@ import org.apache.maven.plugins.annotations.Parameter;
  */
 public class WaitConfiguration implements Serializable {
 
+    // Default HTTP Method to use
+    public static final String DEFAULT_HTTP_METHOD = "HEAD";
+
+    // Default status codes
+    public static final int DEFAULT_MIN_STATUS = 200;
+    public static final int DEFAULT_MAX_STATUS = 399;
+
+    public static final String DEFAULT_STATUS_RANGE = String.format("%d..%d", DEFAULT_MIN_STATUS, DEFAULT_MAX_STATUS);
+
     @Parameter
     private int time;
 
@@ -197,10 +206,10 @@ public class WaitConfiguration implements Serializable {
         private String url;
 
         @Parameter
-        private String method;
+        private String method = DEFAULT_HTTP_METHOD;
 
         @Parameter
-        private String status;
+        private String status = DEFAULT_STATUS_RANGE;
 
         @Parameter
         private boolean allowAllHosts;

--- a/src/main/java/io/fabric8/maven/docker/util/WaitUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/WaitUtil.java
@@ -25,6 +25,8 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
 
+import io.fabric8.maven.docker.config.WaitConfiguration;
+
 
 /**
  * @author roland
@@ -41,13 +43,6 @@ public class WaitUtil {
     // Timeout for pings
     private static final int HTTP_PING_TIMEOUT = 500;
     private static final int TCP_PING_TIMEOUT = 500;
-
-    // Default HTTP Method to use
-    public static final String DEFAULT_HTTP_METHOD = "HEAD";
-
-    // Default status codes
-    public static final int DEFAULT_MIN_STATUS = 200;
-    public static final int DEFAULT_MAX_STATUS = 399;
 
     // Disable HTTP client retries by default.
     public static final int HTTP_CLIENT_RETRIES = 0;
@@ -145,26 +140,17 @@ public class WaitUtil {
             this.url = url;
             this.method = method;
 
-            if (method == null) {
-                this.method = DEFAULT_HTTP_METHOD;
-            }
-
-            if (status == null) {
-                statusMin = DEFAULT_MIN_STATUS;
-                statusMax = DEFAULT_MAX_STATUS;
+            Matcher matcher = Pattern.compile("^(\\d+)\\s*\\.\\.+\\s*(\\d+)$").matcher(status);
+            if (matcher.matches()) {
+                statusMin = Integer.parseInt(matcher.group(1));
+                statusMax = Integer.parseInt(matcher.group(2));
             } else {
-                Matcher matcher = Pattern.compile("^(\\d+)\\s*\\.\\.+\\s*(\\d+)$").matcher(status);
-                if (matcher.matches()) {
-                    statusMin = Integer.parseInt(matcher.group(1));
-                    statusMax = Integer.parseInt(matcher.group(2));
-                } else {
-                    statusMin = statusMax = Integer.parseInt(status);
-                }
+                statusMin = statusMax = Integer.parseInt(status);
             }
         }
 
         public HttpPingChecker(String waitUrl) {
-            this(waitUrl, null, null);
+            this(waitUrl, WaitConfiguration.DEFAULT_HTTP_METHOD, WaitConfiguration.DEFAULT_STATUS_RANGE);
         }
 
         public HttpPingChecker(String url, String method, String status, boolean allowAllHosts) {

--- a/src/test/java/io/fabric8/maven/docker/util/WaitUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/WaitUtilTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeoutException;
 import com.sun.net.httpserver.*;
 import org.junit.*;
 
+import io.fabric8.maven.docker.config.WaitConfiguration;
 import io.fabric8.maven.docker.util.WaitUtil.WaitTimeoutException;
 
 import static org.junit.Assert.*;
@@ -43,21 +44,21 @@ public class WaitUtilTest {
     @Test
     public void httpSuccessWithStatus() throws TimeoutException {
         for (String status : new String[] { "200", "200 ... 300", "200..250" }) {
-            long waited = WaitUtil.wait(700, new WaitUtil.HttpPingChecker(httpPingUrl, null, status));
+            long waited = WaitUtil.wait(700, new WaitUtil.HttpPingChecker(httpPingUrl, WaitConfiguration.DEFAULT_HTTP_METHOD, status));
             assertTrue("Waited less than  700ms: " + waited, waited < 700);
         }
     }
 
     @Test(expected = TimeoutException.class)
     public void httpFailWithStatus() throws TimeoutException {
-        WaitUtil.wait(700, new WaitUtil.HttpPingChecker(httpPingUrl, null, "500"));
+        WaitUtil.wait(700, new WaitUtil.HttpPingChecker(httpPingUrl, WaitConfiguration.DEFAULT_HTTP_METHOD, "500"));
     }
 
     @Test
     public void httpSuccessWithGetMethod() throws Exception {
         serverMethodToAssert = "GET";
         try {
-            WaitUtil.HttpPingChecker checker = new WaitUtil.HttpPingChecker(httpPingUrl, "GET", null);
+            WaitUtil.HttpPingChecker checker = new WaitUtil.HttpPingChecker(httpPingUrl, "GET", WaitConfiguration.DEFAULT_STATUS_RANGE);
             long waited = WaitUtil.wait(700, checker);
             assertTrue("Waited less than 500ms: " + waited, waited < 700);
         } finally {


### PR DESCRIPTION
The log message when waiting on a URL with default settings is a bit confusing:

```
Waiting on url http://localhost:33068/foo/ with method null for status null
```

WIth this change, the message now includes the default HTTP method and the default
status code range:

```
Waiting on url http://localhost:33068/foo/ with method HEAD for status 200..399
```
