### PR TITLE
Dockerfile template issue 205

### DIFF
--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -1,7 +1,7 @@
 
 All build relevant configuration is contained in the `<build>` section
-of an image configuration. In addition to `<dockerFileDir>` and
-`<dockerFile>` the following configuration options are available:
+of an image configuration. In addition to `<dockerFileDir>`, `<dockerFile>`,
+and `<dockerFileTemplate>` the following configuration options are available:
 
 [[config-image-build]]
 .Build configuration (<<config-image, <image> >>)

--- a/src/main/asciidoc/inc/build/_overview.adoc
+++ b/src/main/asciidoc/inc/build/_overview.adoc
@@ -13,6 +13,7 @@ Alternatively an external Dockerfile template or Docker archive can be used. Thi
 
 * *dockerFileDir* specifies a directory containing a Dockerfile that will be used to create the image. The name of the Dockerfile is `Dockerfile` by default but can be also set with the option `dockerFile` (see below).
 * *dockerFile* specifies a specific Dockerfile path. The Docker build context directory is set to `dockerFileDir` if given. If not the directory by default is the directory in which the Dockerfile is stored.
+* *dockerFileTemplate* specifies a Dockerfile which contains variables to be interpolated.  The variable names should be delimited with a double percent "%%" before and after the variable name, for example, "%%myprop%%".  These variables will be replaced by the matching property name in the Maven build.
 * *dockerArchive* specifies a previously saved image archive to load directly. Such a tar archive can be created with `docker save`. If a `dockerArchive` is provided, no `dockerFile` or `dockerFileDir` must be given.
 
 All paths can be either absolute or relative paths (except when both `dockerFileDir` and `dockerFile` are provided in which case `dockerFile` must not be absolute). A relative path is looked up in `${project.basedir}/src/main/docker` by default. You can make it easily an absolute path by using `${project.basedir} in your configuration.

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -2,6 +2,7 @@ package io.fabric8.maven.docker.assembly;
 
 import io.fabric8.maven.docker.config.*;
 import io.fabric8.maven.docker.util.EnvUtil;
+import io.fabric8.maven.docker.util.FileInterpolator;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.docker.util.MojoParameters;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -106,11 +107,23 @@ public class DockerAssemblyManager {
                     }
                 };
             } else {
-                // Create custom docker file in output dir
-                DockerFileBuilder builder = createDockerFileBuilder(buildConfig, assemblyConfig);
-                builder.write(buildDirs.getOutputDirectory());
-                // Add own Dockerfile
-                final File dockerFile = new File(buildDirs.getOutputDirectory(),"Dockerfile");
+                final File dockerFile = new File(buildDirs.getOutputDirectory(), "Dockerfile");;
+                if(buildConfig.getDockerFileTemplate() != null) {
+                    File dockerFileTemplate = buildConfig.getAbsoluteDockerFiletemplatePath(params);
+                    if (!dockerFileTemplate.exists()) {
+                        throw new MojoExecutionException("Configured Dockerfile Template \"" +
+                                buildConfig.getDockerFileTemplate() + "\" (resolved to \"" + dockerFileTemplate +
+                                "\") doesn't exist");
+                    }
+                    // Create docker file in output dir based on template
+                    // FileUtils.copyFile(dockerFileTemplate, dockerFile);
+                    FileInterpolator.interpolate(dockerFileTemplate, dockerFile, params.getProject().getProperties());
+                } else {
+                    // Create custom docker file in output dir based on pom config
+                    DockerFileBuilder builder = createDockerFileBuilder(buildConfig, assemblyConfig);
+                    builder.write(buildDirs.getOutputDirectory());
+                }
+
                 customizer = new ArchiverCustomizer() {
                     @Override
                     public TarArchiver customize(TarArchiver archiver) throws IOException {

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -22,7 +22,7 @@ public class BuildImageConfiguration implements Serializable {
 
     /**
      * Path to a dockerfile to use. Its parent directory is used as build context (i.e. as <code>dockerFileDir</code>).
-     * Multiple different Dockerfiles can be specified that way. If set overwrites a possibly givem
+     * Multiple different Dockerfiles can be specified that way. If set overwrites a possibly given
      * <code>dockerFileDir</code>
      *
      * @parameter

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -30,6 +30,14 @@ public class BuildImageConfiguration implements Serializable {
     private String dockerFile;
 
     /**
+     * Path to a dockerfile template. Variables in the file will be interpolated before it is sent
+     * to docker to build the image.
+     *
+     * @parameter
+     */
+    private String dockerFileTemplate;
+
+    /**
      * Path to a docker archive to load an image instead of building from scratch. Note only either dockerFile or
      * dockerArchive can be used.
      *
@@ -158,7 +166,7 @@ public class BuildImageConfiguration implements Serializable {
     private Map<String,String> buildOptions;
 
     // Path to Dockerfile to use, initialized lazily ....
-    private File dockerFileFile, dockerArchiveFile;
+    private File dockerFileFile, dockerArchiveFile, dockerFileTemplateFile;
 
     public BuildImageConfiguration() {}
 
@@ -168,6 +176,10 @@ public class BuildImageConfiguration implements Serializable {
 
     public File getDockerFile() {
         return dockerFileFile;
+    }
+
+    public File getDockerFileTemplate() {
+        return dockerFileTemplateFile;
     }
 
     public File getDockerArchive() {
@@ -278,6 +290,10 @@ public class BuildImageConfiguration implements Serializable {
         return EnvUtil.prepareAbsoluteSourceDirPath(mojoParams, getDockerFile().getPath());
     }
 
+    public File getAbsoluteDockerFiletemplatePath(MojoParameters mojoParams) {
+        return EnvUtil.prepareAbsoluteSourceDirPath(mojoParams, getDockerFileTemplate().getPath());
+    }
+
     public File getAbsoluteDockerTarPath(MojoParameters mojoParams) {
         return EnvUtil.prepareAbsoluteSourceDirPath(mojoParams, getDockerArchive().getPath());
     }
@@ -304,6 +320,11 @@ public class BuildImageConfiguration implements Serializable {
 
         public Builder dockerFile(String file) {
             config.dockerFile = file;
+            return this;
+        }
+
+        public Builder dockerFileTemplate(String file) {
+            config.dockerFileTemplate = file;
             return this;
         }
 
@@ -499,6 +520,14 @@ public class BuildImageConfiguration implements Serializable {
 
         if (dockerArchive != null) {
             dockerArchiveFile = new File(dockerArchive);
+        }
+
+        if (dockerFileTemplate != null) {
+            // Check/validate dockerFileTemplate
+            dockerFileTemplateFile = new File(dockerFileTemplate);
+            if (dockerFileTemplateFile.isAbsolute()) {
+                throw new IllegalArgumentException("<dockerFileTemplate> path must not be an absolute path");
+            }
         }
     }
 

--- a/src/main/java/io/fabric8/maven/docker/config/BuildTarArchiveCompression.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildTarArchiveCompression.java
@@ -18,7 +18,7 @@ package io.fabric8.maven.docker.config;/*
 import org.codehaus.plexus.archiver.tar.TarArchiver;
 
 /**
- * Enumeration for determine the compression mode when creating docker
+ * Enumeration for determining the compression mode when creating docker archive
  * build archives.
  *
  * @author roland

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -49,6 +49,7 @@ public enum ConfigKey {
     DNS_SEARCH,
     DOCKER_ARCHIVE,
     DOCKER_FILE,
+    DOCKER_FILE_TEMPLATE,
     DOCKER_FILE_DIR,
     ENTRYPOINT,
     ENV,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -88,6 +88,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .dockerArchive(withPrefix(prefix, DOCKER_ARCHIVE, properties))
                 .buildOptions(mapWithPrefix(prefix, BUILD_OPTIONS, properties))
                 .dockerFile(withPrefix(prefix, DOCKER_FILE, properties))
+                .dockerFileTemplate(withPrefix(prefix, DOCKER_FILE_TEMPLATE, properties))
                 .dockerFileDir(withPrefix(prefix, DOCKER_FILE_DIR, properties))
                 .user(withPrefix(prefix, USER, properties))
                 .healthCheck(extractHealthCheck(prefix, properties))

--- a/src/main/java/io/fabric8/maven/docker/util/FileInterpolator.java
+++ b/src/main/java/io/fabric8/maven/docker/util/FileInterpolator.java
@@ -1,0 +1,85 @@
+/*-
+ *
+ * Copyright 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.maven.docker.util;
+
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class for performing variable substitution on a text file
+ *
+ * @author pgier
+ * @since 06.01.17
+ */
+public class FileInterpolator {
+    //public final static String DEFAULT_CHAR_ENCODING = "UTF-8";
+
+    public final static String DEFAULT_START_DELIMITER = "%%";
+    public final static String DEFAULT_END_DELIMITER = "%%";
+
+    /**
+     * Interpolate the variables in the given file.
+     *
+     * @param inputFile
+     * @param outputFile
+     * @param vars
+     * @throws IOException
+     */
+    public static void interpolate(File inputFile, File outputFile, Properties vars) throws IOException {
+        interpolate(inputFile, outputFile, vars, DEFAULT_START_DELIMITER, DEFAULT_END_DELIMITER);
+    }
+
+    /**
+     * Interpolate the variables in the given file
+     *
+     * @param inputFile
+     * @param outputFile
+     * @param vars
+     * @param startDelim
+     * @param endDelim
+     * @throws IOException
+     */
+    public static void interpolate(File inputFile, File outputFile, Properties vars, String startDelim, String endDelim)
+            throws IOException {
+        String input = FileUtils.fileRead(inputFile);
+        String output = interpolate(input, vars, startDelim, endDelim);
+        FileUtils.fileWrite(outputFile, output);
+    }
+
+    private static String interpolate(String input, Properties vars, String startDelim, String endDelim) {
+        StringBuffer output = new StringBuffer();
+        final String regex = startDelim + "([.\\-_\\w]+)" + endDelim + "?";
+        final Pattern pattern = Pattern.compile(regex);
+        final Matcher matcher = pattern.matcher(input);
+        while (matcher.find()) {
+            String replace = vars.getProperty(matcher.group(1));
+            if(replace == null) {
+                // If there isn't a matching property, then just keep the current string
+                replace = matcher.group();
+            }
+            matcher.appendReplacement(output, replace);
+        }
+        matcher.appendTail(output);
+        return output.toString();
+    }
+
+}

--- a/src/test/java/io/fabric8/maven/docker/util/FileInterpolatorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/FileInterpolatorTest.java
@@ -1,0 +1,79 @@
+/*
+ *
+ * Copyright 2014 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.maven.docker.util;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Properties;
+
+/**
+ * Basic tests for File Interpolator
+ *
+ * @author pgier
+ * @since 06.01.17
+ */
+public class FileInterpolatorTest {
+
+    @Test
+    public void testBasicFileInterpolation() throws Exception {
+        Properties vars = new Properties();
+        final String prop1Name = "testProp1";
+        final String prop1Value = "value1";
+        vars.setProperty(prop1Name, prop1Value);
+        String content = "testing a %%" + prop1Name + "%% b testing\n";
+
+        File dockerFileTemplate = File.createTempFile("DockerfileTest", ".template");
+        dockerFileTemplate.deleteOnExit();
+        FileUtils.writeStringToFile(dockerFileTemplate, content);
+        File dockerFile = File.createTempFile("DockerfileTest", null);
+        dockerFile.deleteOnExit();
+        FileInterpolator.interpolate(dockerFileTemplate, dockerFile, vars);
+        String updatedFileContent = FileUtils.readFileToString(dockerFile);
+
+        Assert.assertTrue(updatedFileContent.contains("a " + prop1Value + " b"));
+    }
+
+    @Test
+    public void testFileInterpolationMultiLine() throws Exception {
+        Properties vars = new Properties();
+        final String prop1Name = "test.prop.1";
+        final String prop1Value = "value1";
+        vars.setProperty(prop1Name, prop1Value);
+        final String prop2Name = "test_prop-2.";
+        final String prop2Value = "prop 2 value";
+        vars.setProperty(prop2Name, prop2Value);
+
+        String content = "testing a %%" + prop1Name + "%% b testing\n"
+                + "second line junk %^&*( \n"
+                + "third line %%test_prop-2.%% more stuff \n";
+
+        File dockerFileTemplate = File.createTempFile("DockerfileTest", ".template");
+        dockerFileTemplate.deleteOnExit();
+        FileUtils.writeStringToFile(dockerFileTemplate, content);
+        File dockerFile = File.createTempFile("DockerfileTest", null);
+        dockerFile.deleteOnExit();
+        FileInterpolator.interpolate(dockerFileTemplate, dockerFile, vars);
+        String updatedFileContent = FileUtils.readFileToString(dockerFile);
+
+        Assert.assertTrue(updatedFileContent.contains("a " + prop1Value + " b"));
+        Assert.assertTrue(updatedFileContent.contains("line " + prop2Value + " more"));
+    }
+
+}


### PR DESCRIPTION
Adds a new parameter to the "build" goal called "dockerFileTemplate".  This can be used to allow variable substitution into an existing Dockerfile.  Variable names are delimited by a "%%" at the start and end, and the plugin will attempt to find a matching property.
Related to issue #205, but only implements the variable substitution part.