### PR TITLE
Be more robust when parsing Docker auth config

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,7 +9,8 @@
   - Add new mojo "docker:save" for saving the image to a file (#687)
   - Check whether a temporary tag could be removed and throw an error if not (#725)
   - Allow multi line matches in log output (#628)
-    
+  - Don't use authentication from config when no "auth" is set (#731)
+
 * **0.20.0** (2017-02-17)
   - Removed `build-nofork` and `source-nofork` in favor for a more direct solution which prevents forking of the lifecycle. Please refer the documentation, chapter "Assembly" for more information about this.
 

--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -94,7 +94,7 @@ public class RegistryService {
             throws MojoExecutionException {
 
         return config.getAuthConfigFactory().createAuthConfig(isPush, config.isSkipExtendedAuth(), config.getAuthConfig(),
-                config.getSettings(), user, registry);
+                                                              config.getSettings(), user, registry);
     }
 
     // ===========================================

--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -118,7 +118,7 @@ public class AuthConfigFactory {
 
         // Finally check ~/.docker/config.json
         ret = getAuthConfigFromDockerConfig(registry);
-        if(ret != null) {
+        if (ret != null) {
             log.debug("AuthConfig: credentials from ~.docker/config.json");
             return ret;
         }
@@ -314,7 +314,7 @@ public class AuthConfigFactory {
         JSONObject auths = dockerConfig.getJSONObject("auths");
         String registryToLookup = registry != null ? registry : DOCKER_LOGIN_DEFAULT_REGISTRY;
         JSONObject credentials = getCredentialsNode(auths, registryToLookup);
-        if (credentials == null) {
+        if (credentials == null || !credentials.has("auth")) {
             return null;
         }
         String auth = credentials.getString("auth");


### PR DESCRIPTION
Especially when there is no auth set, don't barf but simply don't
use any auth.

Fixes #731