### PR TITLE
Create at most one PrintStream per log file.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  range: "45...90"
+  precision: 2
+  round: down
+  notify:
+    slack:
+      default:
+        url: "https://hooks.slack.com/services/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"
+        threshold: "2%"
+  status:
+    project:
+      default:
+        threshold: "2%"
+comment:
+  layout: "header, diff, tree, sunburst"
+  require_changes: true
+   

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ It works with Maven 3.0.5 and Docker 1.6.0 or later.
 | [`docker:push`](https://fabric8io.github.io/docker-maven-plugin/#docker:push)     | Push images to a registry             |
 | [`docker:remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:remove) | Remove images from local docker host  |
 | [`docker:logs`](https://fabric8io.github.io/docker-maven-plugin/#docker:logs)     | Show container logs                   |
-| [`docker:source`](https://fabric8io.github.io/docker-maven-plugin/#docker:source)   | Attach docker build archive to Maven project |
+| [`docker:source`](https://fabric8io.github.io/docker-maven-plugin/#docker:source) | Attach docker build archive to Maven project |
+| [`docker:volume-create`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-create) | Create a volume to share data between containers |
+| [`docker:volume-remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-remove) | Remove a created volume |
 
 #### Documentation
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,7 +2,7 @@
 
 * **0.18.2** 
   - Better log message when waiting for URL (#640)
-  - Extended authentication for AWS ECR
+  - Extended authentication for AWS ECR (#663)
   - Add two new goals: "volume-create" and "volume-remove" for volume handling independent of images. 
 
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
 * **0.18.2** 
   - Better log message when waiting for URL (#640)
   - Update to jnr-unixsocket 0.15
+  - Add two new goals: "volume-create" and "volume-remove" for volume handling independent of images. 
 
 * **0.18.1** (2016-11-17)
   - Renamed `basedir` and `exportBasedir` in an `<assembly>` configuration to `targetDir` and `exportTargetDir` since this better reflects the purpose, i.e. the target in the Docker image to which the assembly is copied. The old name is still recognized but deprecated. 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,8 +2,7 @@
 
 * **0.18.2** 
   - Better log message when waiting for URL (#640)
-  - Update to jnr-unixsocket 0.15
-  - Add two new goals: "volume-create" and "volume-remove" for volume handling independent of images. 
+- Add two new goals: "volume-create" and "volume-remove" for volume handling independent of images. 
 
 * **0.18.1** (2016-11-17)
   - Renamed `basedir` and `exportBasedir` in an `<assembly>` configuration to `targetDir` and `exportTargetDir` since this better reflects the purpose, i.e. the target in the Docker image to which the assembly is copied. The old name is still recognized but deprecated. 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,7 +2,9 @@
 
 * **0.18.2** 
   - Better log message when waiting for URL (#640)
-- Add two new goals: "volume-create" and "volume-remove" for volume handling independent of images. 
+  - Extended authentication for AWS ECR
+  - Add two new goals: "volume-create" and "volume-remove" for volume handling independent of images. 
+
 
 * **0.18.1** (2016-11-17)
   - Renamed `basedir` and `exportBasedir` in an `<assembly>` configuration to `targetDir` and `exportTargetDir` since this better reflects the purpose, i.e. the target in the Docker image to which the assembly is copied. The old name is still recognized but deprecated. 

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -15,15 +15,14 @@ completely managed internally.
 
 One purpose of this plugin is to create docker images holding the
 actual application. This is done with the `docker:build` goal.  It
-is easy to include build artifacts and their dependencies into an
-image. Therefore, this plugin uses the
+is easy to include build artifacts and their dependencies into an image. 
+Therefore, this plugin uses the
 [assembly descriptor format](http://maven.apache.org/plugins/maven-assembly-plugin/assembly.html)
 from the
 [maven-assembly-plugin](http://maven.apache.org/plugins/maven-assembly-plugin/)
-to specify the content which will be added from a sub-directory in
-the image (`/maven` by default). Images that are built with this
-plugin can be pushed to public or private Docker registries with
-`docker:push`.
+to specify the content which will be added from a sub-directory in the image 
+(`/maven` by default). Images that are built with this plugin can be pushed 
+to public or private Docker registries with `docker:push`.
 
 ### Running containers
 
@@ -37,8 +36,9 @@ together or share data via volumes. Containers are created and started
 with the `docker:start` goal and stopped and destroyed with the
 `docker:stop` goal. For integration tests both goals are typically
 bound to the the `pre-integration-test` and `post-integration-test` phase,
-respectively. It is recommended to use the [`maven-failsafe-plugin`](http://maven.apache.org/surefire/maven-failsafe-plugin/) for
-integration testing in order to stop the docker container even when
+respectively. It is recommended to use the 
+[`maven-failsafe-plugin`](http://maven.apache.org/surefire/maven-failsafe-plugin/) 
+for integration testing in order to stop the docker container even when
 the tests fail.
 
 For proper isolation, container exposed ports can be dynamically and
@@ -202,5 +202,5 @@ The high-level design goals and initial motiviation fort this plugin are:
   
 So, final words: Enjoy this plugin, and please use the
 [issue tracker](https://github.com/fabric8io/docker-maven-plugin/issues)
-for anything what hurts, or when you have a wish list. 
+for anything that hurts, or when you have a wish list. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.15</version>
+      <version>0.12</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
   <version>0.18-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
-
   <name>docker-maven-plugin</name>
   <description>Docker Maven Plugin</description>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -26,6 +26,7 @@
 
   <url>http://www.jolokia.org</url>
 
+  <!-- Should this reference the outer directory as a parent pom instead?  -->
   <properties>
     <docker.maven.plugin.version>0.18-SNAPSHOT</docker.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -47,6 +48,7 @@
   <modules>
     <module>net</module>
     <module>custom-net</module>
+    <module>volume</module>
     <module>properties</module>
     <module>dockerignore</module>
     <module>docker-compose-demo</module>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -27,7 +27,7 @@
   <url>http://www.jolokia.org</url>
 
   <properties>
-    <docker.maven.plugin.version>0.17-SNAPSHOT</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.18-SNAPSHOT</docker.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/samples/volume/pom.xml
+++ b/samples/volume/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!--
+  Sample project for demonstrating the volume creation feature
+
+  
+  Call it with 'mvn docker:create-volume'.
+  or
+  Call it with 'mvn docker:verify'
+  It will create the volume "newVolume"
+  -->
+
+  <parent>
+    <groupId>io.fabric8</groupId>
+    <artifactId>dmp-sample-parent</artifactId>
+    <version>0.18-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>volume</artifactId>
+  <version>0.18-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <verbose>true</verbose>
+          <autoPull>always</autoPull>
+          <startParallel>true</startParallel>
+          <volumes>
+            <volume>
+              <name>newVolume</name>
+            </volume>
+          </volumes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>start</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>volume-create</goal>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+              <goal>volume-remove</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/main/asciidoc/inc/_authentication.adoc
+++ b/src/main/asciidoc/inc/_authentication.adoc
@@ -5,14 +5,13 @@
 When pulling (via the `autoPull` mode of `{plugin}:start`) or pushing image, it
 might be necessary to authenticate against a Docker registry.
 
-There are three different ways for providing credentials:
+There are five different locations searched for credentials.  In order, these are:
 
-* Using a `<authConfig>` section in the plugin configuration with
-`<username>` and `<password>` elements.
-* Providing system properties `docker.username` and `docker.password`
-from the outside
+* Providing system properties `docker.username` and `docker.password` from the outside.
+* Using a `<authConfig>` section in the plugin configuration with `<username>` and `<password>` elements.
+* Using OpenShift configuration in `~/.config/kube`
 * Using a `<server>` configuration in `~/.m2/settings.xml`
-* Login into a registry with `docker login`
+* Login into a registry with `docker login` (credentials in `~/.docker/config.json`)
 
 Using the username and password directly in the `pom.xml` is not
 recommended since this is widely visible. This is most easiest and
@@ -62,7 +61,7 @@ The server id must specify the registry to push to/pull from, which by
 default is central index `docker.io` (or `index.docker.io` / `registry.hub.docker.com` as fallbacks).
 Here you should add your docker.io account for your repositories. If you have multiple accounts
 for the same registry, the second user can be specified as part of the ID. In the example above, if you
-have a second accorunt 'fabric8io' then use an `<id>docker.io/fabric8io</id>` for this second entry. I.e. add the
+have a second account 'fabric8io' then use an `<id>docker.io/fabric8io</id>` for this second entry. I.e. add the
 username with a slash to the id name. The default without username is only taken if no server entry with
 a username appended id is chosen.
 
@@ -106,7 +105,7 @@ as described in the previous section is used as fallback.
 == OpenShift Authentication
 
 When working with the default registry in OpenShift, the credentials
-to authtenticate are the OpenShift username and access token. So, a
+to authenticate are the OpenShift username and access token. So, a
 typical interaction with the OpenShift registry from the outside is:
 
 ----
@@ -135,7 +134,7 @@ mvn -Ddocker.registry=docker-registry.domain.com:80/default/myimage \
 Alternatively the configuration option `<useOpenShiftAuth>` can be
 added to the `<authConfig>` section.
 
-For dedicted _pull_ and _push_ configuration the system properties
+For dedicated _pull_ and _push_ configuration the system properties
 `docker.pull.useOpenShiftAuth` and `docker.push.useOpenShiftAuth` are
 available as well as the configuration option `<useOpenShiftAuth>` in
 an `<pull>` or `<push>` section within the `<authConfig>`
@@ -148,7 +147,7 @@ Regardless which mode you choose you can encrypt password as described
 in the
 http://maven.apache.org/guides/mini/guide-encryption.html[Maven documentation]. Assuming
 that you have setup a _master password_ in
-`~/.m2/security-settings.xml` you can create easily encrypted
+`~/.m2/security-settings.xml` you can create easily encrypt
 passwords:
 
 .Example
@@ -164,3 +163,10 @@ and/or the `<server>` setting configuration. However, putting an
 encrypted password into `authConfig` in the `pom.xml` doesn't make
 much sense, since this password is encrypted with an individual master
 password.
+
+[[extended-authentication]]
+== Extended Authentication
+
+Some docker registries require additional steps to authenticate.  link:https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_GetStarted.html[Amazon ECR] requires using an IAM access key to obtain temporary docker login credentials. The `docker:push` and `docker:pull` goals automatically execute this exchange for any registry of the form _awsAccountId_*.dkr.ecr.*_awsRegion_*.amazonaws.com*, unless the `skipExtendedAuth` configuration (`docker.skip.extendedAuth` property) is set true.
+
+You can use any IAM access key with the necessary permissions in any of the locations mentioned above except `~/.docker/config.json`. Use the IAM *Access key ID* as the username and the *Secret access key* as the password.

--- a/src/main/asciidoc/inc/_docker-volume-create.adoc
+++ b/src/main/asciidoc/inc/_docker-volume-create.adoc
@@ -1,0 +1,52 @@
+
+[[docker:volume-create]]
+== *docker:volume-create*
+
+This goals creates one or more standalone https://docs.docker.com/engine/tutorials/dockervolumes/[Docker volume], which can be referenced in a <<docker:start>> configuration for linking to a volume during runtime.
+Each volume has therefore a unique and referenceable name. Beside the volume driver and driver options can be specified.
+
+.Example for a volume configuration
+[source,xml]
+----
+<plugin>
+  <configuration>
+    <volumes>
+       <volume>
+         <name>temp-volume</name>
+         <driver>local</Driver>
+         <opts>
+           <type>tmpfs</type>
+           <device>tmpfs</device>
+           <o>size=100m,uid=1000</o>
+         </opts>
+         <labels>
+           <volatileData>true</volatileData>
+         </labels>
+       </volume>
+    </volumes>
+    ...
+  </configuration>
+</plugin>
+----
+
+[[volume-configuration]]
+=== Configuration
+
+The following options are available when creating volumes:
+
+.Volume configuration
+|===
+| Element | Description
+
+| *name*
+| Name of the volume
+
+| *driver*
+| Volume driver to use. By default the driver `local` is used which is created on the local file system. Please refer to your Docker installation which additional drivers are available.
+
+| *opts*
+| Driver specific options passed in as custom `<key>value</key>` where its maps to `key=value` pairs for driver options as they can be provided from the Docker CLI, too. Each volume driver supports different options. The options supported by the `local` driver are the well known http://man7.org/linux/man-pages/man8/mount.8.html[Linux mount options].
+
+|*labels*
+| Labels given as `<key>value</key>` similar to image labels described in <<misc-env, Environment and Labels>>. These labels are used to tag the volumes themselves.
+|===

--- a/src/main/asciidoc/inc/_docker-volume-remove.adoc
+++ b/src/main/asciidoc/inc/_docker-volume-remove.adoc
@@ -1,0 +1,38 @@
+[[docker:volume-remove]]
+== *docker:volume-remove*
+
+This goals is the counterpart to <<docker:volume-create>> and removes a volume.
+Docker volumes are configured outside of Docker images, but can be referenced by them.
+The configuration is the same as for <<docker:volume-create>>
+
+*Example:*
+
+[source,xml]
+----
+<plugin>
+  <configuration>
+    <volumes>
+       <volume>
+         <name>temp-volume</name>
+         ....
+       </volume>
+    </volumes>
+    ...
+  </configuration>
+</plugin>
+----
+
+[[volume-configuration]]
+=== Configuration
+
+The configuration is quite simple. Only the name of the volume to delete is required.
+
+.Volume configuration
+[options="header"]
+|===
+| Element | Description
+
+| *name*
+| Name of the volume
+
+|===

--- a/src/main/asciidoc/inc/_goals.adoc
+++ b/src/main/asciidoc/inc/_goals.adoc
@@ -31,6 +31,12 @@ in the next sections.
 
 |**<<{plugin}:source>>**
 |Attach docker build archive to Maven project
+
+|**<<{plugin}:volume-create>>**
+|Create a volume for containers to share data
+
+|**<<{plugin}:volume-remove>>**
+|Remove a volume
 |===
 
 Note that all goals are orthogonal to each other. For example in order

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -34,6 +34,8 @@ include::inc/_docker-watch.adoc[]
 include::inc/_docker-remove.adoc[]
 include::inc/_docker-logs.adoc[]
 include::inc/_docker-source.adoc[]
+include::inc/_docker-volume-create.adoc[]
+include::inc/_docker-volume-remove.adoc[]
 
 include::inc/_external-configuration.adoc[]
 

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -26,6 +26,7 @@ import org.codehaus.plexus.context.ContextException;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.DockerMachineConfiguration;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
 import io.fabric8.maven.docker.config.handler.ImageConfigResolver;
 import io.fabric8.maven.docker.log.LogDispatcher;
 import io.fabric8.maven.docker.log.LogOutputSpecFactory;
@@ -147,6 +148,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     // Authentication information
     @Parameter
     Map authConfig;
+
+    /**
+     * Volume configuration
+     */
+    @Parameter
+    private List<VolumeConfiguration> volumes;
 
     /**
      * Image configurations configured directly.
@@ -321,7 +328,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         return ret;
     }
 
-    /**
+   /**
      * Override this if your mojo doesnt require access to a Docker host (like creating and attaching
      * docker tar archives)
      *
@@ -342,13 +349,22 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     // =============================================================================================
 
     /**
-     * Get all images to use. Can be restricted via -Ddocker.image to pick a one or more images. The values
-     * is taken as comma separated list.
+     * Get all images to use. Can be restricted via -Ddocker.image to pick a one or more images.
+     * The values are taken as comma separated list.
      *
-     * @return list of image configuration to use
+     * @return list of image configuration to be use. Can be empty but never null.
      */
     protected List<ImageConfiguration> getResolvedImages() {
         return resolvedImages;
+    }
+
+    /**
+     * Get all volumes which are defined separately from the images
+     *
+     * @return defined volumes
+     */
+    protected List<VolumeConfiguration> getVolumes() {
+        return volumes;
     }
 
     // Registry for managed containers

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -141,6 +141,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     @Parameter(property = "docker.registry")
     protected String registry;
 
+    /**
+     * Skip extended authentication
+     */
+    @Parameter(property = "docker.skip.extendedAuth", defaultValue = "false")
+    protected boolean skipExtendedAuth;
+
     // maximum connection to use in parallel for connecting the docker host
     @Parameter(property = "docker.maxConnections", defaultValue = "100")
     private int maxConnections;
@@ -189,6 +195,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (!skip) {
             log = new AnsiLogger(getLog(), useColor, verbose, !settings.getInteractiveMode(), getLogPrefix());
+            authConfigFactory.setLog(log);
+
             LogOutputSpecFactory logSpecFactory = new LogOutputSpecFactory(useColor, logStdout, logDate);
 
             // The 'real' images configuration to use (configured images + externally resolved images)
@@ -406,7 +414,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         String user = isPush ? image.getUser() : null;
         String registry = image.getRegistry() != null ? image.getRegistry() : configuredRegistry;
 
-        return authConfigFactory.createAuthConfig(isPush, authConfig, settings, user, registry);
+        return authConfigFactory.createAuthConfig(isPush, skipExtendedAuth, authConfig, settings, user, registry);
     }
 
     protected LogDispatcher getLogDispatcher(ServiceHub hub) {

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -484,6 +484,11 @@ public class StartMojo extends AbstractDockerMojo {
                         public void error(String error) {
                             log.error("%s", error);
                         }
+                        
+                        @Override
+                        public void close() {
+                            // empty
+                        }
                     });
                     first = false;
                 }

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -484,10 +484,15 @@ public class StartMojo extends AbstractDockerMojo {
                         public void error(String error) {
                             log.error("%s", error);
                         }
-                        
+
                         @Override
                         public void close() {
-                            // empty
+                            // no-op
+                        }
+
+                        @Override
+                        public void open() {
+                            // no-op
                         }
                     });
                     first = false;

--- a/src/main/java/io/fabric8/maven/docker/VolumeCreateMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/VolumeCreateMojo.java
@@ -1,0 +1,31 @@
+package io.fabric8.maven.docker;
+
+
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
+import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.service.VolumeService;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ *  Mojo to create named volumes, useful for preparing integration tests
+ *
+ *  @author Tom Burton
+ *  @version Dec 15, 2016
+ */
+@Mojo(name = "volume-create", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+public class VolumeCreateMojo extends AbstractDockerMojo {
+
+   @Override
+   protected void executeInternal(ServiceHub serviceHub) throws DockerAccessException, MojoExecutionException {
+      VolumeService volService = serviceHub.getVolumeService();
+
+      for (VolumeConfiguration volume : getVolumes()) {
+         log.info("Creating volume '%s'", volume.getName());
+         volService.createVolume(volume);
+      }
+   }
+
+}

--- a/src/main/java/io/fabric8/maven/docker/VolumeRemoveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/VolumeRemoveMojo.java
@@ -1,0 +1,34 @@
+package io.fabric8.maven.docker;
+
+
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
+import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.service.VolumeService;
+
+import java.lang.String;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ *  Mojo to remove volumes created with {@link VolumeCreateMojo}
+ *
+ *  @author Tom Burton
+ */
+@Mojo(name = "volume-remove", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
+public class VolumeRemoveMojo extends AbstractDockerMojo {
+
+   @Override
+   protected void executeInternal(ServiceHub serviceHub)
+         throws DockerAccessException, MojoExecutionException  {
+      VolumeService volService = serviceHub.getVolumeService();
+
+      for ( VolumeConfiguration volume : getVolumes()) {
+         log.info("Removing volume %s", volume.getName());
+         volService.removeVolume(volume.getName());
+      }
+   }
+
+}

--- a/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
@@ -26,9 +26,9 @@ public class AuthConfig {
 
     public AuthConfig(Map<String,String> params) {
         this(params.get("username"),
-                params.get("password"),
-                params.get("email"),
-                params.get("auth"));
+             params.get("password"),
+             params.get("email"),
+             params.get("auth"));
     }
 
     public AuthConfig(String username, String password, String email, String auth) {
@@ -42,11 +42,11 @@ public class AuthConfig {
     /**
      * Constructor which takes an base64 encoded credentials in the form 'user:password'
      *
-     * @param credentialsDockerEncoded the docker encoded user and password
+     * @param credentialsEncoded the docker encoded user and password
      * @param email the email to use for authentication
      */
-    public AuthConfig(String credentialsDockerEncoded, String email) {
-        String credentials = new String(Base64.decodeBase64(credentialsDockerEncoded));
+    public AuthConfig(String credentialsEncoded, String email) {
+        String credentials = new String(Base64.decodeBase64(credentialsEncoded));
         String[] parsedCreds = credentials.split(":",2);
         username = parsedCreds[0];
         password = parsedCreds[1];

--- a/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
@@ -1,7 +1,6 @@
 package io.fabric8.maven.docker.access;
 
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.codec.binary.Base64;
@@ -18,20 +17,26 @@ public class AuthConfig {
 
     public final static AuthConfig EMPTY_AUTH_CONFIG = new AuthConfig("", "", "", "");
 
-    private String authEncoded;
+    private final String username;
+    private final String password;
+    private final String email;
+    private final String auth;
+
+    private final String authEncoded;
 
     public AuthConfig(Map<String,String> params) {
-        this.authEncoded = createAuthEncoded(params);
+        this(params.get("username"),
+                params.get("password"),
+                params.get("email"),
+                params.get("auth"));
     }
 
-    public AuthConfig(String user, String password, String email, String auth) {
-        Map<String,String>  params = new HashMap<>();
-        putNonNull(params, "username", user);
-        putNonNull(params, "password", password);
-        putNonNull(params, "email", email);
-        putNonNull(params, "auth", auth);
-
-        this.authEncoded = createAuthEncoded(params);
+    public AuthConfig(String username, String password, String email, String auth) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.auth = auth;
+        authEncoded = createAuthEncoded();
     }
 
     /**
@@ -43,11 +48,19 @@ public class AuthConfig {
     public AuthConfig(String credentialsDockerEncoded, String email) {
         String credentials = new String(Base64.decodeBase64(credentialsDockerEncoded));
         String[] parsedCreds = credentials.split(":",2);
-        Map<String,String> params = new HashMap<>();
-        putNonNull(params,"username",parsedCreds[0]);
-        putNonNull(params,"password",parsedCreds[1]);
-        putNonNull(params,"email",email);
-        this.authEncoded = createAuthEncoded(params);
+        username = parsedCreds[0];
+        password = parsedCreds[1];
+        this.email = email;
+        auth = null;
+        authEncoded = createAuthEncoded();
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     public String toHeaderValue() {
@@ -56,12 +69,12 @@ public class AuthConfig {
 
     // ======================================================================================================
 
-    private String createAuthEncoded(Map<String,String> params) {
+    private String createAuthEncoded() {
         JSONObject ret = new JSONObject();
-        add(params, ret, "username");
-        add(params, ret, "password");
-        add(params, ret, "email");
-        add(params, ret, "auth");
+        putNonNull(ret, "username", username);
+        putNonNull(ret, "password", password);
+        putNonNull(ret, "email", email);
+        putNonNull(ret, "auth", auth);
         try {
             return Base64.encodeBase64String(ret.toString().getBytes("UTF-8"));
         } catch (UnsupportedEncodingException e) {
@@ -69,13 +82,7 @@ public class AuthConfig {
         }
     }
 
-    private void add(Map<String,String> params, JSONObject ret, String key) {
-        if (params.containsKey(key)) {
-            ret.put(key,params.get(key));
-        }
-    }
-
-    private void putNonNull(Map ret, String key, String value) {
+    private void putNonNull(JSONObject ret, String key, String value) {
         if (value != null) {
             ret.put(key,value);
         }

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -1,7 +1,6 @@
 package io.fabric8.maven.docker.access;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -246,4 +245,20 @@ public interface DockerAccess {
      * cleaning up things.
      */
     void shutdown();
+
+   /**
+    *  Create a volume
+    *
+    *  @param configuration volume configuration
+    *  @return the name of the Volume
+    *  @throws DockerAccessException if the volume could not be created.
+    */
+   String createVolume(VolumeCreateConfig configuration) throws DockerAccessException;
+
+   /**
+    * removes a volume
+    * @param name volume name to remove
+    * @throws DockerAccessException if the volume could not be removed
+    */
+   void removeVolume(String name) throws DockerAccessException;
 }

--- a/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
@@ -78,18 +78,7 @@ public final class UrlBuilder {
 
     public String listContainers(String ... filter) {
         Builder builder = u("containers/json");
-        if (filter.length > 0) {
-            if (filter.length % 2 != 0) {
-                throw new IllegalArgumentException("Filters must be given as key value pairs and not " +Arrays.asList(filter));
-            }
-            JSONObject filters = new JSONObject();
-            for (int i = 0; i < filter.length; i +=2) {
-                JSONArray value = new JSONArray();
-                value.put(filter[i+1]);
-                filters.put(filter[i],value);
-            }
-            builder.p("filters",filters.toString());
-        }
+        addFilters(builder, filter);
         return builder.build();
     }
 
@@ -160,6 +149,14 @@ public final class UrlBuilder {
                 .build();
     }
 
+    public String createVolume() {
+       return u("volumes/create").build();
+    }
+
+    public String removeVolume(String name) {
+       return u("volumes/%s", name).build();
+    }
+
     public String getBaseUrl() {
         return baseUrl;
     }
@@ -203,6 +200,20 @@ public final class UrlBuilder {
         return String.format("%s/%s/%s", baseUrl, apiVersion, path);
     }
 
+    private void addFilters(Builder builder, String... filter) {
+       if (filter.length > 0) {
+           if (filter.length % 2 != 0) {
+               throw new IllegalArgumentException("Filters must be given as key value pairs and not " + Arrays.asList(filter));
+           }
+           JSONObject filters = new JSONObject();
+           for (int i = 0; i < filter.length; i +=2) {
+               JSONArray value = new JSONArray();
+               value.put(filter[i+1]);
+               filters.put(filter[i],value);
+           }
+           builder.p("filters",filters.toString());
+       }
+    }
 
     private static class Builder {
 

--- a/src/main/java/io/fabric8/maven/docker/access/VolumeCreateConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/VolumeCreateConfig.java
@@ -1,0 +1,54 @@
+package io.fabric8.maven.docker.access;
+
+import java.util.Map;
+
+import org.json.JSONObject;
+
+public class VolumeCreateConfig
+{
+    private final JSONObject createConfig = new JSONObject();
+
+    public VolumeCreateConfig(String name) {
+        add("Name", name);
+    }
+
+    public VolumeCreateConfig driver(String driver) {
+       return add("Driver", driver);
+    }
+
+    public VolumeCreateConfig opts(Map<String, String> opts) {
+       if (opts != null && opts.size() > 0) {
+          add("DriverOpts", new JSONObject(opts));
+       }
+       return this;
+    }
+
+    public VolumeCreateConfig labels(Map<String,String> labels) {
+        if (labels != null && labels.size() > 0) {
+           add("Labels", new JSONObject(labels));
+        }
+        return this;
+    }
+
+    public String getName() {
+        return createConfig.getString("Name");
+    }
+
+    /**
+     * Get JSON which is used for <em>creating</em> a volume
+     *
+     * @return string representation for JSON representing creating a volume
+     */
+    public String toJson() {
+        return createConfig.toString();
+    }
+
+    // =======================================================================
+
+    private VolumeCreateConfig add(String name, Object value) {
+        if (value != null) {
+            createConfig.put(name, value);
+        }
+        return this;
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/ecr/AwsSigner4.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ecr/AwsSigner4.java
@@ -1,0 +1,169 @@
+package io.fabric8.maven.docker.access.ecr;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+
+import io.fabric8.maven.docker.access.AuthConfig;
+
+/**
+ * AwsSigner4 implementation that signs requests with the AWS4 signing protocol.
+ *
+ * @author chas
+ * @since 2016-12-9
+ */
+public class AwsSigner4 {
+
+    private static final Comparator<NameValuePair> PAIR_NAME_COMPARATOR = new Comparator<NameValuePair>() {
+        @Override
+        public int compare(NameValuePair l, NameValuePair r) {
+            return l.getName().compareToIgnoreCase(r.getName());
+        }
+    };
+
+    // a-f must be lower case
+    final private static char[] HEXITS = "0123456789abcdef".toCharArray();
+
+    private final String service;
+    private final String region;
+
+    /**
+     * A signer for a particular region and service.
+     *
+     * @param region The aws region.
+     * @param service The aws service.
+     */
+    public AwsSigner4(String region, String service) {
+        this.region = region;
+        this.service = service;
+    }
+
+    /**
+     * Sign a request.  Add the headers that authenticate the request.
+     *
+     * @param request The request to sign.
+     * @param credentials The credentials to use when signing.
+     * @param signingTime The invocation time to use;
+     */
+    public void sign(HttpRequest request, AuthConfig credentials, Date signingTime) {
+        AwsSigner4Request sr = new AwsSigner4Request(region, service, request, signingTime);
+        if(!request.containsHeader("X-Amz-Date")) {
+            request.addHeader("X-Amz-Date", sr.getSigningDateTime());
+        }
+        request.addHeader("Authorization", task4(sr, credentials));
+    }
+
+    /**
+     * Task 1.
+     * <a href="https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html">Create a Canonical Request</a>
+     */
+    String task1(AwsSigner4Request sr) {
+        StringBuilder sb = new StringBuilder(sr.getMethod()).append('\n')
+                .append(sr.getUri().getRawPath()).append('\n')
+                .append(getCanonicalQuery(sr.getUri())).append('\n')
+                .append(sr.getCanonicalHeaders()).append('\n')
+                .append(sr.getSignedHeaders()).append('\n');
+
+        hexEncode(sb, sha256(sr.getBytes()));
+        return sb.toString();
+    }
+
+    /**
+     * Task 2.
+     * <a href="https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html">Create a String to Sign for Signature Version 4</a>
+     */
+    String task2(AwsSigner4Request sr) {
+        StringBuilder sb = new StringBuilder("AWS4-HMAC-SHA256\n")
+                .append(sr.getSigningDateTime()).append('\n')
+                .append(sr.getScope()).append('\n');
+        hexEncode(sb, sha256(task1(sr)));
+        return sb.toString();
+    }
+
+    /**
+     * Task 3.
+     * <a href="https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html">Calculate the Signature for AWS Signature Version 4</a>
+     */
+    final byte[] task3(AwsSigner4Request sr, AuthConfig credentials) {
+        return hmacSha256(getSigningKey(sr, credentials), task2(sr));
+    }
+
+    static byte[] getSigningKey(AwsSigner4Request sr, AuthConfig credentials) {
+        byte[] kSecret = ("AWS4" + credentials.getPassword()).getBytes(StandardCharsets.UTF_8);
+        byte[] kDate = hmacSha256(kSecret, sr.getSigningDate());
+        byte[] kRegion = hmacSha256(kDate, sr.getRegion());
+        byte[] kService = hmacSha256(kRegion, sr.getService());
+        byte[] signingKey = hmacSha256(kService, "aws4_request");
+        return signingKey;
+    }
+
+    /**
+     * Task 4.
+     * <a href="https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html">Add the Signing Information to the Request</a>
+     */
+    String task4(AwsSigner4Request sr, AuthConfig credentials) {
+        StringBuilder sb = new StringBuilder("AWS4-HMAC-SHA256 Credential=")
+                .append(credentials.getUsername() ).append( '/' ).append( sr.getScope() )
+                .append(", SignedHeaders=").append(sr.getSignedHeaders())
+                .append(", Signature=" );
+        hexEncode(sb, task3(sr, credentials));
+        return sb.toString();
+    }
+
+    private String getCanonicalQuery(URI uri) {
+        String query = uri.getQuery();
+        if(query == null || query.isEmpty()) {
+            return "";
+        }
+        List<NameValuePair> params = URLEncodedUtils.parse(query, StandardCharsets.UTF_8);
+        Collections.sort(params, PAIR_NAME_COMPARATOR);
+        return URLEncodedUtils.format(params, StandardCharsets.UTF_8);
+    }
+
+    static void hexEncode(StringBuilder dst, byte[] src) {
+        for ( int i = 0; i < src.length; ++i ) {
+            int v = src[i] & 0xFF;
+            dst.append(HEXITS[v >>> 4]);
+            dst.append(HEXITS[v & 0x0F]);
+        }
+    }
+
+    static byte[] hmacSha256(byte[] key, String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(key, "HmacSHA256"));
+            return mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+        }
+        catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new UnsupportedOperationException(e.getMessage(), e);
+        }
+    }
+
+    private static byte[] sha256(String string) {
+        return sha256(string.getBytes(StandardCharsets.UTF_8));
+    }
+
+     private static byte[] sha256(byte[] bytes) {
+         try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(bytes);
+            return md.digest();
+        }
+         catch (NoSuchAlgorithmException e) {
+             throw new UnsupportedOperationException(e.getMessage(), e);
+         }
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/ecr/AwsSigner4Request.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ecr/AwsSigner4Request.java
@@ -1,0 +1,212 @@
+package io.fabric8.maven.docker.access.ecr;
+
+import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.TreeMap;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.util.EntityUtils;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * The state of an aws sigV4 request.
+ *
+ * @author chas
+ * @since 2016-12-9
+ */
+public class AwsSigner4Request {
+
+    static final SimpleDateFormat TIME_FORMAT = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
+
+    static {
+        TimeZone utc = TimeZone.getTimeZone("GMT");
+        TIME_FORMAT.setTimeZone(utc);
+    }
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
+    private final String region;
+    private final String service;
+    private final HttpRequest request;
+
+    private final String signingDate;
+    private final String signingDateTime;
+    private final String scope;
+
+    private final String method;
+    private final URI uri;
+    private final String canonicalHeaders;
+    private final String signedHeaders;
+
+    AwsSigner4Request(String region, String service, HttpRequest request, Date signingTime) {
+        this.region = region;
+        this.service = service;
+        this.request = request;
+
+        signingDateTime = getSigningDateTime(request, signingTime);
+        signingDate = signingDateTime.substring(0, 8);
+        scope = signingDate + '/' + region + '/' + service + "/aws4_request";
+        method = request.getRequestLine().getMethod();
+        uri = getUri(request);
+
+        Map<String, String> headers = getOrderedHeadersToSign(request.getAllHeaders());
+        signedHeaders = StringUtils.join(headers.keySet(), ';');
+        canonicalHeaders = canonicalHeaders(headers);
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getSigningDate() {
+        return signingDate;
+    }
+
+    public String getSigningDateTime() {
+        return signingDateTime;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public String getCanonicalHeaders() {
+        return canonicalHeaders;
+    }
+
+    public String getSignedHeaders() {
+        return signedHeaders;
+    }
+
+    private static String getSigningDateTime(HttpRequest request, Date signingTime) {
+        Header dateHeader = request.getFirstHeader("X-Amz-Date");
+        if (dateHeader != null) {
+            return dateHeader.getValue();
+        }
+        synchronized (TIME_FORMAT) {
+            return TIME_FORMAT.format(signingTime);
+        }
+    }
+
+    private static URI getUri(HttpRequest request) {
+        String hostName = request.getFirstHeader("host").getValue();
+        String requestTarget = request.getRequestLine().getUri();
+        URI requestUri = createUri(hostName, requestTarget);
+        return requestUri.normalize();
+    }
+
+    private static URI createUri(String authority, String uri) {
+        String scheme = "https";
+        int schemeEnd = uri.indexOf(':');
+        int pathStart = uri.indexOf('/');
+        if (schemeEnd >= 0 && schemeEnd < pathStart) {
+            scheme = uri.substring(0, schemeEnd);
+            if (uri.charAt(pathStart + 1) == '/') {
+                authority = uri.substring(pathStart);
+                pathStart = uri.indexOf('/', pathStart + 2);
+            }
+        }
+
+        String path;
+        String query;
+        int queryIdx = uri.indexOf('?', pathStart);
+        if (queryIdx < 0) {
+            query = null;
+            path = uri.substring(pathStart);
+        } else {
+            query = uri.substring(queryIdx + 1);
+            path = uri.substring(pathStart, queryIdx);
+        }
+        try {
+            return new URI(scheme, authority, path, query, null);
+        } catch (URISyntaxException e) {
+            throw new UndeclaredThrowableException(e);
+        }
+    }
+
+    /**
+     * Get the ordered map of headers to sign.
+     *
+     * @param headers the possible headers to sign
+     * @return A &lt;String, StringBuilder&gt; map of headers to sign. Key is the name of the
+     *         header, Value is the comma separated values with minimized space
+     */
+    private static Map<String, String> getOrderedHeadersToSign(Header[] headers) {
+        Map<String, String> unique = new TreeMap<>();
+        for (Header header : headers) {
+            String key = header.getName().toLowerCase(Locale.US).trim();
+            if (key.equals("connection")) {
+                // do not sign 'connection' header, it is very likely to be changed en-route.
+                continue;
+            }
+            String value = header.getValue();
+            if (value == null) {
+                value = "";
+            } else {
+                // minimize white space
+                value = value.trim().replaceAll("\\s+", " ");
+            }
+            // merge all values with same header name
+            String prior = unique.get(key);
+            if (prior != null) {
+                if (prior.length() > 0) {
+                    value = prior + ',' + value;
+                }
+                unique.put(key, value);
+            } else {
+                unique.put(key, value);
+            }
+        }
+        return unique;
+    }
+
+    /**
+     * Create canonical header set. The headers are ordered by name.
+     *
+     * @param headers The set of headers to sign
+     * @return The signing value from headers. Headers are separated with newline. Each header is
+     *         formatted name:value with each header value whitespace trimmed and minimized
+     */
+    private static String canonicalHeaders(Map<String, String> headers) {
+        StringBuilder canonical = new StringBuilder();
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            canonical.append(header.getKey()).append(':').append(header.getValue()).append('\n');
+        }
+        return canonical.toString();
+    }
+
+    byte[] getBytes() {
+        if (request instanceof HttpEntityEnclosingRequestBase) {
+            try {
+                HttpEntity entity = ((HttpEntityEnclosingRequestBase) request).getEntity();
+                return EntityUtils.toByteArray(entity);
+            } catch (IOException e) {
+                throw new UndeclaredThrowableException(e);
+            }
+        }
+        return EMPTY_BYTES;
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuth.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuth.java
@@ -1,0 +1,124 @@
+package io.fabric8.maven.docker.access.ecr;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.util.Logger;
+
+/**
+ * Exchange local stored credentials for temporary ecr credentials
+ *
+ * @author chas
+ * @since 2016-12-9
+ */
+public class EcrExtendedAuth {
+
+    private static final Pattern AWS_REGISTRY =
+            Pattern.compile("^(\\d{12})\\.dkr\\.ecr\\.([a-z\\-0-9]+)\\.amazonaws\\.com$");
+
+    private final Logger logger;
+    private final Matcher matcher;
+    private final boolean isValid;
+
+    /**
+     * Initialize an extended authentication for ecr registry.
+     *
+     * @param registry The registry, we may or may not be an ecr registry.
+     */
+    public EcrExtendedAuth(Logger logger, String registry) {
+        this.logger = logger;
+        matcher = AWS_REGISTRY.matcher(registry);
+        isValid = matcher.matches();
+        logger.debug("registry = %s, isValid= %b", registry, isValid);
+    }
+
+    /**
+     * Is the registry an ecr registry?
+     * @return true, if the registry matches the ecr pattern
+     */
+    public boolean isValidRegistry() {
+        return isValid;
+    }
+
+    /**
+     * Perform extended authentication.  Use the provided credentials as IAM credentials and
+     * get a temporary ECR token.
+     *
+     * @param localCredentials IAM id/secret
+     * @return ECR base64 encoded username:password
+     * @throws IOException
+     * @throws MojoExecutionException
+     */
+    public AuthConfig extendedAuth(AuthConfig localCredentials) throws IOException, MojoExecutionException {
+        JSONObject jo = getAuthorizationToken(localCredentials);
+
+        JSONArray authorizationDatas = jo.getJSONArray("authorizationData");
+        JSONObject authorizationData = authorizationDatas.getJSONObject(0);
+        String authorizationToken = authorizationData.getString("authorizationToken");
+
+        return new AuthConfig(authorizationToken, "none");
+    }
+
+    private JSONObject getAuthorizationToken(AuthConfig localCredentials) throws IOException, MojoExecutionException {
+        HttpPost request = createSignedRequest(localCredentials, new Date());
+        return executeRequest(createClient(), request);
+    }
+
+    CloseableHttpClient createClient() {
+        return HttpClients.createDefault();
+    }
+
+    JSONObject executeRequest(CloseableHttpClient client, HttpPost request) throws IOException, MojoExecutionException {
+        try {
+            CloseableHttpResponse response = client.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            logger.debug("Response status %d", statusCode);
+            if(statusCode != HttpStatus.SC_OK) {
+                throw new MojoExecutionException("AWS authentication failure");
+            }
+
+            HttpEntity entity = response.getEntity();
+            Reader jr = new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8);
+            return new JSONObject(new JSONTokener(jr));
+        }
+        finally {
+            client.close();
+        }
+    }
+
+    HttpPost createSignedRequest(AuthConfig localCredentials, Date time) {
+        String accountId = matcher.group(1);
+        String region = matcher.group(2);
+        String host = "ecr." + region + ".amazonaws.com";
+
+        logger.debug("GetAuthorizationToken from %s", host);
+
+        HttpPost request = new HttpPost("https://" + host + '/');
+        request.setHeader("host", host);
+        request.setHeader("Content-Type", "application/x-amz-json-1.1");
+        request.setHeader("X-Amz-Target", "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken");
+        request.setEntity(new StringEntity("{\"registryIds\":[\""+ accountId + "\"]}", StandardCharsets.UTF_8));
+
+        AwsSigner4 signer = new AwsSigner4(region, "ecr");
+        signer.sign(request, localCredentials, time);
+        return request;
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -154,6 +154,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
                     LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream));
                     String line;
                     try {
+                        callback.open();
                         while ( (line = reader.readLine()) != null) {
                             callback.log(1, new Timestamp(), line);
                         }

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import io.fabric8.maven.docker.access.hc.util.ClientBuilder;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
@@ -40,6 +39,7 @@ import io.fabric8.maven.docker.access.hc.ApacheHttpClientDelegate.BodyAndStatusR
 import io.fabric8.maven.docker.access.hc.ApacheHttpClientDelegate.HttpBodyAndStatus;
 import io.fabric8.maven.docker.access.hc.http.HttpClientBuilder;
 import io.fabric8.maven.docker.access.hc.unix.UnixSocketClientBuilder;
+import io.fabric8.maven.docker.access.hc.util.ClientBuilder;
 import io.fabric8.maven.docker.access.hc.win.NamedPipeClientBuilder;
 import io.fabric8.maven.docker.access.log.LogCallback;
 import io.fabric8.maven.docker.access.log.LogGetHandle;
@@ -159,6 +159,8 @@ public class DockerAccessWithHcClient implements DockerAccess {
                         }
                     } catch (LogCallback.DoneException e) {
                         // Ok, we stop here ...
+                    } finally {
+                        callback.close();
                     }
                 }
                 return null;

--- a/src/main/java/io/fabric8/maven/docker/access/hc/unix/UnixConnectionSocketFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/unix/UnixConnectionSocketFactory.java
@@ -7,7 +7,6 @@ import java.net.SocketAddress;
 
 import io.fabric8.maven.docker.access.hc.util.AbstractNativeSocketFactory;
 import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
 import org.apache.http.protocol.HttpContext;
 
 final class UnixConnectionSocketFactory extends AbstractNativeSocketFactory {
@@ -18,7 +17,7 @@ final class UnixConnectionSocketFactory extends AbstractNativeSocketFactory {
 
     @Override
     public Socket createSocket(HttpContext context) throws IOException {
-        return new jnr.unixsocket.UnixSocket(UnixSocketChannel.open());
+        return new UnixSocket();
     }
 
     @Override

--- a/src/main/java/io/fabric8/maven/docker/access/hc/unix/UnixSocket.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/unix/UnixSocket.java
@@ -1,0 +1,302 @@
+package io.fabric8.maven.docker.access.hc.unix;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+
+final class UnixSocket extends Socket {
+
+    private final Object connectLock = new Object();
+    private volatile boolean inputShutdown, outputShutdown;
+
+    private final UnixSocketChannel channel;
+
+    UnixSocket() throws IOException {
+        channel = UnixSocketChannel.open();
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint) throws IOException {
+        connect(endpoint, 0);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        if (timeout < 0) {
+            throw new IllegalArgumentException("Timeout may not be negative: " + timeout);
+        }
+
+        if (!(endpoint instanceof UnixSocketAddress)) {
+            throw new IllegalArgumentException("Unsupported address type: " + endpoint.getClass().getName());
+        }
+
+        synchronized (connectLock) {
+            channel.connect((UnixSocketAddress) endpoint);
+        }
+    }
+
+    @Override
+    public void bind(SocketAddress bindpoint) throws IOException {
+        throw new SocketException("Bind is not supported");
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+        return null;
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public int getPort() {
+        return -1;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return -1;
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        synchronized (connectLock) {
+            return channel.getRemoteSocketAddress();
+        }
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        synchronized (connectLock) {
+            return channel.getLocalSocketAddress();
+        }
+    }
+
+    @Override
+    public SocketChannel getChannel() {
+        return null;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        if (!channel.isConnected()) {
+            throw new SocketException("Socket is not connected");
+        }
+
+        if (inputShutdown) {
+            throw new SocketException("Socket input is shutdown");
+        }
+
+        return new FilterInputStream(Channels.newInputStream(channel)) {
+            @Override
+            public void close() throws IOException {
+                shutdownInput();
+            }
+        };
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        if (!channel.isConnected()) {
+            throw new SocketException("Socket is not connected");
+        }
+
+        if (outputShutdown) {
+            throw new SocketException("Socket output is shutdown");
+        }
+
+        return new FilterOutputStream(Channels.newOutputStream(channel)) {
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                out.write(b, off, len);
+            }
+
+            @Override
+            public void close() throws IOException {
+                shutdownOutput();
+            }
+        };
+    }
+
+    @Override
+    public void sendUrgentData(int data) throws IOException {
+        throw new SocketException("Urgent data not supported");
+    }
+
+    @Override
+    public void setSoTimeout(int timeout) {
+        channel.setSoTimeout(timeout);
+    }
+
+    @Override
+    public int getSoTimeout() throws SocketException {
+        return channel.getSoTimeout();
+    }
+
+    @Override
+    public void setSendBufferSize(int size) throws SocketException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Send buffer size must be positive: " + size);
+        }
+
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public synchronized int getSendBufferSize() throws SocketException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        throw new UnsupportedOperationException("Getting the send buffer size is not supported");
+    }
+
+    @Override
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Receive buffer size must be positive: " + size);
+        }
+
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public synchronized int getReceiveBufferSize() throws SocketException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        throw new UnsupportedOperationException("Getting the receive buffer size is not supported");
+    }
+
+    @Override
+    public void setKeepAlive(boolean on) throws SocketException {
+        channel.setKeepAlive(on);
+    }
+
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+        return channel.getKeepAlive();
+    }
+
+    @Override
+    public void setTrafficClass(int tc) throws SocketException {
+        if (tc < 0 || tc > 255) {
+            throw new IllegalArgumentException("Traffic class is not in range 0 -- 255: " + tc);
+        }
+
+        if (isClosed()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public int getTrafficClass() throws SocketException {
+        throw new UnsupportedOperationException("Getting the traffic class is not supported");
+    }
+
+    @Override
+    public void setReuseAddress(boolean on) throws SocketException {
+        if (isClosed()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public boolean getReuseAddress() throws SocketException {
+        throw new UnsupportedOperationException("Getting the SO_REUSEADDR option is not supported");
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+        inputShutdown = true;
+        outputShutdown = true;
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        channel.shutdownInput();
+        inputShutdown = true;
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        channel.shutdownOutput();
+        outputShutdown = true;
+    }
+
+    @Override
+    public String toString() {
+        if (isConnected()) {
+            return "UnixSocket[addr=" + channel.getRemoteSocketAddress() + ']';
+        }
+
+        return "UnixSocket[unconnected]";
+    }
+
+    @Override
+    public boolean isConnected() {
+        return channel.isConnected();
+    }
+
+    @Override
+    public boolean isBound() {
+        return false;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return !channel.isOpen();
+    }
+
+    @Override
+    public boolean isInputShutdown() {
+        return inputShutdown;
+    }
+
+    @Override
+    public boolean isOutputShutdown() {
+        return outputShutdown;
+    }
+
+    @Override
+    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+        // no-op
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/log/LogCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogCallback.java
@@ -1,5 +1,5 @@
 package io.fabric8.maven.docker.access.log;/*
- * 
+ *
  * Copyright 2014 Roland Huss
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@ package io.fabric8.maven.docker.access.log;/*
  * limitations under the License.
  */
 
+import java.io.FileNotFoundException;
 import java.util.concurrent.CancellationException;
 
 import io.fabric8.maven.docker.util.Timestamp;
@@ -42,9 +43,15 @@ public interface LogCallback {
      * @param error error description
      */
     void error(String error);
-    
+
     /**
-     * Must be invoked by caller when callback is no longer used.
+     * To be called by a client to start the callback and allocate the underlying output stream.
+     * In case of a shared stream it might be that the stream is reused
+     */
+    void open() throws FileNotFoundException;
+
+    /**
+     * Invoked by a user when callback is no longer used.
      * Closing the underlying stream may be delayed by the implementation
      * when this stream is shared between multiple clients.
      */

--- a/src/main/java/io/fabric8/maven/docker/access/log/LogCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogCallback.java
@@ -42,6 +42,13 @@ public interface LogCallback {
      * @param error error description
      */
     void error(String error);
+    
+    /**
+     * Must be invoked by caller when callback is no longer used.
+     * Closing the underlying stream may be delayed by the implementation
+     * when this stream is shared between multiple clients.
+     */
+    void close();
 
     /**
      * Exception indicating that logging is done and should be finished

--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -91,6 +91,8 @@ public class LogRequestor extends Thread implements LogGetHandle {
             parseResponse(resp);
         } catch (IOException exp) {
             callback.error(exp.getMessage());
+        } finally {
+            callback.close();
         }
     }
 
@@ -105,6 +107,7 @@ public class LogRequestor extends Thread implements LogGetHandle {
         } catch (IOException exp) {
             callback.error("IO Error while requesting logs: " + exp);
         } finally {
+            callback.close();
             try {
                 synchronized (lock) {
                     client.close();
@@ -224,6 +227,7 @@ public class LogRequestor extends Thread implements LogGetHandle {
                 }
             }
         }
+        callback.close();
     }
 
     @Override

--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -87,6 +87,7 @@ public class LogRequestor extends Thread implements LogGetHandle {
      */
     public void fetchLogs() {
         try {
+            callback.open();
             HttpResponse resp = client.execute(getLogRequest(false));
             parseResponse(resp);
         } catch (IOException exp) {
@@ -101,6 +102,7 @@ public class LogRequestor extends Thread implements LogGetHandle {
         // Response to extract from
 
         try {
+            callback.open();
             request = getLogRequest(true);
             HttpResponse response = client.execute(request);
             parseResponse(response);
@@ -227,7 +229,6 @@ public class LogRequestor extends Thread implements LogGetHandle {
                 }
             }
         }
-        callback.close();
     }
 
     @Override

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -86,7 +86,7 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
     }
 
     private void addVolumes(RunImageConfiguration runConfig, List<String> ret) {
-        VolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
+        RunVolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
         if (volConfig != null) {
             List<String> volumeImages = volConfig.getFrom();
             if (volumeImages != null) {

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -119,7 +119,7 @@ public class RunImageConfiguration implements Serializable {
 
     // Mount volumes from the given image's started containers
     @Parameter
-    private VolumeConfiguration volumes;
+    private RunVolumeConfiguration volumes;
 
     // Links to other container started
     @Parameter
@@ -267,7 +267,7 @@ public class RunImageConfiguration implements Serializable {
         return extraHosts;
     }
 
-    public VolumeConfiguration getVolumeConfiguration() {
+    public RunVolumeConfiguration getVolumeConfiguration() {
         return volumes;
     }
 
@@ -468,7 +468,7 @@ public class RunImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder volumes(VolumeConfiguration volumes) {
+        public Builder volumes(RunVolumeConfiguration volumes) {
             config.volumes = volumes;
             return this;
         }

--- a/src/main/java/io/fabric8/maven/docker/config/RunVolumeConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunVolumeConfiguration.java
@@ -1,0 +1,95 @@
+package io.fabric8.maven.docker.config;/*
+ *
+ * Copyright 2014 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.Serializable;
+import java.util.*;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Run configuration for volumes.
+ *
+ * @author roland
+ * @since 08/12/14
+ */
+public class RunVolumeConfiguration implements Serializable {
+
+    /**
+     * List of images names from where volumes are mounted
+     */
+    @Parameter
+    private List<String> from;
+
+    /**
+     * List of bind parameters for binding/mounting host directories
+     * into the container
+     */
+    @Parameter
+    private List<String> bind;
+
+    /**
+     * List of images to mount from
+     *
+     * @return images
+     */
+    public List<String> getFrom() {
+        return from;
+    }
+
+    /**
+     * List of docker bind specification for mounting local directories
+     * @return list of bind specs
+     */
+    public List<String> getBind() {
+        return bind;
+    }
+
+    // ===========================================
+
+    public static class Builder {
+
+        private RunVolumeConfiguration config = new RunVolumeConfiguration();
+
+        public Builder() {
+            this.config = new RunVolumeConfiguration();
+        }
+
+        public Builder from(List<String> args) {
+            if (args != null) {
+                if (config.from == null) {
+                    config.from = new ArrayList<>();
+                }
+                config.from.addAll(args);
+            }
+            return this;
+        }
+
+        public Builder bind(List<String> args) {
+            if (args != null) {
+                if (config.bind == null) {
+                    config.bind = new ArrayList<>();
+                }
+                config.bind.addAll(args);
+            }
+            return this;
+        }
+
+        public RunVolumeConfiguration build() {
+            return config;
+        }
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/config/VolumeConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/VolumeConfiguration.java
@@ -1,95 +1,90 @@
-package io.fabric8.maven.docker.config;/*
- *
- * Copyright 2014 Roland Huss
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+package io.fabric8.maven.docker.config;
+
+
+import io.fabric8.maven.docker.util.DeepCopy;
 
 import java.io.Serializable;
-import java.util.*;
+import java.lang.String;
+import java.util.Map;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- * Run configuration for volumes.
+ *  Volume Configuration for Volumes to be created prior to container start
  *
- * @author roland
- * @since 08/12/14
+ *  @author Tom Burton
+ *  @version Dec 15, 2016
  */
-public class VolumeConfiguration implements Serializable {
+public class VolumeConfiguration implements Serializable
+{
+   /** Volume Name */
+   @Parameter
+   private String name;
 
-    /**
-     * List of images names from where volumes are mounted
-     */
-    @Parameter
-    private List<String> from;
+   /** Volume driver for mounting the volume */
+   @Parameter
+   private String driver;
 
-    /**
-     * List of bind parameters for binding/mounting host directories
-     * into the container
-     */
-    @Parameter
-    private List<String> bind;
+   /** Driver specific options */
+   @Parameter
+   private Map<String, String> opts;
 
-    /**
-     * List of images to mount from
-     *
-     * @return images
-     */
-    public List<String> getFrom() {
-        return from;
-    }
+   /** Volume labels */
+   @Parameter
+   private Map<String, String> labels;
 
-    /**
-     * List of docker bind specification for mounting local directories
-     * @return list of bind specs
-     */
-    public List<String> getBind() {
-        return bind;
-    }
+   public String getName() {
+       return name;
+   }
 
-    // ===========================================
+   public String getDriver() {
+       return driver;
+   }
 
-    public static class Builder {
+   public Map<String, String> getOpts() {
+       return opts;
+   }
 
-        private VolumeConfiguration config = new VolumeConfiguration();
+   public Map<String, String> getLabels() {
+       return labels;
+   }
 
-        public Builder() {
-            this.config = new VolumeConfiguration();
-        }
+   // =============================================================================
 
-        public Builder from(List<String> args) {
-            if (args != null) {
-                if (config.from == null) {
-                    config.from = new ArrayList<>();
-                }
-                config.from.addAll(args);
-            }
-            return this;
-        }
+   public static class Builder {
+       private final VolumeConfiguration config;
 
-        public Builder bind(List<String> args) {
-            if (args != null) {
-                if (config.bind == null) {
-                    config.bind = new ArrayList<>();
-                }
-                config.bind.addAll(args);
-            }
-            return this;
-        }
+       public Builder()  {
+           this(null);
+       }
 
-        public VolumeConfiguration build() {
-            return config;
-        }
-    }
+       public Builder(VolumeConfiguration that) {
+           this.config = that == null ? new VolumeConfiguration() : DeepCopy.copy(that);
+       }
+
+       public Builder name(String name) {
+           config.name = name;
+           return this;
+       }
+
+       public Builder driver(String driver) {
+           config.driver = driver;
+           return this;
+       }
+
+       public Builder opts(Map<String, String> opts) {
+           config.opts = opts;
+           return this;
+       }
+
+       public Builder labels(Map<String, String> labels) {
+           config.labels = labels;
+           return this;
+       }
+
+       public VolumeConfiguration build() {
+           return config;
+       }
+   }
+
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -236,8 +236,8 @@ class DockerComposeServiceWrapper {
         return ret;
     }
 
-    VolumeConfiguration getVolumeConfig() {
-        VolumeConfiguration.Builder builder = new VolumeConfiguration.Builder();
+    RunVolumeConfiguration getVolumeConfig() {
+        RunVolumeConfiguration.Builder builder = new RunVolumeConfiguration.Builder();
         List<String> volumes = asList("volumes");
         boolean added = false;
         if (volumes.size() > 0) {

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -265,8 +265,8 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return ret;
     }
 
-    private VolumeConfiguration extractVolumeConfig(String prefix, Properties properties) {
-        return new VolumeConfiguration.Builder()
+    private RunVolumeConfiguration extractVolumeConfig(String prefix, Properties properties) {
+        return new RunVolumeConfiguration.Builder()
                 .bind(listWithPrefix(prefix, BIND, properties))
                 .from(listWithPrefix(prefix, VOLUMES_FROM, properties))
                 .build();

--- a/src/main/java/io/fabric8/maven/docker/log/DefaultLogCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/log/DefaultLogCallback.java
@@ -15,7 +15,11 @@ package io.fabric8.maven.docker.log;/*
  * limitations under the License.
  */
 
-import java.io.*;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import io.fabric8.maven.docker.access.log.LogCallback;
 import io.fabric8.maven.docker.util.Timestamp;
@@ -26,27 +30,61 @@ import io.fabric8.maven.docker.util.Timestamp;
  */
 public class DefaultLogCallback implements LogCallback {
 
+    private static Map<String, SharedPrintStream> printStreamMap = new HashMap<>();
+    
     private final LogOutputSpec outputSpec;
-    private PrintStream ps;
+    private final SharedPrintStream sps;
+    
     public DefaultLogCallback(LogOutputSpec outputSpec) throws FileNotFoundException {
         this.outputSpec = outputSpec;
-        ps = createPrintStream(outputSpec.isLogStdout(), outputSpec.getFile());
+        this.sps = createOrReusePrintStream(outputSpec);
     }
-
-    private PrintStream createPrintStream(boolean logStdout, String file) throws FileNotFoundException {
-        return !logStdout && file != null ? new PrintStream(new FileOutputStream(file), true) : System.out;
+    
+    private synchronized SharedPrintStream createOrReusePrintStream(LogOutputSpec spec) throws FileNotFoundException {
+        String file = spec.getFile();
+        if (spec.isLogStdout() || file == null) {
+            return new SharedPrintStream(System.out);
+        }
+        SharedPrintStream sps = printStreamMap.get(file);
+        if (sps == null) {
+            PrintStream ps = new PrintStream(new FileOutputStream(file), true);
+            sps = new SharedPrintStream(ps);
+            
+            printStreamMap.put(file, sps);
+        }
+        else {
+            sps.allocate();
+        }
+        return sps;
+    }
+    
+    private PrintStream ps() {
+        return sps.getPrintStream();
     }
 
     @Override
     public void log(int type, Timestamp timestamp, String txt) {
-        addLogEntry(ps, new LogEntry(type, timestamp, txt));
+        addLogEntry(ps(), new LogEntry(type, timestamp, txt));
     }
 
     @Override
     public void error(String error) {
-        ps.println(error);
+        ps().println(error);
     }
 
+    @Override
+    public synchronized void close() {
+        sps.free();
+        if (!sps.isUsed()) {
+            if (sps.getPrintStream() != System.out) {
+                sps.getPrintStream().close();
+            }
+            String file = outputSpec.getFile();
+            if (file != null) {
+                printStreamMap.remove(file);
+            }
+        }
+    }
     private void addLogEntry(PrintStream ps, LogEntry logEntry) {
         // TODO: Add the entry to a queue, and let the queue be picked up with a small delay from an extra
         // thread which then can sort the entries by time before printing it out in order to avoid race conditions.
@@ -88,4 +126,5 @@ public class DefaultLogCallback implements LogCallback {
             return timestamp.compareTo(entry.timestamp);
         }
     }
+
 }

--- a/src/main/java/io/fabric8/maven/docker/log/DefaultLogCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/log/DefaultLogCallback.java
@@ -62,15 +62,13 @@ public class DefaultLogCallback implements LogCallback {
     @Override
     public synchronized void close() {
         if (this.sps != null) {
-            sps.free();
-            if (!sps.isUsed()) {
-                sps.close();
+            if (sps.close()) {
                 String file = outputSpec.getFile();
                 if (file != null) {
                     printStreamMap.remove(file);
                 }
+                this.sps = null;
             }
-            this.sps = null;
         }
     }
 

--- a/src/main/java/io/fabric8/maven/docker/log/LogDispatcher.java
+++ b/src/main/java/io/fabric8/maven/docker/log/LogDispatcher.java
@@ -16,7 +16,8 @@ package io.fabric8.maven.docker.log;/*
  */
 
 import java.io.FileNotFoundException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.log.LogGetHandle;

--- a/src/main/java/io/fabric8/maven/docker/log/SharedPrintStream.java
+++ b/src/main/java/io/fabric8/maven/docker/log/SharedPrintStream.java
@@ -6,30 +6,32 @@ class SharedPrintStream {
     private PrintStream printStream;
 
     private int numUsers;
-    
-    public SharedPrintStream(PrintStream ps) {
+
+    SharedPrintStream(PrintStream ps) {
         this.printStream = ps;
         this.numUsers = 1;
     }
 
-    public PrintStream getPrintStream() {
+    PrintStream getPrintStream() {
         return printStream;
-    }
-
-    public void setPrintStream(PrintStream printStream) {
-        this.printStream = printStream;
     }
 
     public boolean isUsed() {
         return numUsers > 0;
     }
 
-    public void allocate() {
+    synchronized void allocate() {
         numUsers++;
     }
-    
-    public void free() {
+
+    synchronized void free() {
         assert numUsers > 0;
         numUsers--;
+    }
+
+    public void close() {
+        if (printStream != System.out) {
+            printStream.close();;
+        }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/log/SharedPrintStream.java
+++ b/src/main/java/io/fabric8/maven/docker/log/SharedPrintStream.java
@@ -1,0 +1,35 @@
+package io.fabric8.maven.docker.log;
+
+import java.io.PrintStream;
+
+class SharedPrintStream {
+    private PrintStream printStream;
+
+    private int numUsers;
+    
+    public SharedPrintStream(PrintStream ps) {
+        this.printStream = ps;
+        this.numUsers = 1;
+    }
+
+    public PrintStream getPrintStream() {
+        return printStream;
+    }
+
+    public void setPrintStream(PrintStream printStream) {
+        this.printStream = printStream;
+    }
+
+    public boolean isUsed() {
+        return numUsers > 0;
+    }
+
+    public void allocate() {
+        numUsers++;
+    }
+    
+    public void free() {
+        assert numUsers > 0;
+        numUsers--;
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -252,7 +252,7 @@ public class RunService {
                     .labels(mergeLabels(runConfig.getLabels(), pomLabel))
                     .command(runConfig.getCmd())
                     .hostConfig(createContainerHostConfig(runConfig, mappedPorts));
-            VolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();
+            RunVolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();
             if (volumeConfig != null) {
                 config.binds(volumeConfig.getBind());
             }
@@ -325,7 +325,7 @@ public class RunService {
     }
 
     private void addVolumeConfig(ContainerHostConfig config, RunImageConfiguration runConfig) throws DockerAccessException {
-        VolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
+        RunVolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
         if (volConfig != null) {
             config.binds(volConfig.getBind())
                   .volumesFrom(findVolumesFromContainers(volConfig.getFrom()));

--- a/src/main/java/io/fabric8/maven/docker/service/ServiceHub.java
+++ b/src/main/java/io/fabric8/maven/docker/service/ServiceHub.java
@@ -24,9 +24,9 @@ import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.project.MavenProject;
 
 /**
- * A service hub responsible for creating and managing service which are used by
+ * A service hub responsible for creating and managing services which are used by
  * Mojos for calling to the docker backend. The docker backend (DAO) is injected from the outside.
- &
+ *
  * @author roland
  * @since 01/12/15
  */
@@ -39,6 +39,7 @@ public class ServiceHub {
     private final BuildService buildService;
     private final MojoExecutionService mojoExecutionService;
     private final ArchiveService archiveService;
+    private final VolumeService volumeService;
 
     ServiceHub(DockerAccess dockerAccess, ContainerTracker containerTracker, BuildPluginManager pluginManager,
                DockerAssemblyManager dockerAssemblyManager, MavenProject project, MavenSession session,
@@ -53,10 +54,12 @@ public class ServiceHub {
             queryService = new QueryService(dockerAccess);
             runService = new RunService(dockerAccess, queryService, containerTracker, logSpecFactory, logger);
             buildService = new BuildService(dockerAccess, queryService, archiveService, logger);
+            volumeService = new VolumeService(dockerAccess);
         } else {
             queryService = null;
             runService = null;
             buildService = null;
+            volumeService = null;
         }
     }
 
@@ -99,6 +102,16 @@ public class ServiceHub {
     public RunService getRunService() {
         checkDockerAccessInitialization();
         return runService;
+    }
+    
+    /**
+     * The volume service is responsible for creating volumes
+     *
+     * @return the run service
+     */
+    public VolumeService getVolumeService() {
+        checkDockerAccessInitialization();
+        return volumeService;
     }
 
     public ArchiveService getArchiveService() {

--- a/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
@@ -1,0 +1,38 @@
+package io.fabric8.maven.docker.service;
+
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.access.VolumeCreateConfig;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
+
+import java.lang.String;
+import java.util.Map;
+
+/**
+ *  Service Class for helping control Volumes
+ *
+ *  @author Tom Burton
+ *  @version Dec 15, 2016
+ */
+public class VolumeService {
+   // DAO for accessing the docker daemon
+   private DockerAccess docker;
+
+   VolumeService(DockerAccess dockerAccess) {
+      this.docker = dockerAccess;
+   }
+
+   public String createVolume(VolumeConfiguration vc) throws DockerAccessException {
+      VolumeCreateConfig config =
+          new VolumeCreateConfig(vc.getName())
+              .driver(vc.getDriver())
+              .opts(vc.getOpts())
+              .labels(vc.getLabels());
+
+      return docker.createVolume(config);
+   }
+
+   public void removeVolume(String volumeName) throws DockerAccessException {
+      docker.removeVolume(volumeName);
+   }
+}

--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -1,6 +1,8 @@
 package io.fabric8.maven.docker.util;
 
 import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.access.ecr.EcrExtendedAuth;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.settings.Server;
@@ -16,6 +18,7 @@ import org.yaml.snakeyaml.Yaml;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -44,6 +47,7 @@ public class AuthConfigFactory {
     static final String DOCKER_LOGIN_DEFAULT_REGISTRY = "https://index.docker.io/v1/";
 
     private final PlexusContainer container;
+    private Logger log;
     private static final String[] DEFAULT_REGISTRIES = new String[]{
             "docker.io", "index.docker.io", "registry.hub.docker.com"
     };
@@ -51,10 +55,14 @@ public class AuthConfigFactory {
     /**
      * Constructor which should be used during startup phase of a plugin
      *
-     * @param container the container used for do decrytion of passwords
+     * @param container the container used for do decryption of passwords
      */
     public AuthConfigFactory(PlexusContainer container) {
         this.container = container;
+    }
+
+    public void setLog(Logger log) {
+        this.log = log;
     }
 
     /**
@@ -65,6 +73,94 @@ public class AuthConfigFactory {
      * <ul>
      *    <li>From system properties</li>
      *    <li>From the provided map which can contain key-value pairs</li>
+     *    <li>From the openshift settings in ~/.config/kube</li>
+     *    <li>From the Maven settings stored typically in ~/.m2/settings.xml</li>
+     *    <li>From the Docker settings stored in ~/.docker/config.json</li>
+     * </ul>
+     *
+     * The following properties (prefix with 'docker.') and config key are evaluated:
+     *
+     * <ul>
+     *     <li>username: User to authenticate</li>
+     *     <li>password: Password to authenticate. Can be encrypted</li>
+     *     <li>email: Optional EMail address which is send to the registry, too</li>
+     * </ul>
+     *
+     *  If the repository is in an aws ecr registry and skipExtendedAuth is not true, if found
+     *  credentials are not from docker settings, they will be interpreted as iam credentials
+     *  and exchanged for ecr credentials.
+     *
+     * @param logger The logger for tracing
+     * @param isPush if true this AuthConfig is created for a push, if false it's for a pull
+     * @param skipExtendedAuth if false, do not execute extended authentication methods
+     * @param authConfig String-String Map holding configuration info from the plugin's configuration. Can be <code>null</code> in
+     *                   which case the settings are consulted.
+     * @param settings the global Maven settings object
+     * @param user user to check for
+     * @param registry registry to use, might be null in which case a default registry is checked,
+     * @return the authentication configuration or <code>null</code> if none could be found
+     *
+     * @throws MojoFailureException
+     */
+    public AuthConfig createAuthConfig(boolean isPush, boolean skipExtendedAuth, Map authConfig, Settings settings, String user, String registry)
+            throws MojoExecutionException {
+
+        AuthConfig ret = createStandardAuthConfig(isPush, authConfig, settings, user, registry);
+        if (ret != null) {
+            if (registry == null ) {
+                log.debug("default registry; no extended auth");
+                return ret;
+            }
+            if (skipExtendedAuth) {
+                log.debug("skipping extended auth");
+                return ret;
+            }
+            try {
+                return extendedAuthentication(registry, ret);
+            } catch (IOException e) {
+                throw new MojoExecutionException(e.getMessage(), e);
+            }
+        }
+
+        // Finally check ~/.docker/config.json
+        ret = getAuthConfigFromDockerConfig(registry);
+        if(ret != null) {
+            log.debug("found credentials in ~.docker/config.json");
+            return ret;
+        }
+
+        log.debug("no credentials found");
+        return null;
+    }
+
+    /**
+     * Try various extended authentication method.  Currently only supports amazon ECR
+     *
+     * @param logger The logger for tracing
+     * @param registry The registry to authenticated against.
+     * @param localCredentials The locally stored credentials.
+     * @return The given credentials, if registry does not need extended authentication;
+     * else, the credentials after authentication.
+     * @throws IOException
+     * @throws MojoExecutionException
+     */
+    private AuthConfig extendedAuthentication(String registry, AuthConfig localCredentials) throws IOException, MojoExecutionException {
+        EcrExtendedAuth ecr = new EcrExtendedAuth(log, registry);
+        if (ecr.isValidRegistry()) {
+            return ecr.extendedAuth(localCredentials);
+        }
+        return localCredentials;
+    }
+
+    /**
+     * Create an authentication config object which can be used for communication with a Docker registry
+     *
+     * The authentication information is looked up at various places (in this order):
+     *
+     * <ul>
+     *    <li>From system properties</li>
+     *    <li>From the provided map which can contain key-value pairs</li>
+     *    <li>From the openshift settings in ~/.config/kube</li>
      *    <li>From the Maven settings stored typically in ~/.m2/settings.xml</li>
      * </ul>
      *
@@ -77,7 +173,7 @@ public class AuthConfigFactory {
      * </ul>
      *
      *
-     * @param isPush if true this authconfig is created for a push, if false its for a pull
+     * @param isPush if true this AuthConfig is created for a push, if false it's for a pull
      * @param authConfigMap String-String Map holding configuration info from the plugin's configuration. Can be <code>null</code> in
      *                   which case the settings are consulted.
      * @param settings the global Maven settings object
@@ -87,7 +183,7 @@ public class AuthConfigFactory {
      *
      * @throws MojoFailureException
      */
-    public AuthConfig createAuthConfig(boolean isPush, Map authConfigMap, Settings settings, String user, String registry)
+    private AuthConfig createStandardAuthConfig(boolean isPush, Map authConfigMap, Settings settings, String user, String registry)
             throws MojoExecutionException {
         AuthConfig ret;
 
@@ -96,34 +192,32 @@ public class AuthConfigFactory {
             // System properties docker.username and docker.password always take precedence
             ret = getAuthConfigFromSystemProperties(lookupMode);
             if (ret != null) {
+                log.debug("found credentials in system properties");
                 return ret;
             }
 
             // Check for openshift authentication either from the plugin config or from system props
             ret = getAuthConfigFromOpenShiftConfig(lookupMode,authConfigMap);
             if (ret != null) {
+                log.debug("found openshift credentials");
                 return ret;
             }
 
             // Get configuration from global plugin config
             ret = getAuthConfigFromPluginConfiguration(lookupMode,authConfigMap);
             if (ret != null) {
+                log.debug("found credentials in plugin config");
                 return ret;
             }
         }
 
         // ===================================================================
-        // These are lookups based on registry only, so the direction (push or pull) doesnt matter:
+        // These are lookups based on registry only, so the direction (push or pull) doesn't matter:
 
         // Now lets lookup the registry & user from ~/.m2/setting.xml
         ret = getAuthConfigFromSettings(settings, user, registry);
         if (ret != null) {
-            return ret;
-        }
-
-        // Finally check ~/.docker/config.json
-        ret = getAuthConfigFromDockerConfig(registry);
-        if (ret != null) {
+            log.debug("found credentials in ~/.m2/setting.xml");
             return ret;
         }
 
@@ -406,6 +500,6 @@ public class AuthConfigFactory {
         public String getConfigMapKey() {
             return configMapKey;
         }
-    };
+    }
 
 }

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -19,7 +19,7 @@
               <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
               <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
               <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
-              <package>org.apache.maven.plugins:maven-jar-plugin:jar,${project.groupId}:${project.artifactId}:build</package>
+              <package>org.apache.maven.plugins:maven-jar-plugin:jar,${project.groupId}:${project.artifactId}:build-nofork</package>
               <pre-integration-test>${project.groupId}:${project.artifactId}:start</pre-integration-test>
               <integration-test>org.apache.maven.plugins:maven-failsafe-plugin:integration-test</integration-test>
               <verify>${project.groupId}:${project.artifactId}:stop,org.apache.maven.plugins:maven-failsafe-plugin:verify</verify>
@@ -44,7 +44,7 @@
               <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
               <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
               <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
-              <package>org.apache.maven.plugins:maven-jar-plugin:jar,${project.groupId}:${project.artifactId}:build</package>
+              <package>org.apache.maven.plugins:maven-jar-plugin:jar,${project.groupId}:${project.artifactId}:build-nofork</package>
               <deploy>${project.groupId}:${project.artifactId}:push</deploy>
             </phases>
           </lifecycle>

--- a/src/test/java/io/fabric8/maven/docker/access/ecr/AwsSigner4RequestTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ecr/AwsSigner4RequestTest.java
@@ -1,0 +1,68 @@
+package io.fabric8.maven.docker.access.ecr;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.fabric8.maven.docker.access.AuthConfig;
+
+/**
+ * Test aws request signing
+ *
+ * @author chas
+ * @since 2016-12-21
+ */
+public class AwsSigner4RequestTest {
+
+    private static final String TASK1 = "POST\n"
+            + "/\n"
+            + "\n"
+            + "content-type:application/x-amz-json-1.1\n"
+            + "host:ecr.us-east-1.amazonaws.com\n"
+            + "x-amz-target:AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken\n"
+            + "\n"
+            + "content-type;host;x-amz-target\n"
+            + "1531fbe1f1c4e3437223a1583a6d21d404acf9d910262f629d73d6bf55a545bd";
+
+    private static final String TASK2 = "AWS4-HMAC-SHA256\n"
+            + "20150830T123600Z\n"
+            + "20150830/us-east-1/service/aws4_request\n"
+            + "7c945a283983ca83301de46103427b7035344a4b0cfddd886e3d94b4bed7df5e";
+
+    private static final String TASK3 = "89cd649587898a1913ced5c519425905b192c4662212d37e689e6c20e53edbbd";
+
+    private static final String TASK4 = "AWS4-HMAC-SHA256 "
+            + "Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, "
+            + "SignedHeaders=content-type;host;x-amz-target, "
+            + "Signature=89cd649587898a1913ced5c519425905b192c4662212d37e689e6c20e53edbbd";
+
+    @Test
+    public void testSign() throws Exception {
+        HttpPost request = new HttpPost("https://ecr.us-east-1.amazonaws.com/");
+        request.setHeader("host", "ecr.us-east-1.amazonaws.com");
+        request.setHeader("Content-Type", "application/x-amz-json-1.1");
+        request.setHeader("X-Amz-Target", "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken");
+        request.setEntity(new StringEntity("{\"registryIds\":[\"012345678901\"]}", StandardCharsets.UTF_8));
+
+        AwsSigner4 signer = new AwsSigner4("us-east-1", "ecr");
+
+        Date signingTime = AwsSigner4Request.TIME_FORMAT.parse("20150830T123600Z");
+        AwsSigner4Request sr = new AwsSigner4Request("us-east-1", "service", request, signingTime);
+        AuthConfig credentials = new AuthConfig("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", null, null);
+ 
+        Assert.assertEquals(TASK1, signer.task1(sr));
+
+        Assert.assertEquals(TASK2, signer.task2(sr));
+
+        StringBuilder dst = new StringBuilder();
+        AwsSigner4.hexEncode(dst, signer.task3(sr, credentials));
+        Assert.assertEquals(TASK3, dst.toString());
+
+        Assert.assertEquals(TASK4, signer.task4(sr, credentials));
+    }
+
+}

--- a/src/test/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuthTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuthTest.java
@@ -1,0 +1,92 @@
+package io.fabric8.maven.docker.access.ecr;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.util.Logger;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Date;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Test exchange of local stored credentials for temporary ecr credentials
+ *
+ * @author chas
+ * @since 2016-12-21
+ */
+public class EcrExtendedAuthTest {
+
+    @Mocked
+    private Logger logger;
+
+    @Test
+    public void testIsNotAws() {
+        assertFalse(new EcrExtendedAuth(logger, "jolokia").isValidRegistry());
+    }
+
+    @Test
+    public void testIsAws() {
+        assertTrue(new EcrExtendedAuth(logger, "123456789012.dkr.ecr.eu-west-1.amazonaws.com").isValidRegistry());
+    }
+
+    @Test
+    public void testHeaders() throws ParseException {
+        EcrExtendedAuth eea = new EcrExtendedAuth(logger, "123456789012.dkr.ecr.eu-west-1.amazonaws.com");
+        AuthConfig localCredentials = new AuthConfig("username", "password", null, null);
+        Date signingTime = AwsSigner4Request.TIME_FORMAT.parse("20161217T211058Z");
+        HttpPost request = eea.createSignedRequest(localCredentials, signingTime);
+        assertEquals("ecr.eu-west-1.amazonaws.com", request.getFirstHeader("host").getValue());
+        assertEquals("20161217T211058Z", request.getFirstHeader("X-Amz-Date").getValue());
+        assertEquals("AWS4-HMAC-SHA256 Credential=username/20161217/eu-west-1/ecr/aws4_request, SignedHeaders=content-type;host;x-amz-target, Signature=1bab0f5c269debe913e532011d5d192b190bb4c55d3de1bc1506eefb93e058e1", request.getFirstHeader("Authorization").getValue());
+    }
+
+    @Test
+    public void testClientClosedAndCredentialsDecoded(@Mocked final CloseableHttpClient closeableHttpClient,
+            @Mocked final CloseableHttpResponse closeableHttpResponse,
+            @Mocked final StatusLine statusLine)
+            throws IOException, MojoExecutionException {
+
+        final HttpEntity entity = new StringEntity("{\"authorizationData\": [{"
+          +"\"authorizationToken\": \"QVdTOnBhc3N3b3Jk\","
+          +"\"expiresAt\": 1448878779.809,"
+          +"\"proxyEndpoint\": \"https://012345678910.dkr.ecr.eu-west-1.amazonaws.com\"}]}");
+
+        new Expectations() {{
+            statusLine.getStatusCode(); result = 200;
+            closeableHttpResponse.getEntity(); result = entity;
+        }};
+        EcrExtendedAuth eea = new EcrExtendedAuth(logger, "123456789012.dkr.ecr.eu-west-1.amazonaws.com") {
+            CloseableHttpClient createClient() {
+                return closeableHttpClient;
+            }
+        };
+
+        AuthConfig localCredentials = new AuthConfig("username", "password", null, null);
+        AuthConfig awsCredentials = eea.extendedAuth(localCredentials);
+        assertEquals("AWS", awsCredentials.getUsername());
+        assertEquals("password", awsCredentials.getPassword());
+
+        new Verifications() {{
+             closeableHttpClient.close();
+         }};
+    }
+
+}

--- a/src/test/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuthTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuthTest.java
@@ -1,7 +1,5 @@
 package io.fabric8.maven.docker.access.ecr;
 
-import static org.junit.Assert.*;
-
 import org.junit.Test;
 
 import io.fabric8.maven.docker.access.AuthConfig;
@@ -39,12 +37,12 @@ public class EcrExtendedAuthTest {
 
     @Test
     public void testIsNotAws() {
-        assertFalse(new EcrExtendedAuth(logger, "jolokia").isValidRegistry());
+        assertFalse(new EcrExtendedAuth(logger, "jolokia").isAwsRegistry());
     }
 
     @Test
     public void testIsAws() {
-        assertTrue(new EcrExtendedAuth(logger, "123456789012.dkr.ecr.eu-west-1.amazonaws.com").isValidRegistry());
+        assertTrue(new EcrExtendedAuth(logger, "123456789012.dkr.ecr.eu-west-1.amazonaws.com").isAwsRegistry());
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/log/DefaultLogCallbackTest.java
+++ b/src/test/java/io/fabric8/maven/docker/log/DefaultLogCallbackTest.java
@@ -1,0 +1,173 @@
+package io.fabric8.maven.docker.log;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.fabric8.maven.docker.access.log.LogCallback;
+import io.fabric8.maven.docker.access.log.LogCallback.DoneException;
+import io.fabric8.maven.docker.util.Timestamp;
+
+public class DefaultLogCallbackTest {
+
+    private Path path;
+
+    private LogOutputSpec spec;
+
+    private LogCallback callback;
+
+    private Timestamp ts;
+
+    @Before
+    public void before() throws FileNotFoundException {
+        path = Paths.get("target", "one.log");
+        path.toFile().delete();
+        spec = new LogOutputSpec.Builder().prefix("callback-test")
+                .file(path.toString()).build();
+        callback = new DefaultLogCallback(spec);
+        ts = new Timestamp("2016-12-21T15:09:00.999666333Z");
+    }
+
+    @Test
+    public void shouldLogSequentially() throws IOException, DoneException {
+        callback.log(1, ts, "line 1");
+        callback.log(1, ts, "line 2");
+        callback.close();
+
+        List<String> lines = Files.readAllLines(path);
+        assertThat(lines, contains("callback-test> line 1", "callback-test> line 2"));
+    }
+
+    @Test
+    public void shouldLogError() throws IOException, DoneException {
+        callback.error("error 1");
+        callback.log(1, ts, "line 2");
+        callback.error("error 3");
+        callback.close();
+
+        List<String> lines = Files.readAllLines(path);
+        assertThat(lines, contains("error 1", "callback-test> line 2", "error 3"));
+    }
+
+    @Test
+    public void shouldLogToStdout() throws IOException, DoneException {
+        // we don't need the default stream for this test
+        callback.close();
+
+        path = Paths.get("target", "stdout.log");
+        FileOutputStream os = new FileOutputStream(path.toFile());
+        PrintStream ps = new PrintStream(os);
+        PrintStream stdout = System.out;
+        try {
+            System.setOut(ps);
+            spec = new LogOutputSpec.Builder().prefix("stdout")
+                    .build();
+            callback = new DefaultLogCallback(spec);
+            DefaultLogCallback callback2 = new DefaultLogCallback(spec);
+
+            callback.log(1, ts, "line 1");
+            callback2.log(1, ts, "line 2");
+            callback.log(1, ts, "line 3");
+            callback.close();
+            callback2.log(1, ts, "line 4");
+            callback2.close();
+
+            List<String> lines = Files.readAllLines(path);
+            assertThat(lines, contains("stdout> line 1", "stdout> line 2", "stdout> line 3", "stdout> line 4"));
+        } finally {
+            System.setOut(stdout);
+        }
+    }
+
+    @Test
+    public void shouldKeepStreamOpen() throws IOException, DoneException {
+        DefaultLogCallback callback2 = new DefaultLogCallback(spec);
+
+        callback.log(1, ts, "line 1");
+        callback2.log(1, ts, "line 2");
+        callback.log(1, ts, "line 3");
+        callback.close();
+        callback2.log(1, ts, "line 4");
+        callback2.close();
+
+        List<String> lines = Files.readAllLines(path);
+        assertThat(lines,
+                contains("callback-test> line 1", "callback-test> line 2", "callback-test> line 3", "callback-test> line 4"));
+    }
+
+    @Test
+    public void shouldLogInParallel() throws IOException, DoneException, InterruptedException {
+        DefaultLogCallback callback2 = new DefaultLogCallback(spec);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        LoggerTask task1 = new LoggerTask(callback, 1);
+        LoggerTask task2 = new LoggerTask(callback2, 11);
+        executorService.submit(task1);
+        executorService.submit(task2);
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.SECONDS);
+
+        List<String> lines = Files.readAllLines(path);
+        assertThat(lines.size(), is(20));
+
+        // fill set with expected line numbers
+        Set<Integer> indexes = new HashSet<>();
+        for (int i = 1; i <= 20; i++) {
+            indexes.add(i);
+        }
+
+        // remove found line numbers from set
+        for (String line : lines) {
+            String prefix = "callback-test> line ";
+            assertThat(line, startsWith(prefix));
+            String suffix = line.substring(prefix.length());
+            indexes.remove(Integer.parseInt(suffix));
+        }
+
+        // expect empty set
+        assertThat(indexes, is(empty()));
+    }
+
+    private class LoggerTask implements Runnable {
+
+        private LogCallback cb;
+
+        private int start;
+
+        LoggerTask(LogCallback cb, int start) {
+            this.cb = cb;
+            this.start = start;
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; i < 10; i++) {
+                try {
+                    callback.log(1, ts, "line " + (start + i));
+                } catch (DoneException e) {
+                    // ignore
+                }
+            }
+            cb.close();
+        }
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -357,8 +357,8 @@ public class RunServiceTest {
         return new RestartPolicy.Builder().name("on-failure").retry(1).build();
     }
 
-    private VolumeConfiguration volumeConfiguration() {
-        return new VolumeConfiguration.Builder()
+    private RunVolumeConfiguration volumeConfiguration() {
+        return new RunVolumeConfiguration.Builder()
                 .bind(bind())
                 .from(volumesFrom())
                 .build();

--- a/src/test/java/io/fabric8/maven/docker/service/VolumeServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/VolumeServiceTest.java
@@ -1,0 +1,109 @@
+package io.fabric8.maven.docker.service;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.access.VolumeCreateConfig;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONParser;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+/**
+ *  Basic Unit Tests for {@link VolumeService}
+ *
+ *  @author Tom Burton
+ *  @version Dec 16, 2016
+ */
+public class VolumeServiceTest {
+   private VolumeCreateConfig volumeConfig;
+
+   @Mocked
+   private DockerAccess docker;
+
+   /*
+    * methods to test
+    *
+    * volumeService.createVolumeConfig(volumeName, driver, driverOpts, labels);
+    * volumeService.removeVolume(volumeName);
+    */
+
+   private Map<String, String > withMap(String what) {
+      Map<String, String> map = new HashMap<String, String>();
+      map.put(what + "Key1", "value1");
+      map.put(what + "Key2", "value2");
+
+      return map;
+   }
+
+   @Test
+   public void testCreateVolumeConfig() throws Exception {
+      final VolumeConfiguration config =
+          new VolumeConfiguration.Builder()
+              .name("testVolume")
+              .driver("test")
+              .opts(withMap("opts"))
+              .labels(withMap("labels"))
+              .build();
+
+      new Expectations() {{
+         // Use a 'delegate' to verify the argument given directly. No need
+         // for an 'intermediate' return method in the service just to check this.
+         docker.createVolume(with(new Delegate<VolumeCreateConfig>() {
+            void check(VolumeCreateConfig vcc) {
+               assertThat(vcc.getName(), is("testVolume"));
+               JSONObject vccJson = (JSONObject) JSONParser.parseJSON(vcc.toJson());
+               assertEquals(vccJson.get("Driver"), "test");
+            }
+         })); result = "testVolume";
+      }};
+
+      String volume = new VolumeService(docker).createVolume(config);
+      assertEquals(volume, "testVolume");
+   }
+
+   @Test
+   public void testCreateVolume() throws Exception {
+      VolumeConfiguration vc = new VolumeConfiguration.Builder()
+                                     .name("testVolume")
+                                     .driver("test").opts(withMap("opts"))
+                                     .labels(withMap("labels"))
+                                     .build();
+
+      new Expectations() {{
+         docker.createVolume((VolumeCreateConfig)any); result = "testVolume";
+      }};
+
+      assertThat(vc.getName(), is("testVolume"));
+      String name = new VolumeService(docker).createVolume(vc);
+
+      assertThat(name, is("testVolume"));
+   }
+
+   @Test
+   public void testRemoveVolume() throws Exception {
+      VolumeConfiguration vc = new VolumeConfiguration.Builder()
+            .name("testVolume")
+            .driver("test").opts(withMap("opts"))
+            .labels(withMap("labels"))
+            .build();
+
+      new Expectations() {{
+         docker.createVolume((VolumeCreateConfig) any); result = "testVolume";
+         docker.removeVolume("testVolume");
+      }};
+
+      VolumeService volumeService = new VolumeService(docker);
+      String name = volumeService.createVolume(vc);
+      volumeService.removeVolume(name);
+   }
+
+}

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.*;
  * @since 29.07.14
  */
 @RunWith(JMockit.class)
-public class AuthConfigFatoryTest {
+public class AuthConfigFactoryTest {
 
     public static final String ECR_NAME = "123456789012.dkr.ecr.bla.amazonaws.com";
 


### PR DESCRIPTION
This avoids corrupted log files.

Fixes #652.