### PR TITLE
Adding customizer to service to allow changing the archive root

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/assembly/AllFilesExecCustomizer.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/AllFilesExecCustomizer.java
@@ -31,11 +31,11 @@ import org.codehaus.plexus.util.StringUtils;
  * @author roland
  * @since 26/06/16
  */
-class AllFilesExecCustomizer implements DockerAssemblyManager.ArchiverCustomizer {
-    private DockerAssemblyManager.ArchiverCustomizer innerCustomizer;
+class AllFilesExecCustomizer implements ArchiverCustomizer {
+    private ArchiverCustomizer innerCustomizer;
     private Logger log;
 
-    AllFilesExecCustomizer(DockerAssemblyManager.ArchiverCustomizer inner, Logger logger) {
+    AllFilesExecCustomizer(ArchiverCustomizer inner, Logger logger) {
         innerCustomizer = inner;
         this.log = logger;
     }

--- a/src/main/java/io/fabric8/maven/docker/assembly/ArchiverCustomizer.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/ArchiverCustomizer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.docker.assembly;
+
+import java.io.IOException;
+
+import org.codehaus.plexus.archiver.tar.TarArchiver;
+
+/**
+ * Archiver used to adapt for customizations.
+ *
+ * @author nicola
+ * @since 04/08/2017
+ */
+public interface ArchiverCustomizer {
+    TarArchiver customize(TarArchiver archiver) throws IOException;
+}

--- a/src/main/java/io/fabric8/maven/docker/service/ArchiveService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/ArchiveService.java
@@ -15,6 +15,7 @@ package io.fabric8.maven.docker.service;/*
  * limitations under the License.
  */
 
+import io.fabric8.maven.docker.assembly.ArchiverCustomizer;
 import io.fabric8.maven.docker.assembly.AssemblyFiles;
 import io.fabric8.maven.docker.assembly.DockerAssemblyManager;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
@@ -56,7 +57,22 @@ public class ArchiveService {
      */
     public File createDockerBuildArchive(ImageConfiguration imageConfig, MojoParameters params)
             throws MojoExecutionException {
-        File ret = createArchive(imageConfig.getName(), imageConfig.getBuildConfiguration(), params, log);
+        return createDockerBuildArchive(imageConfig, params, null);
+    }
+
+    /**
+     * Create the tar file container the source for building an image. This tar can be used directly for
+     * uploading to a Docker daemon for creating the image
+     *
+     * @param imageConfig the image configuration
+     * @param params mojo params for the project
+     * @param customizer final customizer to be applied to the tar before being generated
+     * @return file for holding the sources
+     * @throws MojoExecutionException if during creation of the tar an error occurs.
+     */
+    public File createDockerBuildArchive(ImageConfiguration imageConfig, MojoParameters params, ArchiverCustomizer customizer)
+            throws MojoExecutionException {
+        File ret = createArchive(imageConfig.getName(), imageConfig.getBuildConfiguration(), params, log, customizer);
         log.info("%s: Created docker source tar %s",imageConfig.getDescription(), ret);
         return ret;
     }
@@ -99,6 +115,11 @@ public class ArchiveService {
 
     File createArchive(String imageName, BuildImageConfiguration buildConfig, MojoParameters params, Logger log)
             throws MojoExecutionException {
-        return dockerAssemblyManager.createDockerTarArchive(imageName, params, buildConfig, log);
+        return createArchive(imageName, buildConfig, params, log, null);
+    }
+
+    File createArchive(String imageName, BuildImageConfiguration buildConfig, MojoParameters params, Logger log, ArchiverCustomizer customizer)
+            throws MojoExecutionException {
+        return dockerAssemblyManager.createDockerTarArchive(imageName, params, buildConfig, log, customizer);
     }
 }


### PR DESCRIPTION
This will expose the archive customizer to be able to write to the root of the generated tar file (assembly config allows to write into a subfolder, e.g. "maven" by default). S2I files should be written to the ".s2i" folder in the root of the archive.

@rhuss I've tried not to expose maven/plexus objects but I can't find a straightforward approach.

This is to fix the Issue: https://github.com/fabric8io/fabric8-maven-plugin/issues/1009
Related change to f-m-p: https://github.com/nicolaferraro/fabric8-maven-plugin/tree/1009-java-options