### PR TITLE
Support relative paths in `volumes` statements in docker-compose.yaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.8.47</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/ComposeUtils.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/ComposeUtils.java
@@ -1,0 +1,49 @@
+package io.fabric8.maven.docker.config.handler.compose;
+
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+
+/**
+ * Path-resolution methods
+ */
+class ComposeUtils {
+
+    /**
+     * Resolves a docker-compose file against the supplied base directory.  The returned {@code File} is guaranteed to
+     * be {@link File#isAbsolute() absolute}.
+     * <p>
+     * If {@code composeFile} is {@link File#isAbsolute() absolute}, then it is returned unmodified.  Otherwise, the
+     * {@code composeFile} is returned as an absolute {@code File} using the {@link #resolveAbsolutely(String,
+     * MavenProject) resolved} {@code baseDir} as its parent.
+     * </p>
+     *
+     * @param baseDir the base directory containing the docker-compose file (ignored if {@code composeFile} is absolute)
+     * @param composeFile the path of the docker-compose file, may be absolute
+     * @param project the {@code MavenProject} used to resolve the {@code baseDir}
+     * @return an absolute {@code File} reference to the {@code composeFile}
+     */
+    static File resolveComposeFileAbsolutely(String baseDir, String composeFile, MavenProject project) {
+        File yamlFile = new File(composeFile);
+        return yamlFile.isAbsolute() ? yamlFile :  new File(resolveAbsolutely(baseDir, project),composeFile);
+    }
+
+    /**
+     * Resolves the supplied resource (a path or directory on the filesystem) relative the Maven {@link
+     * MavenProject#getBasedir() base directory}.  The returned {@code File} is guaranteed to be {@link
+     * File#isAbsolute() absolute}.  The returned file is <em>not</em> guaranteed to exist.
+     * <p>
+     * If {@code pathToResolve} is {@link File#isAbsolute() absolute}, then it is returned unmodified.  Otherwise, the
+     * {@code pathToResolve} is returned as an absolute {@code File} using the {@link MavenProject#getBasedir() Maven
+     * Project base directory} as its parent.
+     * </p>
+     *
+     * @param pathToResolve represents a filesystem resource, which may be an absolute path
+     * @param project the Maven project used to resolve non-absolute path resources
+     * @return an absolute {@code File} reference to {@code pathToResolve}; <em>not</em> guaranteed to exist
+     */
+    static File resolveAbsolutely(String pathToResolve, MavenProject project) {
+        File baseDirAsFile = new File(pathToResolve);
+        return baseDirAsFile.isAbsolute() ? baseDirAsFile : new File(project.getBasedir(), pathToResolve);
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandler.java
@@ -14,6 +14,9 @@ import org.apache.maven.shared.filtering.MavenReaderFilter;
 import org.apache.maven.shared.filtering.MavenReaderFilterRequest;
 import org.yaml.snakeyaml.Yaml;
 
+import static io.fabric8.maven.docker.config.handler.compose.ComposeUtils.resolveAbsolutely;
+import static io.fabric8.maven.docker.config.handler.compose.ComposeUtils.resolveComposeFileAbsolutely;
+
 
 /**
  * Docker Compose handler for allowing a docker-compose file to be used
@@ -39,7 +42,7 @@ public class DockerComposeConfigHandler implements ExternalConfigHandler {
         List<ImageConfiguration> resolved = new ArrayList<>();
 
         DockerComposeConfiguration handlerConfig = new DockerComposeConfiguration(unresolvedConfig.getExternalConfig());
-        File composeFile = resolveComposeFile(handlerConfig.getBasedir(), handlerConfig.getComposeFile(), project);
+        File composeFile = resolveComposeFileAbsolutely(handlerConfig.getBasedir(), handlerConfig.getComposeFile(), project);
 
         for (Object composeO : getComposeConfigurations(composeFile, project, session)) {
             Map<String, Object> compose = (Map<String, Object>) composeO;
@@ -49,7 +52,7 @@ public class DockerComposeConfigHandler implements ExternalConfigHandler {
                 String serviceName = entry.getKey();
                 Map<String, Object> serviceDefinition = (Map<String, Object>) entry.getValue();
 
-                DockerComposeServiceWrapper mapper = new DockerComposeServiceWrapper(serviceName, composeFile, serviceDefinition, unresolvedConfig);
+                DockerComposeServiceWrapper mapper = new DockerComposeServiceWrapper(serviceName, composeFile, serviceDefinition, unresolvedConfig, resolveAbsolutely(handlerConfig.getBasedir(), project));
                 resolved.add(buildImageConfiguration(mapper, composeFile.getParentFile(), unresolvedConfig, handlerConfig));
             }
         }
@@ -207,8 +210,4 @@ public class DockerComposeConfigHandler implements ExternalConfigHandler {
                 .build();
     }
 
-    private File resolveComposeFile(String baseDir, String compose, MavenProject project) {
-        File yamlFile = new File(compose);
-        return yamlFile.isAbsolute() ? yamlFile :  new File(new File(project.getBasedir(),baseDir),compose);
-    }
 }

--- a/src/test/java/io/fabric8/maven/docker/config/handler/compose/ComposeUtilsTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/compose/ComposeUtilsTest.java
@@ -1,0 +1,50 @@
+package io.fabric8.maven.docker.config.handler.compose;
+
+import org.apache.maven.project.MavenProject;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ */
+public class ComposeUtilsTest {
+
+
+    @Test
+    public void resolveComposeFileWithAbsoluteComposeFile() throws Exception {
+        String absComposeFile = "/absolute/path/to/docker-compose.yaml";
+
+        assertEquals(new File(absComposeFile),
+                ComposeUtils.resolveComposeFileAbsolutely(null, absComposeFile, null));
+    }
+
+    @Test
+    public void resolveComposeFileWithRelativeComposeFileAndAbsoluteBaseDir() throws Exception {
+        String relComposeFile = "relative/path/to/docker-compose.yaml";
+        String absBaseDir = "/basedir/";
+
+        assertEquals(new File(absBaseDir, relComposeFile),
+                ComposeUtils.resolveComposeFileAbsolutely(absBaseDir, relComposeFile, null));
+    }
+
+    @Test
+    public void resolveComposeFileWithRelativeComposeFileAndRelativeBaseDir() throws Exception {
+        String relComposeFile = "relative/path/to/docker-compose.yaml";
+        String relBaseDir = "basedir/";
+        String absMavenProjectDir = "/absoute/path/to/maven/project";
+
+        MavenProject project = mock(MavenProject.class);
+        when(project.getBasedir()).thenReturn(new File(absMavenProjectDir));
+
+
+        assertEquals(new File(new File(absMavenProjectDir, relBaseDir), relComposeFile),
+                ComposeUtils.resolveComposeFileAbsolutely(relBaseDir, relComposeFile, project));
+        verify(project).getBasedir();
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapperTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapperTest.java
@@ -1,0 +1,73 @@
+package io.fabric8.maven.docker.config.handler.compose;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static io.fabric8.maven.docker.config.handler.compose.DockerComposeServiceWrapper.resolveRelativeVolumeBinding;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class DockerComposeServiceWrapperTest {
+
+    private File baseDir = new File("/absolute/basedir");
+    private String relativePath = "./rel";
+    private String userPath = "~/rel";
+    private String bindingPath = "/path/to/container/dir";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void relativeBaseDir() throws Exception {
+        resolveRelativeVolumeBinding(new File("relative/"), null);
+    }
+
+    @Test
+    public void testResolveRelativeVolumePath() throws Exception {
+        String volumeString = String.format("%s:%s", relativePath, bindingPath);
+
+        // './rel:/path/to/container/dir' to '/absolute/basedir/rel:/path/to/container/dir'
+        String relativizedVolumeString = resolveRelativeVolumeBinding(baseDir, volumeString);
+
+        assertEquals(String.format("%s:%s", new File(baseDir, relativePath.substring(2)), bindingPath),
+                relativizedVolumeString);
+    }
+
+    @Test
+    public void testResolveUserVolumePath() throws Exception {
+        String volumeString = String.format("%s:%s", userPath, bindingPath);
+
+        // '~/rel:/path/to/container/dir' to '/user/home/rel:/path/to/container/dir'
+        String relativizedVolumeString = resolveRelativeVolumeBinding(baseDir, volumeString);
+
+        assertEquals(String.format("%s:%s",
+                    new File(System.getProperty("user.home"), relativePath.substring(2)), bindingPath),
+                relativizedVolumeString);
+    }
+
+    @Test
+    public void testResolveNamedVolume() throws Exception {
+        String volumeName = "volname";
+        String volumeString = String.format("%s:%s", volumeName, bindingPath);
+
+        // volumeString should be untouched
+        assertEquals(volumeString, resolveRelativeVolumeBinding(baseDir, volumeString));
+    }
+
+    @Test
+    public void testResolveAbsolutePathMapping() throws Exception {
+        String absolutePath = "/absolute/path";
+        String volumeString = String.format("%s:%s", absolutePath, bindingPath);
+
+        // volumeString should be untouched
+        assertEquals(volumeString, resolveRelativeVolumeBinding(baseDir, volumeString));
+    }
+
+    @Test
+    public void testResolveSinglePath() throws Exception {
+        String absolutePath = "/absolute/path";
+
+        // volumeString should be untouched
+        assertEquals(absolutePath, resolveRelativeVolumeBinding(baseDir, absolutePath));
+    }
+}


### PR DESCRIPTION
* Moves path resolution logic to a utility class
* Includes tests
* Adds mockito-core as a test dependency

Addresses #846

Signed-off-by: Elliot Metsger <emetsger@jhu.edu>