### PR TITLE
Enable properties build only when `from` or `fromExt` is set

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -5,6 +5,7 @@
   - Allow image with multiple path segments (#694)
   - Add support for PKCS#8 private keys in pem.key file. (#730)
   - Improve resource management for certificates and keys. (#730)
+  - When using properties for configuration only build when `from` or `fromExt` is set (#736)
 
 * **0.20.0** (2017-02-17)
   - Removed `build-nofork` and `source-nofork` in favor for a more direct solution which prevents forking of the lifecycle. Please refer the documentation, chapter "Assembly" for more information about this.

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -2,7 +2,7 @@
 For simple needs the image configuration can be completely defined via
 Maven properties which are defined outside of this plugin's
 configuration. Such a property based configuration can be selected
-with an `<type>` of `props`. As extra configuration a prefix for the
+with an `<type>` of `properties`. As extra configuration a prefix for the
 properties can be defined which by default is `docker`.
 
 .Example
@@ -10,7 +10,7 @@ properties can be defined which by default is `docker`.
 ----
 <image>
   <external>
-     <type>props</type>
+     <type>properties</type>
      <prefix>docker</prefix> <!-- this is the default -->
   </external>
 </image>
@@ -18,7 +18,8 @@ properties can be defined which by default is `docker`.
 
 Given this example configuration a single image configuration is built
 up from the following properties, which correspond to the corresponding
-values in the `<build>` and `<run>` sections.
+values in the `<build>` and `<run>` sections. A build configuration is only created
+when a `docker.from` or a `docker.fromExt` is set.
 
 .External properties
 [cols="1,5"]
@@ -92,11 +93,8 @@ values in the `<build>` and `<run>` sections.
 | *docker.exposedPropertyKey*
 | Property part for the exposed container properties like internal IP addresses as described in <<start-overview, docker:start>>.
 
-| *docker.workdir*
-| Container working directory
-
 | *docker.env.VARIABLE*
-| Sets an environment variable. E.g. `<docker.env.JAVA_OPTS>-Xmx512m</docker.env.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is used both for building images and running containers. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created
+| Sets an environment variable. E.g. `<docker.env.JAVA_OPTS>-Xmx512m</docker.env.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is used both for building images and running containers. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
 
 | *docker.envPropertyFile*
 | specifies the path to a property file whose properties are used as environment variables. The environment variables takes precedence over any other environment variables specified.
@@ -105,10 +103,10 @@ values in the `<build>` and `<run>` sections.
 | List of `host:ip` to add to `/etc/hosts`
 
 | *docker.from*
-| Base image for building an image
+| Base image for building an image. Must be set when an image is created (or `fromExt`)
 
 | *docker.fromExt.VARIABLE*
-| Base image for building an image (extended format)
+| Base image for building an image (extended format), which also triggers a build of an image.
 
 | *docker.healthcheck.cmd*
 | Command to use for a healthcheck
@@ -254,8 +252,11 @@ values in the `<build>` and `<run>` sections.
 | *docker.wait.kill*
 | Time in milliseconds to wait between sending SIGTERM and SIGKILL to a container when stopping it.
 
+| *docker.workdir*
+| Container working directory where the image is build in
+
 | *docker.workingDir*
-| Working dir for commands to run in
+| Current Working dir for commands to run in when running containers
 |===
 
 Any other `<run>` or `<build>` sections are ignored when this handler
@@ -288,7 +289,7 @@ run and build configuration sections.
         <images>
           <image>
             <external>
-              <type>props</type>
+              <type>properties</type>
               <prefix>docker</prefix>
             </external>
           </image>

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -222,16 +222,24 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
                 ServiceHub serviceHub = serviceHubFactory.createServiceHub(project, session, access, log, logSpecFactory);
                 executeInternal(serviceHub);
             } catch (DockerAccessException exp) {
-                log.error("%s", exp.getMessage());
+                logException(exp);
                 throw new MojoExecutionException(log.errorMessage(exp.getMessage()), exp);
             } catch (MojoExecutionException exp) {
-                log.error("%s", exp.getMessage());
+                logException(exp);
                 throw exp;
             } finally {
                 if (access != null) {
                     access.shutdown();
                 }
             }
+        }
+    }
+
+    private void logException(Exception exp) {
+        if (exp.getCause() != null) {
+            log.error("%s [%s]", exp.getMessage(), exp.getCause().getMessage());
+        } else {
+            log.error("%s", exp.getMessage());
         }
     }
 

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -195,7 +195,7 @@ public class StartMojo extends AbstractDockerMojo {
             Thread.currentThread().interrupt();
             throw new MojoExecutionException("interrupted", e);
         } catch (IOException e) {
-            throw new MojoExecutionException("I/O Error",e);
+            throw new MojoExecutionException("I/O Error", e);
         } finally {
             shutdownExecutorService(executorService);
 

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccessException.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccessException.java
@@ -23,12 +23,21 @@ public class DockerAccessException extends IOException {
     public DockerAccessException(String message) {
         super(message);
     }
-    
+
     public DockerAccessException(String format, Object...args) {
         super(String.format(format, args));
     }
 
     public DockerAccessException(Throwable cause, String format, Object ... args) {
         super(String.format(format, args),cause);
+    }
+
+    @Override
+    public String getMessage() {
+        if (getCause() != null) {
+            return String.format("%s : %s", super.getMessage(), getCause().getMessage());
+        } else {
+            return super.getMessage();
+        }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -64,7 +64,17 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                         .build());
     }
 
+    // Enable build config only when a `.from.` is configured
+    private boolean buildConfigured(String prefix, Properties properties) {
+        return withPrefix(prefix, FROM, properties) != null ||
+               mapWithPrefix(prefix,FROM_EXT,properties) != null;
+    }
+
+
     private BuildImageConfiguration extractBuildConfiguration(String prefix, Properties properties) {
+        if (!buildConfigured(prefix, properties)) {
+            return null;
+        }
         return new BuildImageConfiguration.Builder()
                 .cmd(withPrefix(prefix, CMD, properties))
                 .cleanup(withPrefix(prefix, CLEANUP, properties))


### PR DESCRIPTION
Otherwise no build configuration will be created. This fixes #736.
Also made error messages a bit more verbose.