### PR TITLE
Add Support for Creating Volumes Take #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ It works with Maven 3.0.5 and Docker 1.6.0 or later.
 | [`docker:remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:remove) | Remove images from local docker host  |
 | [`docker:logs`](https://fabric8io.github.io/docker-maven-plugin/#docker:logs)     | Show container logs                   |
 | [`docker:source`](https://fabric8io.github.io/docker-maven-plugin/#docker:source) | Attach docker build archive to Maven project |
-| [`docker:volume-create`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-create) | Attach docker build archive to Maven project |
-| [`docker:volume-remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-remove) | Attach docker build archive to Maven project |
+| [`docker:volume-create`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-create) | Create a volume to share data between containers |
+| [`docker:volume-remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-remove) | Remove a created volume |
 
 #### Documentation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ It works with Maven 3.0.5 and Docker 1.6.0 or later.
 | [`docker:push`](https://fabric8io.github.io/docker-maven-plugin/#docker:push)     | Push images to a registry             |
 | [`docker:remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:remove) | Remove images from local docker host  |
 | [`docker:logs`](https://fabric8io.github.io/docker-maven-plugin/#docker:logs)     | Show container logs                   |
-| [`docker:source`](https://fabric8io.github.io/docker-maven-plugin/#docker:source)   | Attach docker build archive to Maven project |
+| [`docker:source`](https://fabric8io.github.io/docker-maven-plugin/#docker:source) | Attach docker build archive to Maven project |
+| [`docker:volume-create`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-create) | Attach docker build archive to Maven project |
+| [`docker:volume-remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-remove) | Attach docker build archive to Maven project |
 
 #### Documentation
 

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -15,15 +15,14 @@ completely managed internally.
 
 One purpose of this plugin is to create docker images holding the
 actual application. This is done with the `docker:build` goal.  It
-is easy to include build artifacts and their dependencies into an
-image. Therefore, this plugin uses the
+is easy to include build artifacts and their dependencies into an image. 
+Therefore, this plugin uses the
 [assembly descriptor format](http://maven.apache.org/plugins/maven-assembly-plugin/assembly.html)
 from the
 [maven-assembly-plugin](http://maven.apache.org/plugins/maven-assembly-plugin/)
-to specify the content which will be added from a sub-directory in
-the image (`/maven` by default). Images that are built with this
-plugin can be pushed to public or private Docker registries with
-`docker:push`.
+to specify the content which will be added from a sub-directory in the image 
+(`/maven` by default). Images that are built with this plugin can be pushed 
+to public or private Docker registries with `docker:push`.
 
 ### Running containers
 
@@ -37,8 +36,9 @@ together or share data via volumes. Containers are created and started
 with the `docker:start` goal and stopped and destroyed with the
 `docker:stop` goal. For integration tests both goals are typically
 bound to the the `pre-integration-test` and `post-integration-test` phase,
-respectively. It is recommended to use the [`maven-failsafe-plugin`](http://maven.apache.org/surefire/maven-failsafe-plugin/) for
-integration testing in order to stop the docker container even when
+respectively. It is recommended to use the 
+[`maven-failsafe-plugin`](http://maven.apache.org/surefire/maven-failsafe-plugin/) 
+for integration testing in order to stop the docker container even when
 the tests fail.
 
 For proper isolation, container exposed ports can be dynamically and
@@ -202,5 +202,5 @@ The high-level design goals and initial motiviation fort this plugin are:
   
 So, final words: Enjoy this plugin, and please use the
 [issue tracker](https://github.com/fabric8io/docker-maven-plugin/issues)
-for anything what hurts, or when you have a wish list. 
+for anything that hurts, or when you have a wish list. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,8 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.19-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
-
 
   <name>docker-maven-plugin</name>
   <description>Docker Maven Plugin</description>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -26,8 +26,9 @@
 
   <url>http://www.jolokia.org</url>
 
+  <!-- Should this reference the outer directory as a parent pom instead?  -->
   <properties>
-    <docker.maven.plugin.version>0.17-SNAPSHOT</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.19-SNAPSHOT</docker.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -47,6 +48,7 @@
   <modules>
     <module>net</module>
     <module>custom-net</module>
+    <module>volume</module>
     <module>properties</module>
     <module>dockerignore</module>
     <module>docker-compose-demo</module>

--- a/samples/volume/pom.xml
+++ b/samples/volume/pom.xml
@@ -1,0 +1,61 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!--
+  Sample project for demonstrating the volume creation feature
+
+  
+  Call it with 'mvn docker:create-volume'.
+  or
+  Call it with 'mvn docker:verify'
+  It will create the volume "newVolume"
+  -->
+
+  <parent>
+    <groupId>io.fabric8</groupId>
+    <artifactId>dmp-sample-parent</artifactId>
+    <version>0.18-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>volume</artifactId>
+  <version>0.18-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <verbose>true</verbose>
+          <autoPull>always</autoPull>
+          <startParallel>true</startParallel>
+          <volumes>
+            <volume>
+              <name>newVolume</name>
+            </volume>
+          </volumes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>start</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>volume-create</goal>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/samples/volume/pom.xml
+++ b/samples/volume/pom.xml
@@ -51,6 +51,7 @@
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
+              <goal>volume-remove</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/asciidoc/inc/_docker-volume-create.adoc
+++ b/src/main/asciidoc/inc/_docker-volume-create.adoc
@@ -5,7 +5,7 @@
 Removes a volume
 
 Docker Volumes are configured outside of Docker Images/Containers, 
-and can be references by them.
+and can be referenced by them.
 
 *Example:*
 
@@ -30,7 +30,7 @@ and can be references by them.
 </plugin>
 ----
 
-[[Volume-Configuration]]
+[[volume-configuration]]
 === Configuration
 
 The Sample Above Shows Several Fields.
@@ -38,10 +38,10 @@ Name is the only required field.  It's used so the plugin knows which volume to 
 
 .Volume Configuration
 [options="header"]
-|===============================================================================
+|===
 | Field Name   | Description 
 | *name*       | Name of the Volume
 | *driver*     | Driver to use for creating the volume
 | *driverOpts* | Driver Specific options passed in as custom `<key>value</key>` where its maps to key=value for driver opts from the command line. 
 | *labels*     | labels passed in as custom `<key>value</key>` similar to images
-|===============================================================================
+|===

--- a/src/main/asciidoc/inc/_docker-volume-create.adoc
+++ b/src/main/asciidoc/inc/_docker-volume-create.adoc
@@ -1,0 +1,47 @@
+
+[[docker:volume-remove]]
+== *docker:volume-remove*
+
+Removes a volume
+
+Docker Volumes are configured outside of Docker Images/Containers, 
+and can be references by them.
+
+*Example:*
+
+[source,xml]
+----
+<plugin>
+  <configuration>
+    <volumes>
+       <volume>
+         <name>myVolumeName</name>
+         <driver>Local</Driver>
+         <driverOpts>
+           <someKey>someValue</someKey>
+         </driverOpts>
+         <labels>
+           <someKey>someValue</someKey>
+         </labels>
+       </volume>
+    </volumes>
+    ...
+  </configuration>
+</plugin>
+----
+
+[[Volume-Configuration]]
+=== Configuration
+
+The Sample Above Shows Several Fields.
+Name is the only required field.  It's used so the plugin knows which volume to remove.
+
+.Volume Configuration
+[options="header"]
+|===============================================================================
+| Field Name   | Description 
+| *name*       | Name of the Volume
+| *driver*     | Driver to use for creating the volume
+| *driverOpts* | Driver Specific options passed in as custom `<key>value</key>` where its maps to key=value for driver opts from the command line. 
+| *labels*     | labels passed in as custom `<key>value</key>` similar to images
+|===============================================================================

--- a/src/main/asciidoc/inc/_docker-volume-remove.adoc
+++ b/src/main/asciidoc/inc/_docker-volume-remove.adoc
@@ -5,7 +5,7 @@
 Creates a volume for use when storing data to be read by multiple containers.
 
 Docker Volumes are configured outside of Docker Images/Containers, 
-and can be references by them.
+and can be referenced by them.
 
 *Example:*
 
@@ -30,7 +30,7 @@ and can be references by them.
 </plugin>
 ----
 
-[[Volume-Configuration]]
+[[volume-configuration]]
 === Configuration
 
 The Sample Above Shows Several Fields.
@@ -38,10 +38,10 @@ Except for Name the fields are optional
 
 .Volume Configuration
 [options="header"]
-|===============================================================================
+|===
 | Field Name   | Description 
 | *name*       | Name of the Volume
 | *driver*     | Driver to use for creating the volume
 | *driverOpts* | Driver Specific options passed in as custom `<key>value</key>` where its maps to key=value for driver opts from the command line. 
 | *labels*     | labels passed in as custom `<key>value</key>` similar to images
-|===============================================================================
+|===

--- a/src/main/asciidoc/inc/_docker-volume-remove.adoc
+++ b/src/main/asciidoc/inc/_docker-volume-remove.adoc
@@ -1,0 +1,47 @@
+
+[[docker:volume-create]]
+== *docker:volume-create*
+
+Creates a volume for use when storing data to be read by multiple containers.
+
+Docker Volumes are configured outside of Docker Images/Containers, 
+and can be references by them.
+
+*Example:*
+
+[source,xml]
+----
+<plugin>
+  <configuration>
+    <volumes>
+       <volume>
+         <name>myVolumeName</name>
+         <driver>Local</Driver>
+         <driverOpts>
+           <someKey>someValue</someKey>
+         </driverOpts>
+         <labels>
+           <someKey>someValue</someKey>
+         </labels>
+       </volume>
+    </volumes>
+    ...
+  </configuration>
+</plugin>
+----
+
+[[Volume-Configuration]]
+=== Configuration
+
+The Sample Above Shows Several Fields.
+Except for Name the fields are optional
+
+.Volume Configuration
+[options="header"]
+|===============================================================================
+| Field Name   | Description 
+| *name*       | Name of the Volume
+| *driver*     | Driver to use for creating the volume
+| *driverOpts* | Driver Specific options passed in as custom `<key>value</key>` where its maps to key=value for driver opts from the command line. 
+| *labels*     | labels passed in as custom `<key>value</key>` similar to images
+|===============================================================================

--- a/src/main/asciidoc/inc/_goals.adoc
+++ b/src/main/asciidoc/inc/_goals.adoc
@@ -31,6 +31,12 @@ in the next sections.
 
 |**<<{plugin}:source>>**
 |Attach docker build archive to Maven project
+
+|**<<{plugin}:volume-create>>**
+|Create a volume for containers to share data
+
+|**<<{plugin}:volume-remove>>**
+|Remove a volume
 |===
 
 Note that all goals are orthogonal to each other. For example in order

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -34,6 +34,8 @@ include::inc/_docker-watch.adoc[]
 include::inc/_docker-remove.adoc[]
 include::inc/_docker-logs.adoc[]
 include::inc/_docker-source.adoc[]
+include::inc/_docker-volume-create.adoc[]
+include::inc/_docker-volume-remove.adoc[]
 
 include::inc/_external-configuration.adoc[]
 

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -26,6 +26,7 @@ import org.codehaus.plexus.context.ContextException;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.DockerMachineConfiguration;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
 import io.fabric8.maven.docker.config.handler.ImageConfigResolver;
 import io.fabric8.maven.docker.log.LogDispatcher;
 import io.fabric8.maven.docker.log.LogOutputSpecFactory;
@@ -148,6 +149,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     @Parameter
     Map authConfig;
 
+    /**
+     * volume configurations configured directly.
+     */
+    @Parameter
+    private List<VolumeConfiguration> volumes;
+    
     /**
      * Image configurations configured directly.
      */
@@ -321,7 +328,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         return ret;
     }
 
-    /**
+   /**
      * Override this if your mojo doesnt require access to a Docker host (like creating and attaching
      * docker tar archives)
      *
@@ -342,14 +349,20 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     // =============================================================================================
 
     /**
-     * Get all images to use. Can be restricted via -Ddocker.image to pick a one or more images. The values
-     * is taken as comma separated list.
+     * Get all images to use. Can be restricted via -Ddocker.image to pick a one or more images. 
+     * The values are taken as comma separated list.
      *
      * @return list of image configuration to use
      */
     protected List<ImageConfiguration> getResolvedImages() {
         return resolvedImages;
     }
+    
+    /**
+     *  getUser configured images
+     *  @return
+     */
+    protected List<VolumeConfiguration> getVolumes() { return volumes; }
 
     // Registry for managed containers
     private void setDockerHostAddressProperty(String dockerUrl) throws MojoFailureException {

--- a/src/main/java/io/fabric8/maven/docker/VolumeCreateMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/VolumeCreateMojo.java
@@ -34,8 +34,9 @@ public class VolumeCreateMojo extends AbstractDockerMojo
    {
       VolumeService volService = serviceHub.getVolumeService();
       
-      for ( VolumeConfiguration volume : getVolumes())
-      { volService.createVolume(volume); }
+      for ( VolumeConfiguration volume : getVolumes()) { 
+         volService.createVolume(volume); 
+      }
    }
 
 }

--- a/src/main/java/io/fabric8/maven/docker/VolumeCreateMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/VolumeCreateMojo.java
@@ -1,0 +1,41 @@
+package io.fabric8.maven.docker;
+
+
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
+import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.service.VolumeService;
+
+import java.lang.String;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ *  Mojo to Create Named Volumes prior to Docker container start
+ *  
+ *  @author Tom Burton
+ *  @version Dec 15, 2016
+ */
+@Mojo(name = "volume-create", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+public class VolumeCreateMojo extends AbstractDockerMojo
+{
+   
+   /** Default Constructor - Does Nothing */
+   public VolumeCreateMojo() { }
+
+   /* (non-Javadoc)
+    * @see io.fabric8.maven.docker.AbstractDockerMojo#executeInternal(io.fabric8.maven.docker.service.ServiceHub)
+    */
+   @Override
+   protected void executeInternal(ServiceHub serviceHub)
+         throws DockerAccessException, MojoExecutionException
+   {
+      VolumeService volService = serviceHub.getVolumeService();
+      
+      for ( VolumeConfiguration volume : getVolumes())
+      { volService.createVolume(volume); }
+   }
+
+}

--- a/src/main/java/io/fabric8/maven/docker/VolumeRemoveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/VolumeRemoveMojo.java
@@ -34,8 +34,9 @@ public class VolumeRemoveMojo extends AbstractDockerMojo
    {
       VolumeService volService = serviceHub.getVolumeService();
       
-      for ( VolumeConfiguration volume : getVolumes())
-      { volService.removeVolume(volume.getName()); }
+      for ( VolumeConfiguration volume : getVolumes()) { 
+         volService.removeVolume(volume.getName()); 
+      }
    }
 
 }

--- a/src/main/java/io/fabric8/maven/docker/VolumeRemoveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/VolumeRemoveMojo.java
@@ -1,0 +1,41 @@
+package io.fabric8.maven.docker;
+
+
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
+import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.service.VolumeService;
+
+import java.lang.String;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ *  Mojo to Create Named Volumes prior to Docker container start
+ *  
+ *  @author Tom Burton
+ *  @version Dec 15, 2016
+ */
+@Mojo(name = "volume-remove", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+public class VolumeRemoveMojo extends AbstractDockerMojo
+{
+   
+   /** Default Constructor - Does Nothing */
+   public VolumeRemoveMojo() { }
+
+   /* (non-Javadoc)
+    * @see io.fabric8.maven.docker.AbstractDockerMojo#executeInternal(io.fabric8.maven.docker.service.ServiceHub)
+    */
+   @Override
+   protected void executeInternal(ServiceHub serviceHub)
+         throws DockerAccessException, MojoExecutionException
+   {
+      VolumeService volService = serviceHub.getVolumeService();
+      
+      for ( VolumeConfiguration volume : getVolumes())
+      { volService.removeVolume(volume.getName()); }
+   }
+
+}

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -11,6 +11,7 @@ import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.log.LogOutputSpec;
 import io.fabric8.maven.docker.model.Container;
 import io.fabric8.maven.docker.model.Network;
+import io.fabric8.maven.docker.model.Volume;
 
 /**
  * Access to the <a href="http://docs.docker.io/en/latest/reference/api/docker_remote_api/">Docker API</a> which
@@ -246,4 +247,30 @@ public interface DockerAccess {
      * cleaning up things.
      */
     void shutdown();
+
+   /**
+    *  Create a volume for use by containers
+    *  
+    *  @param configuration volume configuration
+    *  @return the name of the Volume
+    *  @throws DockerAccessException if the volume could not be created.
+    */
+   String createVolume(VolumeCreateConfig configuration)
+         throws DockerAccessException;
+
+   /**
+    * Get a Volume
+    * 
+    * @param name volume name
+    * @return <code>VolumeDetails<code> representing the volume or null if none could be found
+    * @throws DockerAccessException if the volume could not be inspected
+    */
+   Volume getVolume(String name) throws DockerAccessException;
+
+   /**
+    * removes a volume
+    * @param name volume name to remove
+    * @throws DockerAccessException if the volume could not be removed
+    */
+   void removeVolume(String name) throws DockerAccessException;
 }

--- a/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
@@ -78,18 +78,7 @@ public final class UrlBuilder {
 
     public String listContainers(String ... filter) {
         Builder builder = u("containers/json");
-        if (filter.length > 0) {
-            if (filter.length % 2 != 0) {
-                throw new IllegalArgumentException("Filters must be given as key value pairs and not " +Arrays.asList(filter));
-            }
-            JSONObject filters = new JSONObject();
-            for (int i = 0; i < filter.length; i +=2) {
-                JSONArray value = new JSONArray();
-                value.put(filter[i+1]);
-                filters.put(filter[i],value);
-            }
-            builder.p("filters",filters.toString());
-        }
+        processFilters(builder, filter);
         return builder.build();
     }
 
@@ -160,6 +149,24 @@ public final class UrlBuilder {
                 .build();
     }
 
+    public String listVolumes(String... filter) { 
+       Builder builder = u("volumes");       
+       processFilters(builder, filter);
+       return builder.build();
+    }   
+    
+    public String createVolume() {
+       return u("volumes/create").build();
+    }
+    
+    public String inspectVolume(String name) {
+       return u("volumes/%s", name).build();
+    }
+    
+    public String removeVolume(String name) {
+       return u("volumes/%s", name).build();
+    }
+    
     public String getBaseUrl() {
         return baseUrl;
     }
@@ -203,6 +210,21 @@ public final class UrlBuilder {
         return String.format("%s/%s/%s", baseUrl, apiVersion, path);
     }
 
+    private void processFilters(Builder builder, String... filter)
+    {
+       if (filter.length > 0) {
+           if (filter.length % 2 != 0) {
+               throw new IllegalArgumentException("Filters must be given as key value pairs and not " +Arrays.asList(filter));
+           }
+           JSONObject filters = new JSONObject();
+           for (int i = 0; i < filter.length; i +=2) {
+               JSONArray value = new JSONArray();
+               value.put(filter[i+1]);
+               filters.put(filter[i],value);
+           }
+           builder.p("filters",filters.toString());
+       }
+    }
 
     private static class Builder {
 

--- a/src/main/java/io/fabric8/maven/docker/access/VolumeCreateConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/VolumeCreateConfig.java
@@ -1,0 +1,57 @@
+package io.fabric8.maven.docker.access;
+
+import java.io.*;
+import java.util.*;
+
+import io.fabric8.maven.docker.util.EnvUtil;
+import org.apache.commons.lang3.text.StrSubstitutor;
+import io.fabric8.maven.docker.config.Arguments;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class VolumeCreateConfig 
+{
+    private final JSONObject createConfig = new JSONObject();
+    private final String name;
+
+    public VolumeCreateConfig(String name) 
+    {
+        this.name = name;
+        add("Name", name);
+    }
+
+    public VolumeCreateConfig driver(String driver) 
+    { return add("Driver", driver); }
+    
+    public VolumeCreateConfig driverOpts(Map<String, String> driverOpts) 
+    { 
+       if (driverOpts != null && driverOpts.size() > 0) 
+       { add("DriverOpts", new JSONObject(driverOpts)); }
+       return this; 
+    }
+    
+    public VolumeCreateConfig labels(Map<String,String> labels) 
+    {
+        if (labels != null && labels.size() > 0) 
+        { add("Labels", new JSONObject(labels)); }
+        return this;
+    }
+    
+    public String getVolumeName() { return name; }
+
+    /**
+     * Get JSON which is used for <em>creating</em> a volume
+     *
+     * @return string representation for JSON representing creating a volume
+     */
+    public String toJson() { return createConfig.toString(); }
+
+    // =======================================================================
+
+    private VolumeCreateConfig add(String name, Object value) 
+    {
+        if (value != null) { createConfig.put(name, value); }
+        return this;
+    }
+
+}

--- a/src/main/java/io/fabric8/maven/docker/access/VolumeCreateConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/VolumeCreateConfig.java
@@ -20,20 +20,23 @@ public class VolumeCreateConfig
         add("Name", name);
     }
 
-    public VolumeCreateConfig driver(String driver) 
-    { return add("Driver", driver); }
+    public VolumeCreateConfig driver(String driver) { 
+       return add("Driver", driver); 
+    }
     
     public VolumeCreateConfig driverOpts(Map<String, String> driverOpts) 
     { 
-       if (driverOpts != null && driverOpts.size() > 0) 
-       { add("DriverOpts", new JSONObject(driverOpts)); }
+       if (driverOpts != null && driverOpts.size() > 0) { 
+          add("DriverOpts", new JSONObject(driverOpts)); 
+       }
        return this; 
     }
     
     public VolumeCreateConfig labels(Map<String,String> labels) 
     {
-        if (labels != null && labels.size() > 0) 
-        { add("Labels", new JSONObject(labels)); }
+        if (labels != null && labels.size() > 0) { 
+           add("Labels", new JSONObject(labels)); 
+        }
         return this;
     }
     

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -86,7 +86,7 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
     }
 
     private void addVolumes(RunImageConfiguration runConfig, List<String> ret) {
-        VolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
+        ImageVolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
         if (volConfig != null) {
             List<String> volumeImages = volConfig.getFrom();
             if (volumeImages != null) {

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -86,7 +86,7 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
     }
 
     private void addVolumes(RunImageConfiguration runConfig, List<String> ret) {
-        ImageVolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
+        RunVolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
         if (volConfig != null) {
             List<String> volumeImages = volConfig.getFrom();
             if (volumeImages != null) {

--- a/src/main/java/io/fabric8/maven/docker/config/ImageVolumeConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageVolumeConfiguration.java
@@ -1,0 +1,95 @@
+package io.fabric8.maven.docker.config;/*
+ *
+ * Copyright 2014 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.Serializable;
+import java.util.*;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Run configuration for volumes.
+ *
+ * @author roland
+ * @since 08/12/14
+ */
+public class ImageVolumeConfiguration implements Serializable {
+
+    /**
+     * List of images names from where volumes are mounted
+     */
+    @Parameter
+    private List<String> from;
+
+    /**
+     * List of bind parameters for binding/mounting host directories
+     * into the container
+     */
+    @Parameter
+    private List<String> bind;
+
+    /**
+     * List of images to mount from
+     *
+     * @return images
+     */
+    public List<String> getFrom() {
+        return from;
+    }
+
+    /**
+     * List of docker bind specification for mounting local directories
+     * @return list of bind specs
+     */
+    public List<String> getBind() {
+        return bind;
+    }
+
+    // ===========================================
+
+    public static class Builder {
+
+        private ImageVolumeConfiguration config = new ImageVolumeConfiguration();
+
+        public Builder() {
+            this.config = new ImageVolumeConfiguration();
+        }
+
+        public Builder from(List<String> args) {
+            if (args != null) {
+                if (config.from == null) {
+                    config.from = new ArrayList<>();
+                }
+                config.from.addAll(args);
+            }
+            return this;
+        }
+
+        public Builder bind(List<String> args) {
+            if (args != null) {
+                if (config.bind == null) {
+                    config.bind = new ArrayList<>();
+                }
+                config.bind.addAll(args);
+            }
+            return this;
+        }
+
+        public ImageVolumeConfiguration build() {
+            return config;
+        }
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -119,7 +119,7 @@ public class RunImageConfiguration implements Serializable {
 
     // Mount volumes from the given image's started containers
     @Parameter
-    private VolumeConfiguration volumes;
+    private ImageVolumeConfiguration volumes;
 
     // Links to other container started
     @Parameter
@@ -267,7 +267,7 @@ public class RunImageConfiguration implements Serializable {
         return extraHosts;
     }
 
-    public VolumeConfiguration getVolumeConfiguration() {
+    public ImageVolumeConfiguration getVolumeConfiguration() {
         return volumes;
     }
 
@@ -468,7 +468,7 @@ public class RunImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder volumes(VolumeConfiguration volumes) {
+        public Builder volumes(ImageVolumeConfiguration volumes) {
             config.volumes = volumes;
             return this;
         }

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -119,7 +119,7 @@ public class RunImageConfiguration implements Serializable {
 
     // Mount volumes from the given image's started containers
     @Parameter
-    private ImageVolumeConfiguration volumes;
+    private RunVolumeConfiguration volumes;
 
     // Links to other container started
     @Parameter
@@ -267,7 +267,7 @@ public class RunImageConfiguration implements Serializable {
         return extraHosts;
     }
 
-    public ImageVolumeConfiguration getVolumeConfiguration() {
+    public RunVolumeConfiguration getVolumeConfiguration() {
         return volumes;
     }
 
@@ -468,7 +468,7 @@ public class RunImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder volumes(ImageVolumeConfiguration volumes) {
+        public Builder volumes(RunVolumeConfiguration volumes) {
             config.volumes = volumes;
             return this;
         }

--- a/src/main/java/io/fabric8/maven/docker/config/RunVolumeConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunVolumeConfiguration.java
@@ -26,7 +26,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @author roland
  * @since 08/12/14
  */
-public class ImageVolumeConfiguration implements Serializable {
+public class RunVolumeConfiguration implements Serializable {
 
     /**
      * List of images names from where volumes are mounted
@@ -62,10 +62,10 @@ public class ImageVolumeConfiguration implements Serializable {
 
     public static class Builder {
 
-        private ImageVolumeConfiguration config = new ImageVolumeConfiguration();
+        private RunVolumeConfiguration config = new RunVolumeConfiguration();
 
         public Builder() {
-            this.config = new ImageVolumeConfiguration();
+            this.config = new RunVolumeConfiguration();
         }
 
         public Builder from(List<String> args) {
@@ -88,7 +88,7 @@ public class ImageVolumeConfiguration implements Serializable {
             return this;
         }
 
-        public ImageVolumeConfiguration build() {
+        public RunVolumeConfiguration build() {
             return config;
         }
     }

--- a/src/main/java/io/fabric8/maven/docker/config/VolumeConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/VolumeConfiguration.java
@@ -1,95 +1,113 @@
-package io.fabric8.maven.docker.config;/*
- *
- * Copyright 2014 Roland Huss
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+package io.fabric8.maven.docker.config;
+
+
+import io.fabric8.maven.docker.config.ImageConfiguration.Builder;
+import io.fabric8.maven.docker.util.DeepCopy;
 
 import java.io.Serializable;
-import java.util.*;
+import java.lang.String;
+import java.util.Map;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
- * Run configuration for volumes.
- *
- * @author roland
- * @since 08/12/14
+ *  Volume Configuration for Volumes to be created prior to container start
+ *  
+ *  @author Tom Burton
+ *  @version Dec 15, 2016
  */
-public class VolumeConfiguration implements Serializable {
+public class VolumeConfiguration implements Serializable
+{
+   /** Volume Name */
+   @Parameter
+   private String name;
+    
+   /** Docker Driver for mounting the volume */
+   @Parameter
+   private String driver;
+   
+   /** Driver specific options */
+   @Parameter
+   private Map<String, String> driverOpts;
+   
+   /** volume labels */
+   @Parameter
+   private Map<String, String> labels;
 
-    /**
-     * List of images names from where volumes are mounted
-     */
-    @Parameter
-    private List<String> from;
+   /** 
+    *  get the name of this volume
+    *  @return
+    */
+   public String getName() { return name; }
 
-    /**
-     * List of bind parameters for binding/mounting host directories
-     * into the container
-     */
-    @Parameter
-    private List<String> bind;
+   /**
+    *  get the docker driver for used to mounting the volume
+    *  @return
+    */
+   public String getDriver() { return driver; }
 
-    /**
-     * List of images to mount from
-     *
-     * @return images
-     */
-    public List<String> getFrom() {
-        return from;
-    }
+   /**
+    *  get driver specific options
+    *  @return
+    */
+   public Map<String, String> getDriverOpts() { return driverOpts; }
 
-    /**
-     * List of docker bind specification for mounting local directories
-     * @return list of bind specs
-     */
-    public List<String> getBind() {
-        return bind;
-    }
+   /**
+    *  get volume labels
+    *  @return
+    */
+   public Map<String, String> getLabels() { return labels; }
 
-    // ===========================================
+   /** Default Constructor - Does Nothing */
+   public VolumeConfiguration() { }
 
-    public static class Builder {
+   
+   /*
+    * =======================================================================
+    * Builder For Volume Configurations
+    * ======================================================================= 
+    */
 
-        private VolumeConfiguration config = new VolumeConfiguration();
+   public static final Builder builder() { return new Builder(); }
+   
+   public static class Builder 
+   {
+       private final VolumeConfiguration config;
 
-        public Builder() {
-            this.config = new VolumeConfiguration();
-        }
+       public Builder()  { this(null); }
 
-        public Builder from(List<String> args) {
-            if (args != null) {
-                if (config.from == null) {
-                    config.from = new ArrayList<>();
-                }
-                config.from.addAll(args);
-            }
-            return this;
-        }
+       public Builder(VolumeConfiguration that) 
+       {
+          if (that == null) { this.config = new VolumeConfiguration(); } 
+          else { this.config = DeepCopy.copy(that); }
+       }
 
-        public Builder bind(List<String> args) {
-            if (args != null) {
-                if (config.bind == null) {
-                    config.bind = new ArrayList<>();
-                }
-                config.bind.addAll(args);
-            }
-            return this;
-        }
+       public Builder name(String name) 
+       {
+           config.name = name;
+           return this;
+       }
+       
+       public Builder driver(String driver) 
+       {
+           config.driver = driver;
+           return this;
+       }
 
-        public VolumeConfiguration build() {
-            return config;
-        }
-    }
+       public Builder driverOpts(Map<String, String> driverOpts) 
+       {
+           config.driverOpts = driverOpts;
+           return this;
+       }
+       
+       public Builder labels(Map<String, String> labels) 
+       {
+           config.labels = labels;
+           return this;
+       }
+       
+       public VolumeConfiguration build() { return config; }
+       
+   }
+   
 }

--- a/src/main/java/io/fabric8/maven/docker/config/VolumeConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/VolumeConfiguration.java
@@ -78,8 +78,12 @@ public class VolumeConfiguration implements Serializable
 
        public Builder(VolumeConfiguration that) 
        {
-          if (that == null) { this.config = new VolumeConfiguration(); } 
-          else { this.config = DeepCopy.copy(that); }
+          if (that == null) { 
+             this.config = new VolumeConfiguration(); 
+          } 
+          else { 
+             this.config = DeepCopy.copy(that); 
+          }
        }
 
        public Builder name(String name) 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -236,8 +236,8 @@ class DockerComposeServiceWrapper {
         return ret;
     }
 
-    VolumeConfiguration getVolumeConfig() {
-        VolumeConfiguration.Builder builder = new VolumeConfiguration.Builder();
+    ImageVolumeConfiguration getVolumeConfig() {
+        ImageVolumeConfiguration.Builder builder = new ImageVolumeConfiguration.Builder();
         List<String> volumes = asList("volumes");
         boolean added = false;
         if (volumes.size() > 0) {

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -236,8 +236,8 @@ class DockerComposeServiceWrapper {
         return ret;
     }
 
-    ImageVolumeConfiguration getVolumeConfig() {
-        ImageVolumeConfiguration.Builder builder = new ImageVolumeConfiguration.Builder();
+    RunVolumeConfiguration getVolumeConfig() {
+        RunVolumeConfiguration.Builder builder = new RunVolumeConfiguration.Builder();
         List<String> volumes = asList("volumes");
         boolean added = false;
         if (volumes.size() > 0) {

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -265,8 +265,8 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return ret;
     }
 
-    private ImageVolumeConfiguration extractVolumeConfig(String prefix, Properties properties) {
-        return new ImageVolumeConfiguration.Builder()
+    private RunVolumeConfiguration extractVolumeConfig(String prefix, Properties properties) {
+        return new RunVolumeConfiguration.Builder()
                 .bind(listWithPrefix(prefix, BIND, properties))
                 .from(listWithPrefix(prefix, VOLUMES_FROM, properties))
                 .build();

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -265,8 +265,8 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return ret;
     }
 
-    private VolumeConfiguration extractVolumeConfig(String prefix, Properties properties) {
-        return new VolumeConfiguration.Builder()
+    private ImageVolumeConfiguration extractVolumeConfig(String prefix, Properties properties) {
+        return new ImageVolumeConfiguration.Builder()
                 .bind(listWithPrefix(prefix, BIND, properties))
                 .from(listWithPrefix(prefix, VOLUMES_FROM, properties))
                 .build();

--- a/src/main/java/io/fabric8/maven/docker/model/Volume.java
+++ b/src/main/java/io/fabric8/maven/docker/model/Volume.java
@@ -1,0 +1,41 @@
+package io.fabric8.maven.docker.model;
+/*
+ *
+ * Copyright 2014 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Map;
+
+/**
+ * Interface representing a container
+ *
+ * @author Tom Burton
+ * @since 12/15/16
+ */
+public interface Volume {
+
+   String getName();
+   
+   String getDriver();
+   
+   String getMountpoint();
+   
+   Map<String, String> getStatus();
+   
+   Map<String, String> getLabels();
+   
+   String getScope();
+    
+}

--- a/src/main/java/io/fabric8/maven/docker/model/VolumeDetails.java
+++ b/src/main/java/io/fabric8/maven/docker/model/VolumeDetails.java
@@ -1,0 +1,76 @@
+package io.fabric8.maven.docker.model;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import javax.xml.bind.DatatypeConverter;
+import java.util.*;
+
+/**
+ *  Describes the Details of a created Volume
+ *  
+ *  @author Tom Burton
+ *  @version Dec 16, 2016
+ */
+public class VolumeDetails implements Volume 
+{
+    static final String LABELS = "Labels";
+    static final String NAME = "Name";
+    static final String DRIVER = "Driver";
+    static final String MOUNTPOINT = "Mountpount";
+    static final String STATUS = "Status";
+    static final String SCOPE = "Scope";
+    
+    static final String SLASH = "/";
+    
+    //TODO: should these be an enum?
+    static final String SCOPE_GLOBAL = "global";
+    static final String SCOPE_LOCAL  = "local";
+
+    private final JSONObject json;
+
+    public VolumeDetails(JSONObject json) { this.json = json; }
+
+    @Override
+    public String getName() 
+    {
+       String name = json.getString(NAME);
+
+       if (name.startsWith(SLASH)) { name = name.substring(1); }
+       return name;
+    }
+
+
+    @Override
+    public String getDriver() { return json.getString(DRIVER); }
+
+    @Override
+    public String getMountpoint() { return json.getString(MOUNTPOINT); }
+
+    @Override
+    public Map<String, String> getStatus() 
+    { return parseMap(json.getJSONObject(STATUS)); }
+
+    @Override
+    public Map<String, String> getLabels() 
+    { return parseMap(json.getJSONObject(LABELS)); }
+      
+    private Map<String, String> parseMap(JSONObject labels) 
+    {
+        int length = labels.length();
+        Map<String, String> mapped = new HashMap<>(length);
+
+        Iterator<String> iterator = labels.keys();
+        while (iterator.hasNext()) 
+        {
+           String key = iterator.next();
+           mapped.put(key, labels.get(key).toString());
+        }
+
+        return mapped;
+    }
+
+   @Override
+   public String getScope() { return json.getString(SCOPE); }
+    
+}

--- a/src/main/java/io/fabric8/maven/docker/model/VolumeDetails.java
+++ b/src/main/java/io/fabric8/maven/docker/model/VolumeDetails.java
@@ -52,8 +52,9 @@ public class VolumeDetails implements Volume
     { return parseMap(json.getJSONObject(STATUS)); }
 
     @Override
-    public Map<String, String> getLabels() 
-    { return parseMap(json.getJSONObject(LABELS)); }
+    public Map<String, String> getLabels() { 
+       return parseMap(json.getJSONObject(LABELS)); 
+    }
       
     private Map<String, String> parseMap(JSONObject labels) 
     {

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -252,7 +252,7 @@ public class RunService {
                     .labels(mergeLabels(runConfig.getLabels(), pomLabel))
                     .command(runConfig.getCmd())
                     .hostConfig(createContainerHostConfig(runConfig, mappedPorts));
-            ImageVolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();
+            RunVolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();
             if (volumeConfig != null) {
                 config.binds(volumeConfig.getBind());
             }
@@ -325,7 +325,7 @@ public class RunService {
     }
 
     private void addVolumeConfig(ContainerHostConfig config, RunImageConfiguration runConfig) throws DockerAccessException {
-        ImageVolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
+        RunVolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
         if (volConfig != null) {
             config.binds(volConfig.getBind())
                   .volumesFrom(findVolumesFromContainers(volConfig.getFrom()));

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -252,7 +252,7 @@ public class RunService {
                     .labels(mergeLabels(runConfig.getLabels(), pomLabel))
                     .command(runConfig.getCmd())
                     .hostConfig(createContainerHostConfig(runConfig, mappedPorts));
-            VolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();
+            ImageVolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();
             if (volumeConfig != null) {
                 config.binds(volumeConfig.getBind());
             }
@@ -325,7 +325,7 @@ public class RunService {
     }
 
     private void addVolumeConfig(ContainerHostConfig config, RunImageConfiguration runConfig) throws DockerAccessException {
-        VolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
+        ImageVolumeConfiguration volConfig = runConfig.getVolumeConfiguration();
         if (volConfig != null) {
             config.binds(volConfig.getBind())
                   .volumesFrom(findVolumesFromContainers(volConfig.getFrom()));

--- a/src/main/java/io/fabric8/maven/docker/service/ServiceHub.java
+++ b/src/main/java/io/fabric8/maven/docker/service/ServiceHub.java
@@ -24,9 +24,9 @@ import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.project.MavenProject;
 
 /**
- * A service hub responsible for creating and managing service which are used by
+ * A service hub responsible for creating and managing services which are used by
  * Mojos for calling to the docker backend. The docker backend (DAO) is injected from the outside.
- &
+ *
  * @author roland
  * @since 01/12/15
  */
@@ -39,6 +39,7 @@ public class ServiceHub {
     private final BuildService buildService;
     private final MojoExecutionService mojoExecutionService;
     private final ArchiveService archiveService;
+    private final VolumeService volumeService;
 
     ServiceHub(DockerAccess dockerAccess, ContainerTracker containerTracker, BuildPluginManager pluginManager,
                DockerAssemblyManager dockerAssemblyManager, MavenProject project, MavenSession session,
@@ -53,10 +54,12 @@ public class ServiceHub {
             queryService = new QueryService(dockerAccess);
             runService = new RunService(dockerAccess, queryService, containerTracker, logSpecFactory, logger);
             buildService = new BuildService(dockerAccess, queryService, archiveService, logger);
+            volumeService = new VolumeService(dockerAccess);
         } else {
             queryService = null;
             runService = null;
             buildService = null;
+            volumeService = null;
         }
     }
 
@@ -99,6 +102,16 @@ public class ServiceHub {
     public RunService getRunService() {
         checkDockerAccessInitialization();
         return runService;
+    }
+    
+    /**
+     * The volume service is responsible for creating volumes
+     *
+     * @return the run service
+     */
+    public VolumeService getVolumeService() {
+        checkDockerAccessInitialization();
+        return volumeService;
     }
 
     public ArchiveService getArchiveService() {

--- a/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
@@ -6,7 +6,7 @@ import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.PortMapping;
 import io.fabric8.maven.docker.access.VolumeCreateConfig;
-import io.fabric8.maven.docker.config.ImageVolumeConfiguration;
+import io.fabric8.maven.docker.config.RunVolumeConfiguration;
 import io.fabric8.maven.docker.config.NetworkConfig;
 import io.fabric8.maven.docker.config.RunImageConfiguration;
 import io.fabric8.maven.docker.config.VolumeConfiguration;
@@ -34,8 +34,9 @@ public class VolumeService
    /**
     * Sets the DockerAccess object
     */
-   public VolumeService(DockerAccess dockerAccess) 
-   { this.docker = dockerAccess; }
+   public VolumeService(DockerAccess dockerAccess) { 
+      this.docker = dockerAccess; 
+   }
    
    public String createVolume(VolumeConfiguration vc)
           throws DockerAccessException
@@ -60,6 +61,7 @@ public class VolumeService
            return vconfig;
    }
    
-   public void removeVolume(String volumeName) throws DockerAccessException
-   { docker.removeVolume(volumeName); }
+   public void removeVolume(String volumeName) throws DockerAccessException { 
+      docker.removeVolume(volumeName); 
+   }
 }

--- a/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
@@ -1,0 +1,65 @@
+package io.fabric8.maven.docker.service;
+
+import io.fabric8.maven.docker.access.ContainerCreateConfig;
+import io.fabric8.maven.docker.access.ContainerNetworkingConfig;
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.access.PortMapping;
+import io.fabric8.maven.docker.access.VolumeCreateConfig;
+import io.fabric8.maven.docker.config.ImageVolumeConfiguration;
+import io.fabric8.maven.docker.config.NetworkConfig;
+import io.fabric8.maven.docker.config.RunImageConfiguration;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.docker.util.PomLabel;
+
+import java.lang.String;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ *  Service Class for helping control Volumes 
+ * 
+ *  @author Tom Burton
+ *  @version Dec 15, 2016
+ */
+public class VolumeService
+{
+   // logger delegated from top
+   private Logger log;
+
+   // DAO for accessing the docker daemon
+   private DockerAccess docker;
+
+   /**
+    * Sets the DockerAccess object
+    */
+   public VolumeService(DockerAccess dockerAccess) 
+   { this.docker = dockerAccess; }
+   
+   public String createVolume(VolumeConfiguration vc)
+          throws DockerAccessException
+   {
+      VolumeCreateConfig vcc = createVolumeConfig(vc.getName(), vc.getDriver(), 
+                                                  vc.getDriverOpts(), 
+                                                  vc.getLabels());
+      
+      return docker.createVolume(vcc);
+   }
+   
+   // visible for testing
+   VolumeCreateConfig createVolumeConfig(String volumeName,
+                                         String driver,
+                                         Map<String, String> driverOpts, 
+                                         Map<String, String> labels)
+                      throws DockerAccessException 
+   {
+       VolumeCreateConfig vconfig = new VolumeCreateConfig(volumeName)
+             .driver(driver).driverOpts(driverOpts)
+             .labels(labels);
+           return vconfig;
+   }
+   
+   public void removeVolume(String volumeName) throws DockerAccessException
+   { docker.removeVolume(volumeName); }
+}

--- a/src/test/java/io/fabric8/maven/docker/model/VolumeDetailsTest.java
+++ b/src/test/java/io/fabric8/maven/docker/model/VolumeDetailsTest.java
@@ -1,0 +1,108 @@
+package io.fabric8.maven.docker.model;
+
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+public class VolumeDetailsTest 
+{
+
+    private VolumeDetails volume;
+
+    private JSONObject json;
+
+    @Before
+    public void setup() { json = new JSONObject(); }
+
+    @Test
+    public void testVolumeWithLabels() {
+        givenAVolumeWithLabels();
+        whenCreateVolume();
+        thenLabelsSizeIs(2);
+        thenLabelsContains("key1", "value1");
+        thenLabelsContains("key2", "value2");
+    }
+    
+    @Test
+    public void testVolumeWithStatus() 
+    {
+        givenAVolumeWithStatus();
+        whenCreateVolume();
+        assertThat(volume.getStatus().size(), is(2));
+        thenStatusContains("key1", "value1");
+        thenStatusContains("key2", "value2");
+    }
+
+    @Test
+    public void testCreateVolume() throws Exception 
+    {
+        givenVolumeData();
+        whenCreateVolume();
+        thenValidateVolume();
+    }
+    
+    private void thenLabelsContains(String key, String value)
+    {
+       assertThat(volume.getLabels(),          hasKey(key));
+       assertThat(volume.getLabels().get(key), is(value));
+    } 
+    
+    private void thenStatusContains(String key, String value) 
+    {
+       assertThat(volume.getStatus(),          hasKey(key));
+       assertThat(volume.getStatus().get(key), is(value));
+    }
+
+    private void givenAVolumeWithLabels() {
+        JSONObject labels = new JSONObject();
+        labels.put("key1", "value1");
+        labels.put("key2", "value2");
+        
+        json.put(VolumeDetails.LABELS, labels);
+    }
+    
+    private void givenAVolumeWithStatus() 
+    {
+       JSONObject status = new JSONObject();
+       status.put("key1", "value1");
+       status.put("key2", "value2");
+       
+       json.put(VolumeDetails.STATUS, status);
+   }
+
+    private void givenVolumeData() 
+    {
+        json.put(VolumeDetails.NAME,       "/milkman-kindness");
+        json.put(VolumeDetails.DRIVER,     "test-driver");
+        json.put(VolumeDetails.MOUNTPOINT, "/ver/lib/docker/testVolume");
+
+        json.put(VolumeDetails.SCOPE, VolumeDetails.SCOPE_LOCAL);
+    }
+
+    private void thenLabelsSizeIs(int size) 
+    { assertThat(volume.getLabels().size(), is(2)); }
+
+    private void thenValidateVolume() 
+    {
+        assertThat(volume.getName(),       is("milkman-kindness"));
+        assertThat(volume.getDriver(),     is("test-driver"));
+        assertThat(volume.getMountpoint(), is("/ver/lib/docker/testVolume"));
+        assertThat(volume.getScope(),      is(VolumeDetails.SCOPE_LOCAL));
+        
+        try { assertThat(volume.getLabels(), is(nullValue())); }
+        catch(JSONException je)
+        { assertThat(je.getMessage(), is("JSONObject[\"Labels\"] not found.")); }
+        
+        try { assertThat(volume.getStatus(), is(nullValue())); }
+        catch(JSONException je)
+        { assertThat(je.getMessage(), is("JSONObject[\"Status\"] not found.")); }  
+    }
+
+    private void whenCreateVolume() { volume = new VolumeDetails(json); }
+
+}

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -357,8 +357,8 @@ public class RunServiceTest {
         return new RestartPolicy.Builder().name("on-failure").retry(1).build();
     }
 
-    private ImageVolumeConfiguration volumeConfiguration() {
-        return new ImageVolumeConfiguration.Builder()
+    private RunVolumeConfiguration volumeConfiguration() {
+        return new RunVolumeConfiguration.Builder()
                 .bind(bind())
                 .from(volumesFrom())
                 .build();

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -357,8 +357,8 @@ public class RunServiceTest {
         return new RestartPolicy.Builder().name("on-failure").retry(1).build();
     }
 
-    private VolumeConfiguration volumeConfiguration() {
-        return new VolumeConfiguration.Builder()
+    private ImageVolumeConfiguration volumeConfiguration() {
+        return new ImageVolumeConfiguration.Builder()
                 .bind(bind())
                 .from(volumesFrom())
                 .build();

--- a/src/test/java/io/fabric8/maven/docker/service/VolumeServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/VolumeServiceTest.java
@@ -1,0 +1,142 @@
+package io.fabric8.maven.docker.service;
+
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.access.VolumeCreateConfig;
+import io.fabric8.maven.docker.config.VolumeConfiguration;
+import io.fabric8.maven.docker.util.Logger;
+
+import java.lang.String;
+import java.util.HashMap;
+import java.util.Map;
+
+import mockit.Expectations;
+import mockit.Mocked;
+
+import org.hamcrest.core.Is;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *  Basic Unit Tests for {@link VolumeService}  
+ *  
+ *  @author Tom Burton
+ *  @version Dec 16, 2016
+ */
+public class VolumeServiceTest
+{
+   private VolumeCreateConfig volumeConfig;
+   
+   @Mocked
+   private DockerAccess docker;
+   
+   private VolumeService volumeService;
+
+   /**
+    * @throws java.lang.Exception
+    */
+   @Before
+   public void setUp() throws Exception 
+   { volumeService = new VolumeService(docker); }
+
+   /**
+    * @throws java.lang.Exception
+    */
+   @After
+   public void tearDown() throws Exception { }
+   
+   /*
+    * methods to test
+    * 
+    * volumeService.createVolumeConfig(volumeName, driver, driverOpts, labels);
+    * volumeService.removeVolume(volumeName);
+    */
+   
+   private Map<String, String > withMap()
+   {
+      Map<String, String> map = new HashMap<String, String>();
+      map.put("key1", "value1");
+      map.put("key2", "value2");
+      
+      return map;
+   }
+   
+   private void validateMap(Map<String, String> map)
+   {
+      assertThat(map.size(), is(2));
+      
+      assertThat(map, hasKey("key1"));
+      assertThat(map, hasValue("value1"));
+      assertThat(map.get("key1"), is("value1"));
+      
+      assertThat(map, hasKey("key2"));
+      assertThat(map, hasValue("value2"));
+      assertThat(map.get("key2"), is("value2"));
+   }
+   
+   
+   @Test
+   public void testCreateVolumeConfig() throws Exception
+   {
+      /* in case VolumeConfiguration ever implements equals
+      VolumeConfiguration vc = VolumeConfiguration.builder()
+            .name("testVolume")
+            .driver("test").driverOpts(withMap())
+            .labels(withMap())
+            .build();
+      */
+
+      VolumeCreateConfig vcc = volumeService.createVolumeConfig("testVolume", 
+                                                                "test", withMap(), 
+                                                                withMap());
+      assertThat(vcc.getVolumeName(), is("testVolume"));
+      
+      String vccJson = vcc.toJson();
+      
+      assertThat(vccJson, containsString('"'+"Driver"+'"'+':'+'"'+"test"+'"'));
+   }
+
+   @Test
+   public void testCreateVolume() throws Exception
+   {
+      
+      VolumeConfiguration vc = VolumeConfiguration.builder()
+                                     .name("testVolume")
+                                     .driver("test").driverOpts(withMap())
+                                     .labels(withMap())
+                                     .build();
+      
+      new Expectations() {{
+         docker.createVolume((VolumeCreateConfig)any); result = "testVolume";
+      }};
+      
+      assertThat(vc.getName(), is("testVolume"));
+      String name = volumeService.createVolume(vc);
+      
+      assertThat(name, is("testVolume"));
+   }
+   
+   @Test
+   public void testRemoveVolume() throws Exception
+   {
+      VolumeConfiguration vc = VolumeConfiguration.builder()
+            .name("testVolume")
+            .driver("test").driverOpts(withMap())
+            .labels(withMap())
+            .build();
+
+      String name = volumeService.createVolume(vc);
+      
+      volumeService.removeVolume(name);
+      
+      //TODO: add real verification here
+      assertTrue(true);
+   }
+   
+}


### PR DESCRIPTION
This is a new feature to add named volume support.

added `volume-create` and `volume-remove` goals
example config in the samples directory.
simple unit tests added.
Non-automatic, both goals have to be explicitly called.

PR to Master per @rhuss ask on Pull Request https://github.com/fabric8io/docker-maven-plugin/pull/654