### PR TITLE
fix empty link causing NullPointerException

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -12,6 +12,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.shared.utils.io.FileUtils;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicates;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -127,7 +128,8 @@ public class EnvUtil {
         if(input==null) {
             return Collections.emptyList();
         }
-        return Lists.newArrayList(Iterables.concat(Iterables.transform(input, COMMA_SPLITTER)));
+        Iterable<String> nonEmptyInputs = Iterables.filter(input, Predicates.notNull());
+        return Lists.newArrayList(Iterables.concat(Iterables.transform(nonEmptyInputs, COMMA_SPLITTER)));
     }
 
     public static String[] splitOnSpaceWithEscape(String toSplit) {

--- a/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
@@ -45,6 +45,30 @@ public class EnvUtilTest {
         assertTrue(Iterables.elementsEqual(it, expected));
     }
 
+    public void assertEmptyList(Iterable<String> actual) {
+        assertTrue(Iterables.elementsEqual(Collections.emptyList(), actual));
+    }
+    @Test
+    public void splitAtCommasEmpty() {
+        assertEmptyList(EnvUtil.splitAtCommasAndTrim(Collections.<String>emptyList()));
+    }
+
+    @Test
+    public void splitAtCommasSingleEmpty() {
+        assertEmptyList(EnvUtil.splitAtCommasAndTrim(Arrays.asList("")));
+    }
+
+    @Test
+    public void splitAtCommasNullList() {
+        assertEmptyList(EnvUtil.splitAtCommasAndTrim(null));
+    }
+
+    // null occurs when <links><link></link></links>
+    @Test
+    public void splitAtCommasNullInList() {
+        assertEmptyList(EnvUtil.splitAtCommasAndTrim(Collections.<String>singletonList(null)));
+    }
+
     @Test
     @TestCaseName("{method}: input \"{0}\" splits to {1}")
     @Parameters


### PR DESCRIPTION
When configuration has an empty link, a NullPointerException is thrown.
```xml
  <configuration>
    <links>
      <link></link>
    </links>
...
  </configuration>
```