### PR TITLE
PropertyConfigHandler fixes

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -13,6 +13,9 @@ import org.apache.maven.plugins.annotations.Parameter;
  */
 public class BuildImageConfiguration implements Serializable {
 
+    public static final String DEFAULT_FILTER = "${*}";
+    public static final String DEFAULT_CLEANUP = "try";
+
     /**
      * Directory holding an external Dockerfile which is used to build the
      * image. This Dockerfile will be enriched by the addition build configuration
@@ -40,7 +43,7 @@ public class BuildImageConfiguration implements Serializable {
      * How interpolation of a dockerfile should be performed
      */
     @Parameter
-    private String filter = "${*}";
+    private String filter = DEFAULT_FILTER;
 
     /**
      * Base Image
@@ -70,7 +73,7 @@ public class BuildImageConfiguration implements Serializable {
     private List<String> runCmds;
 
     @Parameter
-    private String cleanup = "try";
+    private String cleanup = DEFAULT_CLEANUP;
 
     @Parameter
     private boolean nocache = false;
@@ -284,7 +287,11 @@ public class BuildImageConfiguration implements Serializable {
         }
 
         public Builder filter(String filter) {
-            config.filter = filter;
+            if (filter == null) {
+                config.filter = DEFAULT_FILTER;
+            } else {
+                config.filter = filter;
+            }
             return this;
         }
 
@@ -365,7 +372,11 @@ public class BuildImageConfiguration implements Serializable {
         }
 
         public Builder cleanup(String cleanup) {
-            config.cleanup = cleanup;
+            if (cleanup == null) {
+                config.cleanup = DEFAULT_CLEANUP;
+            } else {
+                config.cleanup = cleanup;
+            }
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -64,10 +64,12 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                         .build());
     }
 
-    // Enable build config only when a `.from.` is configured
+    // Enable build config only when a `.from.`, `.dockerFile.`, or `.dockerFileDir.` is configured
     private boolean buildConfigured(String prefix, Properties properties) {
         return withPrefix(prefix, FROM, properties) != null ||
-               mapWithPrefix(prefix,FROM_EXT,properties) != null;
+                mapWithPrefix(prefix, FROM_EXT, properties) != null ||
+                withPrefix(prefix, DOCKER_FILE, properties) != null ||
+                withPrefix(prefix, DOCKER_FILE_DIR, properties) != null;
     }
 
 

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -28,6 +28,8 @@ import org.apache.maven.project.MavenProject;
 import org.junit.*;
 import org.junit.runner.RunWith;
 
+import static io.fabric8.maven.docker.config.BuildImageConfiguration.DEFAULT_CLEANUP;
+import static io.fabric8.maven.docker.config.BuildImageConfiguration.DEFAULT_FILTER;
 import static org.junit.Assert.*;
 
 /**
@@ -228,6 +230,56 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
         ImageConfiguration config = resolveExternalImageConfig(testData);
         assertEquals(false, config.getBuildConfiguration().optimise());
+    }
+
+    @Test
+    public void testDockerFile() {
+        String[] testData = new String[] {k(ConfigKey.NAME), "image", k(ConfigKey.DOCKER_FILE), "file" };
+
+        ImageConfiguration config = resolveExternalImageConfig(testData);
+        assertNotNull(config.getBuildConfiguration());
+    }
+
+    @Test
+    public void testDockerFileDir() {
+        String[] testData = new String[] {k(ConfigKey.NAME), "image", k(ConfigKey.DOCKER_FILE_DIR), "dir" };
+
+        ImageConfiguration config = resolveExternalImageConfig(testData);
+        assertNotNull(config.getBuildConfiguration());
+    }
+
+    @Test
+    public void testFilterDefault() {
+        String[] testData = new String[] {k(ConfigKey.NAME), "image", k(ConfigKey.FROM), "base" };
+
+        ImageConfiguration config = resolveExternalImageConfig(testData);
+        assertEquals(DEFAULT_FILTER, config.getBuildConfiguration().getFilter());
+    }
+
+    @Test
+    public void testFilter() {
+        String filter = "@";
+        String[] testData = new String[] {k(ConfigKey.NAME), "image", k(ConfigKey.FROM), "base", k(ConfigKey.FILTER), filter };
+
+        ImageConfiguration config = resolveExternalImageConfig(testData);
+        assertEquals(filter, config.getBuildConfiguration().getFilter());
+    }
+
+    @Test
+    public void testCleanupDefault() {
+        String[] testData = new String[] {k(ConfigKey.NAME), "image", k(ConfigKey.FROM), "base" };
+
+        ImageConfiguration config = resolveExternalImageConfig(testData);
+        assertEquals(DEFAULT_CLEANUP, config.getBuildConfiguration().cleanupMode().toParameter());
+    }
+
+    @Test
+    public void testCleanup() {
+        CleanupMode mode = CleanupMode.REMOVE;
+        String[] testData = new String[] {k(ConfigKey.NAME), "image", k(ConfigKey.FROM), "base", k(ConfigKey.CLEANUP), mode.toParameter() };
+
+        ImageConfiguration config = resolveExternalImageConfig(testData);
+        assertEquals(mode, config.getBuildConfiguration().cleanupMode());
     }
 
     @Test


### PR DESCRIPTION
PropertyConfigHandler#buildConfigured should also return true if the dockerFile or dockerFileDir properties are set

BuildImageConfiguration do not overwrite filter and cleanup default values with null properties

Signed-off-by: Adrian Gonzalez <adrian.gonzalez@ef.com>