### PR TITLE
Do not attempt to build null-named images, skip them.

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
@@ -109,23 +109,14 @@ public class ConfigHelper {
         List<ImageConfiguration> ret = new ArrayList<>();
         if (unresolvedImages != null) {
             for (ImageConfiguration image : unresolvedImages) {
-                ret.addAll(imageResolver.resolve(image));
+                if(image.getName() != null) {
+                    ret.addAll(imageResolver.resolve(image));
+                }
+
             }
-            verifyImageNames(ret);
         }
         return ret;
     }
-
-
-    // Extract authentication information
-    private static void verifyImageNames(List<ImageConfiguration> ret) {
-        for (ImageConfiguration config : ret) {
-            if (config.getName() == null) {
-                throw new IllegalArgumentException("Configuration error: <image> must have a non-null <name>");
-            }
-        }
-    }
-
 
     // =========================================================================
 

--- a/src/test/java/io/fabric8/maven/docker/config/ConfigHelperTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/ConfigHelperTest.java
@@ -44,14 +44,9 @@ public class ConfigHelperTest {
 
     @Test
     public void noName() throws Exception {
-        try {
-            List<ImageConfiguration> configs = Arrays.asList(new ImageConfiguration.Builder().build());
-            ConfigHelper.resolveImages(null, configs, createResolver(), null, createCustomizer());
-            fail();
-        } catch (IllegalArgumentException exp) {
-            assertTrue(exp.getMessage().contains("name"));
-        }
-
+        List<ImageConfiguration> configs = Arrays.asList(new ImageConfiguration.Builder().build());
+        List<ImageConfiguration> images = ConfigHelper.resolveImages(null, configs, createResolver(), null, createCustomizer());
+        assertEquals("List should be empty", 0, images.size());
     }
 
     @Test


### PR DESCRIPTION
Makes it easier to include JAR based submodules in your projects.

Part of the problem is the ```docker:build``` goal gets indiscriminately run against all modules in a project, regardless of whether or not they are configured to build a docker image.