### PR TITLE
Allow logging prefix to be disabled

### DIFF
--- a/src/main/asciidoc/inc/start/_logging.adoc
+++ b/src/main/asciidoc/inc/start/_logging.adoc
@@ -12,6 +12,9 @@ When running containers the standard output and standard error of the container 
 | *prefix*
 | Prefix to use for the log output in order to identify the container. By default the image `alias` is used or alternatively the container `id`.
 
+| *disablePrefix*
+| Whether to disable the prefix added to log lines to differentiate containers. When only one container is in use and no differentiation is needed, you can eliminate noise by disabling log prefixing. Defaults to `false`.
+
 | *date*
 a| Dateformat to use for log timestamps. If `<date>` is not given no timestamp will be shown. The date specification can be either a constant or a date format. The recognized constants are:
 
@@ -28,7 +31,7 @@ As an alternative a date-time format string as recognized by
 http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html[JodaTime] is possible. In order to set a consistent date format the global configuration parameter `logDate` can be used.
 
 | *color*
-| Color used for coloring the prefix when coloring is enabeld (i.e. if running in a console and `useColor` is set). The available colors are `YELLOW`, `CYAN`, `MAGENTA`, `GREEN`, `RED`, `BLUE`. If coloring is enabled and now color is provided a color is picked for you.
+| Color used for coloring the prefix when coloring is enabled (i.e. if running in a console and `useColor` is set). The available colors are `YELLOW`, `CYAN`, `MAGENTA`, `GREEN`, `RED`, `BLUE`. If coloring is enabled and now color is provided a color is picked for you.
 
 | *file*
 | Path to a file to which the log output is written. This file is overwritten for every run and colors are switched off.

--- a/src/main/java/io/fabric8/maven/docker/config/LogConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/LogConfiguration.java
@@ -11,13 +11,16 @@ import org.apache.maven.plugins.annotations.Parameter;
  */
 public class LogConfiguration implements Serializable {
 
-    public static final LogConfiguration DEFAULT = new LogConfiguration(false, null, null, null, null, null);
+    public static final LogConfiguration DEFAULT = new LogConfiguration(false, null, false, null, null, null, null);
 
     @Parameter(defaultValue = "true")
     private boolean enabled = true;
 
     @Parameter
     private String prefix;
+
+    @Parameter (defaultValue = "false")
+    private boolean disablePrefix = false;
 
     @Parameter
     private String date;
@@ -33,9 +36,10 @@ public class LogConfiguration implements Serializable {
 
     public LogConfiguration() {}
 
-    private LogConfiguration(boolean enabled, String prefix, String color, String date, String file, LogDriver driver) {
+    private LogConfiguration(boolean enabled, String prefix, boolean disablePrefix, String color, String date, String file, LogDriver driver) {
         this.enabled = enabled;
         this.prefix = prefix;
+        this.disablePrefix = disablePrefix;
         this.date = date;
         this.color = color;
         this.file = file;
@@ -44,6 +48,10 @@ public class LogConfiguration implements Serializable {
 
     public String getPrefix() {
         return prefix;
+    }
+
+    public boolean isDisablePrefix() {
+        return disablePrefix;
     }
 
     public String getDate() {
@@ -97,6 +105,7 @@ public class LogConfiguration implements Serializable {
     public static class Builder {
         private boolean enabled = true;
         private String prefix, date, color, file;
+        private boolean disablePrefix = false;
         private Map<String, String> driverOpts;
         private String driverName;
         public Builder enabled(boolean enabled) {
@@ -106,6 +115,11 @@ public class LogConfiguration implements Serializable {
 
         public Builder prefix(String prefix) {
             this.prefix = prefix;
+            return this;
+        }
+
+        public Builder disablePrefix(boolean disablePrefix) {
+            this.disablePrefix = disablePrefix;
             return this;
         }
 
@@ -136,7 +150,7 @@ public class LogConfiguration implements Serializable {
 
 
         public LogConfiguration build() {
-            return new LogConfiguration(enabled, prefix, color, date, file,
+            return new LogConfiguration(enabled, prefix, disablePrefix, color, date, file,
                                         driverName != null ? new LogDriver(driverName,driverOpts) : null);
         }
     }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -69,6 +69,7 @@ public enum ConfigKey {
     LINKS,
     LOG_ENABLED("log.enabled"),
     LOG_PREFIX("log.prefix"),
+    LOG_DISABLE_PREFIX("log.disablePrefix"),
     LOG_DATE("log.date"),
     LOG_COLOR("log.color"),
     LOG_DRIVER_NAME("log.driver.name"),

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -231,6 +231,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         if (enabled != null) {
             builder.enabled(enabled);
         }
+        Boolean disablePrefix = booleanWithPrefix(prefix, LOG_DISABLE_PREFIX, properties);
+        if (disablePrefix != null) {
+            builder.disablePrefix(disablePrefix);
+        }
         return builder.build();
     }
 

--- a/src/main/java/io/fabric8/maven/docker/log/LogOutputSpec.java
+++ b/src/main/java/io/fabric8/maven/docker/log/LogOutputSpec.java
@@ -65,8 +65,8 @@ public class LogOutputSpec {
         return logStdout;
     }
 
-    public String getPrompt(boolean withColor,Timestamp timestamp) {
-        return formatTimestamp(timestamp,withColor) + formatPrefix(prefix, withColor) + "> ";
+    public String getPrompt(boolean withColor, Timestamp timestamp) {
+        return formatTimestamp(timestamp,withColor) + (prefix == null ? "" : formatPrefix(prefix, withColor) + "> ");
     }
 
     public String getFile(){

--- a/src/main/java/io/fabric8/maven/docker/log/LogOutputSpecFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/log/LogOutputSpecFactory.java
@@ -41,7 +41,7 @@ public class LogOutputSpecFactory {
         LogConfiguration logConfig = extractLogConfiguration(imageConfiguration);
 
         addLogFormat(builder, logConfig);
-        addPrefix(builder, logConfig.getPrefix(), imageConfiguration.getAlias(), containerId);
+        addPrefix(builder, logConfig.getPrefix(), logConfig.isDisablePrefix(), imageConfiguration.getAlias(), containerId);
         builder.file(logConfig.getFileLocation())
                .useColor(useColor)
                .logStdout(logStdout)
@@ -50,7 +50,11 @@ public class LogOutputSpecFactory {
         return builder.build();
     }
 
-    private void addPrefix(LogOutputSpec.Builder builder, String logPrefix, String alias, String containerId) {
+    private void addPrefix(LogOutputSpec.Builder builder, String logPrefix, boolean disablePrefix, String alias, String containerId) {
+        // Don't configure a prefix if we've disabled it
+        if (disablePrefix) {
+            return;
+        }
         String prefix = logPrefix;
         if (prefix == null) {
             prefix = alias;

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -438,6 +438,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals("green", config.getColor());
         assertTrue(config.isEnabled());
         assertEquals("SRV", config.getPrefix());
+        assertTrue(config.isDisablePrefix());
         assertEquals("iso8601", config.getDate());
         assertEquals("json",config.getDriver().getName());
         assertEquals(2, config.getDriver().getOpts().size());
@@ -519,6 +520,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
             k(ConfigKey.WAIT_EXIT), "0",
             k(ConfigKey.WAIT_URL), "http://foo.com",
             k(ConfigKey.LOG_PREFIX), "SRV",
+            k(ConfigKey.LOG_DISABLE_PREFIX), "true",
             k(ConfigKey.LOG_COLOR), "green",
             k(ConfigKey.LOG_ENABLED), "true",
             k(ConfigKey.LOG_DATE), "iso8601",

--- a/src/test/java/io/fabric8/maven/docker/log/DefaultLogCallbackTest.java
+++ b/src/test/java/io/fabric8/maven/docker/log/DefaultLogCallbackTest.java
@@ -44,6 +44,34 @@ public class DefaultLogCallbackTest {
     }
 
     @Test
+    public void canDisablePrefix() throws IOException, DoneException {
+        callback.close();
+        spec = new LogOutputSpec.Builder().file(file.toString()).build();
+		callback = new DefaultLogCallback(spec);
+		callback.open();
+
+        callback.log(1, ts, "unprefixed line");
+        callback.close();
+
+        List<String> lines = Arrays.asList(FileUtils.fileReadArray(file));
+        assertThat(lines, contains("unprefixed line"));
+    }
+
+    @Test
+    public void blankPrefixHonored() throws IOException, DoneException {
+        callback.close();
+        spec = new LogOutputSpec.Builder().prefix("").file(file.toString()).build();
+		callback = new DefaultLogCallback(spec);
+		callback.open();
+
+        callback.log(1, ts, "blank prefix line");
+        callback.close();
+
+        List<String> lines = Arrays.asList(FileUtils.fileReadArray(file));
+        assertThat(lines, contains("> blank prefix line"));
+    }
+
+    @Test
     public void shouldLogSequentially() throws IOException, DoneException {
         callback.log(1, ts, "line 1");
         callback.log(1, ts, "line 2");


### PR DESCRIPTION
Adds a new "disablePrefix" option to the log configuration that will
cause container logs to be presented without a prefix.

Signed-off-by: Scott Coplin <coplin.6@osu.edu>