### PR TITLE
Preserve leading whitespace in logs

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -45,7 +45,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 public class LogRequestor extends Thread implements LogGetHandle {
 
     // Patter for matching log entries
-    static final Pattern LOG_LINE = Pattern.compile("^\\[?(?<timestamp>[^\\s\\]]*)]?\\s+(?<entry>.*?)\\s*$", Pattern.DOTALL);
+    static final Pattern LOG_LINE = Pattern.compile("^\\[?(?<timestamp>[^\\s\\]]*)]? (?<entry>.*?)\\s*$", Pattern.DOTALL);
     private final CloseableHttpClient client;
 
     private final String containerId;

--- a/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
@@ -97,6 +97,25 @@ public class LogRequestorTest {
     }
 
     @Test
+    public void testMessageWithLeadingWhitespace() throws Exception {
+        final Streams type = Streams.STDOUT;
+        final String message0 = " I have a leading space";
+        final String message1 = "\tI have a leading tab";
+
+        final ByteBuffer body = responseContent(type, message0, message1);
+        final InputStream inputStream = new ByteArrayInputStream(body.array());
+
+        setupMocks(inputStream);
+        new LogRequestor(client, urlBuilder, containerId, callback).fetchLogs();
+
+        new Verifications() {{
+            callback.log(type.type, (Timestamp) any, message0);
+            callback.log(type.type, (Timestamp) any, message1);
+        }};
+    }
+
+
+    @Test
     public void testAllStreams() throws Exception {
         final Random rand = new Random();
         final int upperBound = 1024;


### PR DESCRIPTION
Changes the log line match pattern to preserve leading whitespace in log
lines by only consuming a single space delimiter between the timestamp
and the message body.

Signed-off-by: Scott Coplin <coplin.6@osu.edu>