### PR TITLE
Ignore empty List<String> configuration values

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,8 @@
   - Fix property config handler to work also with dockerFile and dockerFileDir (#790)
   - Fix `dockerFile` option when pointing to another Dockerfile name (#784)
   - Allow comma separated list of container names in dependsOn elements (#810)
+  - Trim whitespace and ignore empty elements in build configuration ports, runCmds, tags, volumes (#816)
+  - Trim whitespace and ignore empty elements in run configuration ports (#816)
   
 * **0.21.0** (2017-05-16)
   - Add wait checker for checking the exit code of a container ([#498](https://github.com/fabric8io/docker-maven-plugin/issues/498)) 

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -85,22 +85,22 @@ a| Definition of a health check as described in <<build-healthcheck, Healthcheck
 | if set to true then it will compress all the `runCmds` into a single `RUN` directive so that only one image layer is created.
 
 | *ports*
-| The exposed ports which is a list of `<port>` elements, one for each port to expose. The format can be either pure numerical ("8080") or with the protocol attached ("8080/tcp"),
+| The exposed ports which is a list of `<port>` elements, one for each port to expose. Whitespace is trimmed from each element and empty elements are ignored. The format can be either pure numerical ("8080") or with the protocol attached ("8080/tcp").
 
 | *runCmds*
-| Commands to be run during the build process. It contains *run* elements which are passed to the shell. The run commands are inserted right after the assembly and after *workdir* in to the Dockerfile. This tag is not to be confused with the `<run>` section for this image which specifies the runtime behaviour when starting containers.
+| Commands to be run during the build process. It contains *run* elements which are passed to the shell. Whitespace is trimmed from each element and empty elements are ignored. The run commands are inserted right after the assembly and after *workdir* in to the Dockerfile. This tag is not to be confused with the `<run>` section for this image which specifies the runtime behaviour when starting containers.
 
 | *skip*
 | if set to true disables building of the image. This config option is best used together with a maven property
 
 | *tags*
-| List of additional `tag` elements with which an image is to be tagged after the build.
+| List of additional `tag` elements with which an image is to be tagged after the build. Whitespace is trimmed from each element and empty elements are ignored.
 
 | *user*
 | User to which the Dockerfile should switch to the end (corresponds to the `USER` Dockerfile directive).
 
 | *volumes*
-| List of `volume` elements to create a container volume.
+| List of `volume` elements to create a container volume. Whitespace is trimmed from each element and empty elements are ignored.
 
 | *workdir*
 | Directory to change to when starting the container.

--- a/src/main/asciidoc/inc/start/_port-mapping.adoc
+++ b/src/main/asciidoc/inc/start/_port-mapping.adoc
@@ -1,5 +1,5 @@
 
-The `<ports>` configuration contains a list of port mappings. Each mapping has multiple parts, each separate by a colon. This is equivalent to the port mapping when using the Docker CLI with option `-p`.
+The `<ports>` configuration contains a list of port mappings. Whitespace is trimmed from each element and empty elements are ignored. Each mapping has multiple parts, each separate by a colon. This is equivalent to the port mapping when using the Docker CLI with option `-p`.
 
 A `port` stanza may take one of the following forms:
 

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -7,6 +7,8 @@ import java.util.*;
 import io.fabric8.maven.docker.util.*;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import javax.annotation.Nonnull;
+
 /**
  * @author roland
  * @since 02.09.14
@@ -175,16 +177,19 @@ public class BuildImageConfiguration implements Serializable {
         return assembly;
     }
 
+    @Nonnull
     public List<String> getPorts() {
-        return ports;
+        return EnvUtil.removeEmpties(ports);
     }
 
+    @Nonnull
     public List<String> getVolumes() {
-        return volumes != null ? volumes : Collections.<String>emptyList();
+        return EnvUtil.removeEmpties(volumes);
     }
 
+    @Nonnull
     public List<String> getTags() {
-        return tags != null ? tags : Collections.<String>emptyList();
+        return EnvUtil.removeEmpties(tags);
     }
 
     public Map<String, String> getEnv() {
@@ -232,8 +237,9 @@ public class BuildImageConfiguration implements Serializable {
         return entryPoint;
     }
 
+    @Nonnull
     public List<String> getRunCmds() {
-        return runCmds;
+        return EnvUtil.removeEmpties(runCmds);
     }
 
     public String getUser() {

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -179,17 +179,17 @@ public class BuildImageConfiguration implements Serializable {
 
     @Nonnull
     public List<String> getPorts() {
-        return EnvUtil.removeEmpties(ports);
+        return EnvUtil.removeEmptyEntries(ports);
     }
 
     @Nonnull
     public List<String> getVolumes() {
-        return EnvUtil.removeEmpties(volumes);
+        return EnvUtil.removeEmptyEntries(volumes);
     }
 
     @Nonnull
     public List<String> getTags() {
-        return EnvUtil.removeEmpties(tags);
+        return EnvUtil.removeEmptyEntries(tags);
     }
 
     public Map<String, String> getEnv() {
@@ -239,7 +239,7 @@ public class BuildImageConfiguration implements Serializable {
 
     @Nonnull
     public List<String> getRunCmds() {
-        return EnvUtil.removeEmpties(runCmds);
+        return EnvUtil.removeEmptyEntries(runCmds);
     }
 
     public String getUser() {

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -212,8 +212,9 @@ public class RunImageConfiguration implements Serializable {
         return memorySwap;
     }
 
+    @Nonnull
     public List<String> getPorts() {
-        return (ports != null) ? ports : Collections.<String>emptyList();
+        return EnvUtil.removeEmpties(ports);
     }
 
     public Arguments getCmd() {

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -1,7 +1,6 @@
 package io.fabric8.maven.docker.config;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -214,7 +213,7 @@ public class RunImageConfiguration implements Serializable {
 
     @Nonnull
     public List<String> getPorts() {
-        return EnvUtil.removeEmpties(ports);
+        return EnvUtil.removeEmptyEntries(ports);
     }
 
     public Arguments getCmd() {

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -12,12 +12,14 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.shared.utils.io.FileUtils;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static java.util.concurrent.TimeUnit.*;
 
@@ -120,6 +122,27 @@ public class EnvUtil {
             return COMMA_SPLIT.split(input);
         }
     };
+
+    static public final Predicate<String> NOT_EMPTY = new Predicate<String>() {
+        @Override
+        public boolean apply(@Nullable String s) {
+            return s!=null && !s.isEmpty();
+        }
+    };
+
+    /**
+     * Remove empty members of a list.
+     * @param input A list of String
+     * @return A list of Non-Empty (length>0) String
+     */
+    @Nonnull
+    public static List<String> removeEmpties(@Nullable List<String> input) {
+        if(input==null) {
+            return Collections.emptyList();
+        }
+        Iterable<String> nonEmptyInputs = Iterables.filter(input, NOT_EMPTY);
+        return Lists.newArrayList(Iterables.concat(nonEmptyInputs));
+    }
 
     /**
      * Split each element of an Iterable<String> at commas.
@@ -360,5 +383,4 @@ public class EnvUtil {
     public static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().contains("windows");
     }
-
 }

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -123,10 +123,18 @@ public class EnvUtil {
         }
     };
 
-    static public final Predicate<String> NOT_EMPTY = new Predicate<String>() {
+    private static final Predicate<String> NOT_EMPTY = new Predicate<String>() {
         @Override
         public boolean apply(@Nullable String s) {
             return s!=null && !s.isEmpty();
+        }
+    };
+
+    private static final Function<String,String> TRIM = new Function<String,String>() {
+        @Nullable
+        @Override
+        public String apply(@Nullable String s) {
+            return s!=null ?s.trim() :s;
         }
     };
 
@@ -136,12 +144,13 @@ public class EnvUtil {
      * @return A list of Non-Empty (length>0) String
      */
     @Nonnull
-    public static List<String> removeEmpties(@Nullable List<String> input) {
+    public static List<String> removeEmptyEntries(@Nullable List<String> input) {
         if(input==null) {
             return Collections.emptyList();
         }
-        Iterable<String> nonEmptyInputs = Iterables.filter(input, NOT_EMPTY);
-        return Lists.newArrayList(Iterables.concat(nonEmptyInputs));
+        Iterable<String> trimmedInputs = Iterables.transform(input, TRIM);
+        Iterable<String> nonEmptyInputs = Iterables.filter(trimmedInputs, NOT_EMPTY);
+        return Lists.newArrayList(nonEmptyInputs);
     }
 
     /**

--- a/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
@@ -39,6 +39,12 @@ public class EnvUtilTest {
     }
 
     @Test
+    public void removeEmpties() {
+        assertEquals(ImmutableList.of("ein"),  EnvUtil.removeEmpties(Arrays.asList(null, "", "ein")));
+        assertEquals(ImmutableList.of(), EnvUtil.removeEmpties(null));
+    }
+
+    @Test
     public void splitAtCommas() {
         Iterable<String> it = EnvUtil.splitAtCommasAndTrim(Arrays.asList("db,postgres:9:db", "postgres:db"));
         Iterable<String> expected = ImmutableList.of ("db", "postgres:9:db","postgres:db");

--- a/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
@@ -39,9 +39,9 @@ public class EnvUtilTest {
     }
 
     @Test
-    public void removeEmpties() {
-        assertEquals(ImmutableList.of("ein"),  EnvUtil.removeEmpties(Arrays.asList(null, "", "ein")));
-        assertEquals(ImmutableList.of(), EnvUtil.removeEmpties(null));
+    public void removeEmptyEntries() {
+        assertEquals(ImmutableList.of("ein"),  EnvUtil.removeEmptyEntries(Arrays.asList(null, "", " ein", " ")));
+        assertEquals(ImmutableList.of(), EnvUtil.removeEmptyEntries(null));
     }
 
     @Test


### PR DESCRIPTION
Allow empty list elements.  This often occurs when a parent (corporate) pom has configuration values that are overridden by some, but not all, children.