### PR TITLE
Docker Compose: allow version "2" not only "2.x"

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandler.java
@@ -59,7 +59,7 @@ public class DockerComposeConfigHandler implements ExternalConfigHandler {
 
     private void validateVersion(Map<String, Object> compose, File file) {
         Object version = compose.get("version");
-        if (version == null || !version.toString().trim().startsWith("2.")) {
+        if (version == null || !(Objects.equals(version, "2") && version.toString().trim().startsWith("2."))) {
             throw new ExternalConfigHandlerException("Only version 2.X of the docker-compose format is supported for " + file);
         }
     }


### PR DESCRIPTION
Fixes #829 