### PR TITLE
Fix work with maven build directory path and absolute paths in it

### DIFF
--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -88,7 +88,7 @@ the URL is:
 | `docker.maxConnections`
 
 | *outputDirectory*
-| If this a relative directory path it is set realtive to ${build.directory} (which normally is the target/ directory within the project directory). The default value is docker and is only used for the goal {plugin}:build.
+| Default output directory to be used by this plugin. If this a relative directory path it is set relative to the project directory. The default value is `target/docker` and is only used for the goal {plugin}:build.
 | `docker.target.dir`
 
 | *portPropertyFile*

--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -88,7 +88,7 @@ the URL is:
 | `docker.maxConnections`
 
 | *outputDirectory*
-| Default output directory to be used by this plugin. The default value is `{build.directory}/docker` and is only used for the goal `{plugin}:build`.
+| If this a relative directory path it is set realtive to ${build.directory} (which normally is the target/ directory within the project directory). The default value is docker and is only used for the goal {plugin}:build.
 | `docker.target.dir`
 
 | *portPropertyFile*

--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -88,7 +88,7 @@ the URL is:
 | `docker.maxConnections`
 
 | *outputDirectory*
-| Default output directory to be used by this plugin. The default value is `target/docker` and is only used for the goal `{plugin}:build`.
+| Default output directory to be used by this plugin. The default value is `{build.directory}/docker` and is only used for the goal `{plugin}:build`.
 | `docker.target.dir`
 
 | *portPropertyFile*

--- a/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
@@ -41,7 +41,7 @@ abstract public class AbstractBuildSupportMojo extends AbstractDockerMojo {
     @Parameter(property = "docker.source.dir", defaultValue="src/main/docker")
     private String sourceDirectory;
 
-    @Parameter(property = "docker.target.dir", defaultValue="docker")
+    @Parameter(property = "docker.target.dir", defaultValue="target/docker")
     private String outputDirectory;
 
 

--- a/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
@@ -41,7 +41,7 @@ abstract public class AbstractBuildSupportMojo extends AbstractDockerMojo {
     @Parameter(property = "docker.source.dir", defaultValue="src/main/docker")
     private String sourceDirectory;
 
-    @Parameter(property = "docker.target.dir", defaultValue="target/docker")
+    @Parameter(property = "docker.target.dir", defaultValue="docker")
     private String outputDirectory;
 
 

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -320,6 +320,10 @@ public class EnvUtil {
         if (file.isAbsolute()) {
             return file;
         }
+        File directoryFile = new File(directory);
+        if (directoryFile.isAbsolute()) {
+            return new File(new File(directory), path);
+        }
         return new File(new File(params.getProject().getBasedir(), directory), path);
     }
 

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -308,7 +308,7 @@ public class EnvUtil {
     }
 
     public static File prepareAbsoluteOutputDirPath(MojoParameters params, String dir, String path) {
-        return prepareAbsolutePath(params, new File(params.getOutputDirectory(), dir).toString(), path);
+        return prepareAbsolutePath(params, new File(new File(params.getProject().getBuild().getDirectory(), params.getOutputDirectory()), dir).toString(), path);
     }
 
     public static File prepareAbsoluteSourceDirPath(MojoParameters params, String path) {

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -308,23 +308,21 @@ public class EnvUtil {
     }
 
     public static File prepareAbsoluteOutputDirPath(MojoParameters params, String dir, String path) {
-        return prepareAbsolutePath(params, new File(new File(params.getProject().getBuild().getDirectory(), params.getOutputDirectory()), dir).toString(), path);
+        return prepareAbsolutePath(params, new File(params.getOutputDirectory(), dir), path);
     }
 
     public static File prepareAbsoluteSourceDirPath(MojoParameters params, String path) {
-        return prepareAbsolutePath(params, params.getSourceDirectory(), path);
+        return prepareAbsolutePath(params, new File(params.getSourceDirectory()), path);
     }
 
-    private static File prepareAbsolutePath(MojoParameters params, String directory, String path) {
+    private static File prepareAbsolutePath(MojoParameters params, File directory, String path) {
         File file = new File(path);
         if (file.isAbsolute()) {
             return file;
         }
-        File directoryFile = new File(directory);
-        if (directoryFile.isAbsolute()) {
-            return new File(new File(directory), path);
-        }
-        return new File(new File(params.getProject().getBasedir(), directory), path);
+        return directory.isAbsolute() ?
+            new File(directory, path) :
+            new File(new File(params.getProject().getBasedir(), directory.getPath()), path);
     }
 
     // create a timestamp file holding time in epoch seconds

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyConfigurationSourceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyConfigurationSourceTest.java
@@ -1,21 +1,18 @@
 package io.fabric8.maven.docker.assembly;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import io.fabric8.maven.docker.config.AssemblyConfiguration;
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.MojoParameters;
-import java.net.URI;
-import java.net.URISyntaxException;
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.project.MavenProject;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class DockerAssemblyConfigurationSourceTest {
 
@@ -126,9 +123,9 @@ public class DockerAssemblyConfigurationSourceTest {
             assertStartsWithDir(absolutePath, source.getTemporaryRootDirectory());
         } else {
             // if not - then at some level each plugin directory must be equal to outputDir
-            assertChildOfDir(projectDir + File.separator + params.getOutputDirectory(), source.getOutputDirectory());
-            assertChildOfDir(projectDir + File.separator + params.getOutputDirectory(), source.getWorkingDirectory());
-            assertChildOfDir(projectDir + File.separator + params.getOutputDirectory(), source.getTemporaryRootDirectory());
+            assertSubDirOf(projectDir + File.separator + params.getOutputDirectory(), source.getOutputDirectory());
+            assertSubDirOf(projectDir + File.separator + params.getOutputDirectory(), source.getWorkingDirectory());
+            assertSubDirOf(projectDir + File.separator + params.getOutputDirectory(), source.getTemporaryRootDirectory());
         }
     }
 
@@ -142,22 +139,14 @@ public class DockerAssemblyConfigurationSourceTest {
         assertEquals(expectedStartsWith, path.toString().substring(0, length));
     }
 
-    private void assertChildOfDir(String rootPath, File childCandidatePath) throws URISyntaxException {
-        File rootDir = new File(new URI(rootPath).normalize().getPath()).getAbsoluteFile();
-        File childCandidateDir = new File(new URI(childCandidatePath.getAbsolutePath()).normalize().getPath()).getAbsoluteFile();
-
-        do {
-
-            if (childCandidateDir == null && !childCandidateDir.equals(rootDir)) {
-                fail(childCandidatePath + " is not a child of " + rootPath);
-            }
-
-            if (rootDir.equals(childCandidateDir)) {
-                // success
-                return;
-            }
-
-            childCandidateDir = childCandidateDir.getParentFile();
-        } while (true);
+    private void assertSubDirOf(String rootPath, File subDirPath) throws URISyntaxException {
+        String rootDir = normalizedAbsolutePath(rootPath);
+        String candidate = normalizedAbsolutePath(subDirPath.getAbsolutePath());
+        assertTrue(candidate.startsWith(rootDir));
     }
+
+    private String normalizedAbsolutePath(String rootPath) throws URISyntaxException {
+        return new File(new URI(rootPath).normalize().getPath()).getAbsolutePath();
+    }
+
 }


### PR DESCRIPTION
@rhuss When writing tests to check source and output directories for some reason it was desided to set only `.` as a basefile for MavenProject object. Unfortunately that field was designed to be a link to pom-file not a basepath of a project and because of that some side-effects appeared. Then main one is that when you call `MavenProject.getBasedir` after it, it calls `getParentFile` for a file you set, and it is `null` for `new File('.')` so in this case `new File(params.getProject().getBasedir(), directory)` is equal to `new File(directory)`. Because of this test that checks using an absolute paths as output directories is false positive.