### PR TITLE
Allow system/cli properties to be used in the Dockerfile

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -95,7 +95,10 @@ public class DockerAssemblyManager {
                 }
 
                 verifyGivenDockerfile(dockerFile, buildConfig, params.getProject(), log);
-                final File interpolatedDockerFile = interpolateDockerfile(dockerFile, buildDirs, params.getProject().getProperties(), buildConfig.getFilter());
+                Properties interpolationProperties = new Properties();
+                interpolationProperties.putAll(params.getProject().getProperties());
+                interpolationProperties.putAll(params.getSession().getSystemProperties());
+                final File interpolatedDockerFile = interpolateDockerfile(dockerFile, buildDirs, interpolationProperties, buildConfig.getFilter());
                 // User dedicated Dockerfile from extra directory
                 customizer = new ArchiverCustomizer() {
                     @Override


### PR DESCRIPTION
Currently the Dockerfile interpolation doesn't include properties specified from
the command line, and only uses the values in the POM.  This change allows
the cli to set new properties and override the pom property values.