### PR TITLE
Document default lifecycle bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ It works with Maven 3.0.5 and Docker 1.6.0 or later.
 
 #### Goals
 
-| Goal                                          | Description                           |
-| --------------------------------------------- | ------------------------------------- |
-| [`docker:start`](https://fabric8io.github.io/docker-maven-plugin/#docker:start)   | Create and start containers           |
-| [`docker:stop`](https://fabric8io.github.io/docker-maven-plugin/#docker:stop)     | Stop and destroy containers           |
-| [`docker:build`](https://fabric8io.github.io/docker-maven-plugin/#docker:build)   | Build images                          |
-| [`docker:watch`](https://fabric8io.github.io/docker-maven-plugin/#docker:watch)   | Watch for doing rebuilds and restarts |
-| [`docker:push`](https://fabric8io.github.io/docker-maven-plugin/#docker:push)     | Push images to a registry             |
-| [`docker:remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:remove) | Remove images from local docker host  |
-| [`docker:logs`](https://fabric8io.github.io/docker-maven-plugin/#docker:logs)     | Show container logs                   |
-| [`docker:source`](https://fabric8io.github.io/docker-maven-plugin/#docker:source) | Attach docker build archive to Maven project |
-| [`docker:save`](https://fabric8io.github.io/docker-maven-plugin/#docker:save)     | Save image to a file             |
-| [`docker:volume-create`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-create) | Create a volume to share data between containers |
-| [`docker:volume-remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-remove) | Remove a created volume |
+| Goal                                                                                            | Default Lifecycle Phase | Description                                      |
+| ----------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------------------------ |
+| [`docker:start`](https://fabric8io.github.io/docker-maven-plugin/#docker:start)                 | pre-integration-test    | Create and start containers                      |
+| [`docker:stop`](https://fabric8io.github.io/docker-maven-plugin/#docker:stop)                   | post-integration-test   | Stop and destroy containers                      |
+| [`docker:build`](https://fabric8io.github.io/docker-maven-plugin/#docker:build)                 | install                 | Build images                                     |
+| [`docker:watch`](https://fabric8io.github.io/docker-maven-plugin/#docker:watch)                 |                         | Watch for doing rebuilds and restarts            |
+| [`docker:push`](https://fabric8io.github.io/docker-maven-plugin/#docker:push)                   | deploy                  | Push images to a registry                        |
+| [`docker:remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:remove)               | post-integration-test   | Remove images from local docker host             |
+| [`docker:logs`](https://fabric8io.github.io/docker-maven-plugin/#docker:logs)                   |                         | Show container logs                              |
+| [`docker:source`](https://fabric8io.github.io/docker-maven-plugin/#docker:source)               | package                 | Attach docker build archive to Maven project     |
+| [`docker:save`](https://fabric8io.github.io/docker-maven-plugin/#docker:save)                   |                         | Save image to a file                             |
+| [`docker:volume-create`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-create) | pre-integration-test    | Create a volume to share data between containers |
+| [`docker:volume-remove`](https://fabric8io.github.io/docker-maven-plugin/#docker:volume-remove) | post-integration-test   | Remove a created volume                          |
 
 #### Documentation
 

--- a/src/main/asciidoc/inc/_goals.adoc
+++ b/src/main/asciidoc/inc/_goals.adoc
@@ -4,41 +4,52 @@ This plugin supports the following goals which are explained in detail
 in the next sections.
 
 .Plugin Goals
-[cols="1,3"]
+[cols="1,1,2"]
 |===
-|Goal | Description
+|Goal | Default Lifecycle Phase | Description
 
 |**<<{plugin}:build>>**
+|install
 |Build images
 
 |**<<{plugin}:start>>** or **<<{plugin}:start,{plugin}:run>>**
+|pre-integration-test
 |Create and start containers
 
 |**<<{plugin}:stop>>**
+|post-integration-test
 |Stop and destroy containers
 
 |**<<{plugin}:push>>**
+|deploy
 |Push images to a registry
 
 |**<<{plugin}:watch>>**
+|
 |Watch for doing rebuilds and restarts
 
 |**<<{plugin}:remove>>**
+|post-integration-test
 |Remove images from local docker host
 
 |**<<{plugin}:logs>>**
+|
 |Show container logs
 
 |**<<{plugin}:source>>**
+|
 |Attach docker build archive to Maven project
 
 |**<<{plugin}:save>>**
+|
 |Save images to a file
 
 |**<<{plugin}:volume-create>>**
+|pre-integration-test
 |Create a volume for containers to share data
 
 |**<<{plugin}:volume-remove>>**
+|post-integration-test
 |Remove a volume
 |===
 


### PR DESCRIPTION
This PR adds to the documentation the default bindings of the plugin goals to the Maven lifecycle phases.

I hope this helps folks to better grasp _when_ the plugin does _what_ and reduce the "I have no idea why this happens" moments for newbies (like me).