### PR TITLE
Don't fail build if volume-clean fails.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,6 +8,7 @@
   - Preserve leading whitespace in logs (#875)
   - Maven property interpolation in Dockerfiles (#877)
   - Allow parameters for the log prefix (#890)
+  - When removing a volume don't error if the volume does not exist (#788)
   
 * **0.22.1** (2017-08-28)
   - Allow Docker compose version "2", too ([#829](https://github.com/fabric8io/docker-maven-plugin/issues/829))

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -272,7 +272,7 @@ public interface DockerAccess {
    String createVolume(VolumeCreateConfig configuration) throws DockerAccessException;
 
    /**
-    * removes a volume
+    * Removes a volume. It is a no-op if the volume does not exist.
     * @param name volume name to remove
     * @throws DockerAccessException if the volume could not be removed
     */

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -524,7 +524,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
     public void removeVolume(String name) throws DockerAccessException {
         try {
             String url = urlBuilder.removeVolume(name);
-            delegate.delete(url, HTTP_NO_CONTENT);
+            delegate.delete(url, HTTP_NO_CONTENT, HTTP_NOT_FOUND);
         } catch (IOException e) {
             throw new DockerAccessException(e, "Unable to remove volume [%s]", name);
         }

--- a/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
@@ -33,14 +33,6 @@ public class VolumeService {
    }
 
    public void removeVolume(String volumeName) throws DockerAccessException {
-      try {
-	docker.removeVolume(volumeName);
-      } catch ( DockerAccessException dae ) {
-	// IGNORE
-	// If you're using volume-clean, the most likely cause for a failure
-	// is that the volume doesn't exist.  In that case, the build should
-	// not be failed.  For any other probable cause of failure, another
-	// goal will almost certainly point you at the real problem.
-      }
+      docker.removeVolume(volumeName);
    }
 }

--- a/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/VolumeService.java
@@ -33,6 +33,14 @@ public class VolumeService {
    }
 
    public void removeVolume(String volumeName) throws DockerAccessException {
-      docker.removeVolume(volumeName);
+      try {
+	docker.removeVolume(volumeName);
+      } catch ( DockerAccessException dae ) {
+	// IGNORE
+	// If you're using volume-clean, the most likely cause for a failure
+	// is that the volume doesn't exist.  In that case, the build should
+	// not be failed.  For any other probable cause of failure, another
+	// goal will almost certainly point you at the real problem.
+      }
    }
 }


### PR DESCRIPTION
This fix is admittedly simplistic.  It does not take into account any of the other possible causes for an exception.  However, if you are using volume-clean, chances are you're using volume-create, or many of the other goals provided by DMP.  In that case, you will almost certainly receive errors pointing you at the
real problem.