### PR TITLE
Add new assembly option "name"

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+* **0.20-SNAPSHOT**
+  - New assembly configuration "name" for specifying the directory which holds the assembly files (#634)
+  
 * **0.20.1** (2017-03-29)
   - Tune log output for image names ([#737](https://github.com/fabric8io/docker-maven-plugin/issues/737))
   - Allow image with multiple path segments ([#694](https://github.com/fabric8io/docker-maven-plugin/issues/694))

--- a/samples/data-jolokia/pom.xml
+++ b/samples/data-jolokia/pom.xml
@@ -162,6 +162,8 @@
                    for deploying them. I.e. this image has a script 'deploy-and-run.sh' which exactly
                    does this. -->
                 <assembly>
+                  <name>app</name>
+                  <targetDir>/maven</targetDir>
                   <mode>tar</mode>
                   <user>www-data:www-data:www-data</user>
                   <descriptor>assembly.xml</descriptor>

--- a/src/main/asciidoc/inc/_authentication.adoc
+++ b/src/main/asciidoc/inc/_authentication.adoc
@@ -167,6 +167,9 @@ password.
 [[extended-authentication]]
 == Extended Authentication
 
-Some docker registries require additional steps to authenticate.  link:https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_GetStarted.html[Amazon ECR] requires using an IAM access key to obtain temporary docker login credentials. The `docker:push` and `docker:pull` goals automatically execute this exchange for any registry of the form _awsAccountId_*.dkr.ecr.*_awsRegion_*.amazonaws.com*, unless the `skipExtendedAuth` configuration (`docker.skip.extendedAuth` property) is set true.
+Some docker registries require additional steps to authenticate.
+link:https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_GetStarted.html[Amazon ECR] requires using an IAM access key to obtain temporary docker login credentials.
+The `docker:push` and `docker:pull` goals automatically execute this exchange for any registry of the form _<awsAccountId>_ *.dkr.ecr.* _<awsRegion>_ *.amazonaws.com*, unless the `skipExtendedAuth` configuration (`docker.skip.extendedAuth` property) is set true.
 
-You can use any IAM access key with the necessary permissions in any of the locations mentioned above except `~/.docker/config.json`. Use the IAM *Access key ID* as the username and the *Secret access key* as the password.
+You can use any IAM access key with the necessary permissions in any of the locations mentioned above except `~/.docker/config.json`.
+Use the IAM *Access key ID* as the username and the *Secret access key* as the password.

--- a/src/main/asciidoc/inc/build/_assembly.adoc
+++ b/src/main/asciidoc/inc/build/_assembly.adoc
@@ -7,8 +7,11 @@ The `<assembly>` element within `<build>` is has an XML struture and defines how
 |===
 | Element | Description
 
+| *name* 
+| Assembly name, which is `maven` by default. This name is used for the archived and directories created during the build and holding the assembly files. If an <<external-dockerfile,external Dockerfile>> is used than this name is also the relative directory which contains the assembly files.
+
 | *targetDir*
-| Directory under which the files and artifacts contained in the assembly will be copied within the container. The default value for this is `/maven`.
+| Directory under which the files and artifacts contained in the assembly will be copied within the container. The default value for this is `/<assembly name>`, so `/maven` if *name* is not set to a different value. This option has no meaning when an <<external-dockerfile,external Dockerfile>> is used.
 
 | <<build-assembly-descriptor, *inline*>>
 | Inlined assembly descriptor as described in <<build-assembly-descriptor,Assembly Descriptor>> below.

--- a/src/main/asciidoc/inc/build/_overview.adoc
+++ b/src/main/asciidoc/inc/build/_overview.adoc
@@ -9,15 +9,28 @@ When using this mode, the Dockerfile is created on the fly with all instructions
 
 [[external-dockerfile]]
 .External Dockerfile or Docker archive
-Alternatively an external Dockerfile template or Docker archive can be used. This mode is switch on by using one of these three configuration options within
+Alternatively an external Dockerfile template or Docker archive can be used. This mode is switched on by using one of these three configuration options within
 
 * *dockerFileDir* specifies a directory containing a Dockerfile that will be used to create the image. The name of the Dockerfile is `Dockerfile` by default but can be also set with the option `dockerFile` (see below).
 * *dockerFile* specifies a specific Dockerfile path. The Docker build context directory is set to `dockerFileDir` if given. If not the directory by default is the directory in which the Dockerfile is stored.
 * *dockerArchive* specifies a previously saved image archive to load directly. Such a tar archive can be created with `docker save`. If a `dockerArchive` is provided, no `dockerFile` or `dockerFileDir` must be given.
 
-All paths can be either absolute or relative paths (except when both `dockerFileDir` and `dockerFile` are provided in which case `dockerFile` must not be absolute). A relative path is looked up in `${project.basedir}/src/main/docker` by default. You can make it easily an absolute path by using `${project.basedir} in your configuration.
+All paths can be either absolute or relative paths (except when both `dockerFileDir` and `dockerFile` are provided in which case `dockerFile` must not be absolute). A relative path is looked up in `${project.basedir}/src/main/docker` by default. You can make it easily an absolute path by using `${project.basedir}` in your configuration.
 
-Any additional files located in the `dockerFileDir` directory will also be added to the build context as well as any files specified by an assembly. However, you still need to insert `ADD` or `COPY` directives yourself into the Dockerfile.
+Any additional files located in the `dockerFileDir` directory will also be added to the build context as well. 
+You can also use an assembly if specified in an <<build-assembly,assembly configuration>>. 
+However you need to add the files on your own in the Dockerfile with an `ADD` or `COPY` command.
+The files of the assembly are stored in a build context relative directory `maven/` but can be changed by changing the assembly name with the option `<name>` in the assembly configuration.
+
+E.g. the files can be added with
+
+.Example
+[source,dockerfils]
+----
+COPY maven/ /my/target/directory
+----
+
+so that the assembly files will end up in `/my/target/directory` within the container. 
 
 If this directory contains a `.maven-dockerignore` (or alternatively, a `.maven-dockerexclude` file), then it is used for excluding files for the build. Each line in this file is treated as an http://ant.apache.org/manual/Types/fileset.html[FileSet exclude pattern] as used by the http://maven.apache.org/plugins/maven-assembly-plugin[maven-assembly-plugin]. It is similar to `.dockerignore` when using Docker but has a slightly different syntax (hence the different name).
 

--- a/src/main/java/io/fabric8/maven/docker/assembly/AssemblyFiles.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/AssemblyFiles.java
@@ -1,5 +1,5 @@
 package io.fabric8.maven.docker.assembly;/*
- * 
+ *
  * Copyright 2014 Roland Huss
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ public class AssemblyFiles {
      * @param assemblyDirectory directory into which the files are copied
      */
     public AssemblyFiles(File assemblyDirectory) {
-        this.assemblyDirectory = new File(assemblyDirectory.getParentFile(), DockerAssemblyManager.ASSEMBLY_NAME);
+        this.assemblyDirectory = assemblyDirectory;
     }
 
     /**

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -49,7 +49,6 @@ public class DockerAssemblyManager {
     public static final String SCRATCH_IMAGE = "scratch";
 
     // Assembly name used also as build directory within outputBuildDir
-    public static final String ASSEMBLY_NAME = "maven";
     public static final String DOCKER_IGNORE = ".maven-dockerignore";
     public static final String DOCKER_EXCLUDE = ".maven-dockerexclude";
     public static final String DOCKER_INCLUDE = ".maven-dockerinclude";
@@ -132,7 +131,7 @@ public class DockerAssemblyManager {
                 }
             }
 
-            return createBuildTarBall(buildDirs, customizer, assemblyMode, buildConfig.getCompression());
+            return createBuildTarBall(assemblyConfig.getName(), buildDirs, customizer, assemblyMode, buildConfig.getCompression());
 
         } catch (IOException e) {
             throw new MojoExecutionException(String.format("Cannot create Dockerfile in %s", buildDirs.getOutputDirectory()), e);
@@ -149,6 +148,7 @@ public class DockerAssemblyManager {
         BuildDirs buildDirs = createBuildDirs(name, mojoParams);
 
         AssemblyConfiguration assemblyConfig = buildConfig.getAssemblyConfiguration();
+        String assemblyName = assemblyConfig.getName();
         DockerAssemblyConfigurationSource source =
                         new DockerAssemblyConfigurationSource(mojoParams, buildDirs, assemblyConfig);
         Assembly assembly = getAssemblyConfig(assemblyConfig, source);
@@ -156,9 +156,9 @@ public class DockerAssemblyManager {
 
         synchronized (trackArchiver) {
             MappingTrackArchiver ta = (MappingTrackArchiver) trackArchiver;
-            ta.init(log);
+            ta.init(log, assemblyName);
             assembly.setId("tracker");
-            assemblyArchiver.createArchive(assembly, ASSEMBLY_NAME, "track", source, false);
+            assemblyArchiver.createArchive(assembly, assemblyName, "track", source, false);
             return ta.getAssemblyFiles(mojoParams.getSession());
         }
     }
@@ -201,11 +201,11 @@ public class DockerAssemblyManager {
     }
 
     // Create final tar-ball to be used for building the archive to send to the Docker daemon
-    private File createBuildTarBall(BuildDirs buildDirs, ArchiverCustomizer archiverCustomizer,
+    private File createBuildTarBall(String name, BuildDirs buildDirs, ArchiverCustomizer archiverCustomizer,
                                     AssemblyMode buildMode, ArchiveCompression compression) throws MojoExecutionException {
         File archive = new File(buildDirs.getTemporaryRootDirectory(), "docker-build." + compression.getFileSuffix());
         try {
-            TarArchiver archiver = createBuildArchiver(buildDirs.getOutputDirectory(), archive, buildMode);
+            TarArchiver archiver = createBuildArchiver(name, buildDirs.getOutputDirectory(), archive, buildMode);
             archiver = archiverCustomizer.customize(archiver);
             archiver.setCompression(compression.getTarCompressionMethod());
             archiver.createArchive();
@@ -273,14 +273,14 @@ public class DockerAssemblyManager {
         return archiveDir;
     }
 
-    private TarArchiver createBuildArchiver(File outputDir, File archive, AssemblyMode buildMode) throws NoSuchArchiverException {
+    private TarArchiver createBuildArchiver(String name, File outputDir, File archive, AssemblyMode buildMode) throws NoSuchArchiverException {
         TarArchiver archiver = (TarArchiver) archiverManager.getArchiver("tar");
         archiver.setLongfile(TarLongFileMode.posix);
 
         if (buildMode.isArchive()) {
             DefaultArchivedFileSet archiveSet =
-                    DefaultArchivedFileSet.archivedFileSet(new File(outputDir, "maven." + buildMode.getExtension()));
-            archiveSet.setPrefix(ASSEMBLY_NAME + "/");
+                    DefaultArchivedFileSet.archivedFileSet(new File(outputDir, name + "." + buildMode.getExtension()));
+            archiveSet.setPrefix(name + "/");
             archiveSet.setIncludingEmptyDirectories(true);
             archiveSet.setUsingDefaultExcludes(false);
             archiver.addArchivedFileSet(archiveSet);
@@ -311,7 +311,7 @@ public class DockerAssemblyManager {
             builder.workdir(buildConfig.getWorkdir());
         }
         if (assemblyConfig != null) {
-            builder.add(ASSEMBLY_NAME, "")
+            builder.add(assemblyConfig.getName(), "")
                    .basedir(assemblyConfig.getTargetDir())
                    .assemblyUser(assemblyConfig.getUser())
                    .exportTargetDir(assemblyConfig.exportTargetDir());
@@ -353,7 +353,7 @@ public class DockerAssemblyManager {
         try {
             originalArtifactFile = ensureThatArtifactFileIsSet(params.getProject());
             assembly.setId("docker");
-            assemblyArchiver.createArchive(assembly, ASSEMBLY_NAME, buildMode.getExtension(), source, false);
+            assemblyArchiver.createArchive(assembly, assemblyConfig.getName(), buildMode.getExtension(), source, false);
         } catch (ArchiveCreationException | AssemblyFormattingException e) {
             String error = "Failed to create assembly for docker image " +
                            " (with mode '" + buildMode + "'): " + e.getMessage() + ".";

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
@@ -50,8 +50,8 @@ public class DockerFileBuilder {
 
     // List of files to add. Source and destination follow except that destination
     // in interpreted as a relative path to the exportDir
-    // See also http://docs.docker.io/reference/builder/#add
-    private List<AddEntry> addEntries = new ArrayList<>();
+    // See also http://docs.docker.io/reference/builder/#copy
+    private List<CopyEntry> copyEntries = new ArrayList<>();
 
     // list of ports to expose and environments to use
     private List<String> ports = new ArrayList<>();
@@ -104,7 +104,7 @@ public class DockerFileBuilder {
         addLabels(b);
         addPorts(b);
 
-        addEntries(b);
+        addCopy(b);
         addWorkdir(b);
         addRun(b);
         addVolumes(b);
@@ -181,10 +181,10 @@ public class DockerFileBuilder {
         }
     }
 
-    private void addEntries(StringBuilder b) {
+    private void addCopy(StringBuilder b) {
         if (assemblyUser != null) {
             String tmpDir = createTempDir();
-            copyAddEntries(b,tmpDir);
+            addCopyEntries(b, tmpDir);
 
             String[] userParts = StringUtils.split(assemblyUser, ":");
             String userArg = userParts.length > 1 ? userParts[0] + ":" + userParts[1] : userParts[0];
@@ -197,7 +197,7 @@ public class DockerFileBuilder {
                 DockerFileKeyword.RUN.addTo(b, chmod);
             }
         } else {
-            copyAddEntries(b, "");
+            addCopyEntries(b, "");
         }
     }
 
@@ -205,8 +205,8 @@ public class DockerFileBuilder {
          return "/tmp/" + UUID.randomUUID().toString();
     }
 
-    private void copyAddEntries(StringBuilder b, String topLevelDir) {
-        for (AddEntry entry : addEntries) {
+    private void addCopyEntries(StringBuilder b, String topLevelDir) {
+        for (CopyEntry entry : copyEntries) {
             String dest = topLevelDir + (basedir.equals("/") ? "" : basedir) + "/" + entry.destination;
             DockerFileKeyword.COPY.addTo(b, entry.source, dest);
         }
@@ -353,7 +353,7 @@ public class DockerFileBuilder {
     }
 
     public DockerFileBuilder add(String source, String destination) {
-        this.addEntries.add(new AddEntry(source, destination));
+        this.copyEntries.add(new CopyEntry(source, destination));
         return this;
     }
 
@@ -423,10 +423,10 @@ public class DockerFileBuilder {
     }
 
     // All entries required, destination is relative to exportDir
-    private static final class AddEntry {
+    private static final class CopyEntry {
         private String source,destination;
 
-        private AddEntry(String src, String dest) {
+        private CopyEntry(String src, String dest) {
             source = src;
 
             // Strip leading slashes

--- a/src/main/java/io/fabric8/maven/docker/assembly/MappingTrackArchiver.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/MappingTrackArchiver.java
@@ -1,5 +1,5 @@
 package io.fabric8.maven.docker.assembly;/*
- * 
+ *
  * Copyright 2014 Roland Huss
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,13 +48,16 @@ public class MappingTrackArchiver extends TrackingArchiver {
     // Logger to use
     protected Logger log;
 
+    // Target directory to use for storing the assembly files (== name)
+    private String assemblyName;
+
     /**
      * Get all files depicted by this assembly.
      *
      * @return assembled files
      */
     public AssemblyFiles getAssemblyFiles(MavenSession session) {
-        AssemblyFiles ret = new AssemblyFiles(getDestFile());
+        AssemblyFiles ret = new AssemblyFiles(new File(getDestFile().getParentFile(), assemblyName));
         // Where the 'real' files are copied to
         for (Addition addition : added) {
             Object resource = addition.resource;
@@ -175,8 +178,9 @@ public class MappingTrackArchiver extends TrackingArchiver {
         );
     }
 
-    public void init(Logger log) {
+    public void init(Logger log, String assemblyName) {
         this.log = log;
+        this.assemblyName = assemblyName;
         added.clear();
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
@@ -23,6 +23,13 @@ public class AssemblyConfiguration implements Serializable {
     @Parameter
     private String targetDir;
 
+    /**
+     * Name of the assembly which is used also as name of the archive
+     * which is created and has to be used when providing an own Dockerfile
+     */
+    @Parameter
+    private String name = "maven";
+
     @Parameter
     private String descriptor;
 
@@ -82,7 +89,7 @@ public class AssemblyConfiguration implements Serializable {
         } else if (basedir != null) {
             return basedir;
         } else {
-            return DEFAULT_BASE_DIR;
+            return "/" + getName();
         }
     }
 
@@ -127,8 +134,12 @@ public class AssemblyConfiguration implements Serializable {
         return (ignorePermissions != null) ? ignorePermissions : Boolean.FALSE;
     }
 
-    public PermissionMode getPermissions() {
+     public PermissionMode getPermissions() {
         return permissions != null ? permissions : PermissionMode.keep;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public static class Builder {

--- a/src/test/java/io/fabric8/maven/docker/assembly/MappingTrackArchiverTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/MappingTrackArchiverTest.java
@@ -1,5 +1,5 @@
 package io.fabric8.maven.docker.assembly;/*
- * 
+ *
  * Copyright 2014 Roland Huss
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +42,7 @@ public class MappingTrackArchiverTest {
     @Before
     public void setup() throws IllegalAccessException {
         archiver = new MappingTrackArchiver();
-        archiver.init(new AnsiLogger(new SystemStreamLog(),false,false));
+        archiver.init(new AnsiLogger(new SystemStreamLog(),false,false), "maven");
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
this can be used to specify the assembly name which is used also as directory
for holding the assembly files. I.e. the directory which needs to be refered to when
an extrean Dockerfile wants to include an assembly. "targetDir" now defaults to "/" + this name.

Also extended the documentation to clarify the usage.

Fixes #634