### PR TITLE
Allow comma separated list of container names in dependsOn elements

### DIFF
--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -64,7 +64,7 @@
                   <alias>box2</alias>
                 </network>
                 <dependsOn>
-                  <dependsOn>box1</dependsOn>
+                  <container>box1</container>
                 </dependsOn>
                 <namingStrategy>none</namingStrategy>
                 <cmd>

--- a/src/main/asciidoc/inc/start/_depends-on.adoc
+++ b/src/main/asciidoc/inc/start/_depends-on.adoc
@@ -4,6 +4,7 @@ Your containers should preferably be able to deal with temporarily unresolvable 
 
 The `<dependsOn>` configuration can be used to expresses custom network dependencies between your containers. `docker:start` will ensure that all dependencies a container depends on are completely started (fulfilling all `<wait>` conditions) before the depending container is started.
 
+Additionally, each `<container>` element can specify a comma separated set of containers.  Comma (and whitespace) can be used to separate containers since valid docker container names contain only characters, digits, underscores, periods and dashes.
 
 .Example
 [source,xml]

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -97,7 +97,7 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
 
     private void addLinks(RunImageConfiguration runConfig, List<String> ret) {
         // Custom networks can have circular links, no need to be considered for the starting order.
-        if (runConfig.getLinks() != null && !runConfig.getNetworkingConfig().isCustomNetwork()) {
+        if (!runConfig.getNetworkingConfig().isCustomNetwork()) {
             for (String[] link : EnvUtil.splitOnLastColon(runConfig.getLinks())) {
                 ret.add(link[0]);
             }
@@ -114,7 +114,7 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
 
     private void addDependsOn(RunImageConfiguration runConfig, List<String> ret) {
         // Only used in custom networks.
-        if (runConfig.getDependsOn() != null && runConfig.getNetworkingConfig().isCustomNetwork()) {
+        if (runConfig.getNetworkingConfig().isCustomNetwork()) {
             for (String link : runConfig.getDependsOn()) {
                 ret.add(link);
             }

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -10,6 +10,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import io.fabric8.maven.docker.util.EnvUtil;
 
+import javax.annotation.Nonnull;
+
 /**
  * @author roland
  * @since 02.09.14
@@ -189,6 +191,7 @@ public class RunImageConfiguration implements Serializable {
         return domainname;
     }
 
+    @Nonnull
     public List<String> getDependsOn() {
         return EnvUtil.splitAtCommasAndTrim(dependsOn);
     }
@@ -271,6 +274,7 @@ public class RunImageConfiguration implements Serializable {
         return volumes;
     }
 
+    @Nonnull
     public List<String> getLinks() {
         return EnvUtil.splitAtCommasAndTrim(links);
     }

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -190,7 +190,7 @@ public class RunImageConfiguration implements Serializable {
     }
 
     public List<String> getDependsOn() {
-        return dependsOn;
+        return EnvUtil.splitAtCommasAndTrim(dependsOn);
     }
 
     public String getUser() {

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -17,6 +17,8 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+import javax.annotation.Nonnull;
+
 import static java.util.concurrent.TimeUnit.*;
 
 /**
@@ -124,6 +126,7 @@ public class EnvUtil {
      * @param input Iterable over strings.
      * @return An Iterable over string which breaks down each input element at comma boundaries
      */
+    @Nonnull
     public static List<String> splitAtCommasAndTrim(Iterable<String> input) {
         if(input==null) {
             return Collections.emptyList();


### PR DESCRIPTION
### Description
Allow comma separated list of <dependsOn> elements.  (Similar to #558)
### Info

* Feature request: Allow something like:
```
<dependsOn>
   <container>mongo,identity</container>
</dependsOn>
```