### PR TITLE
Support standard maven property interpolation

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@
   - Add support for credential helper to authenticate against a registry (#821)
   - Fix registry auth config in plugin configuration (#858)
   - Preserve leading whitespace in logs (#875)
+  - Maven property interpolation in Dockerfiles (#877)
 
 * **0.22.1** (2017-08-28)
   - Allow Docker compose version "2", too ([#829](https://github.com/fabric8io/docker-maven-plugin/issues/829))

--- a/src/main/asciidoc/inc/build/_overview.adoc
+++ b/src/main/asciidoc/inc/build/_overview.adoc
@@ -42,7 +42,7 @@ Except for the <<build-assembly,assembly configuration>> all other configuration
 [[build-filtering]]
 .Filtering
 fabric8-maven-plugin filters given Dockerfile with Maven properties, much like the `maven-resource-plugin` does. Filtering is enabled by default and can be switched off with a build config `<filter>false</filter>`. Properties which we want to replace are specified with the `${..}` syntax. 
-Only properties which are set in the Maven build are replaced, all other remain untouched. 
+Replacement includes Maven project properties such as `${project.artifactId}`, properties set in the build, command-line properties, and system properties. Unresolved properties remain untouched.
 
 This partial replacement means that you can easily mix it with Docker build arguments and environment variable reference, but you need to be careful.
 If you want to be more explicit about the property delimiter to clearly separate Docker properties and Maven properties you can redefine the delimiter.
@@ -53,8 +53,8 @@ For example, the default `<filter>${*}</filter>` parse Maven properties in the f
 If you specify a single character for `<filter>` then this delimiter is taken for both, the start and the end.
 E.g a `<filter>@</filter>` triggers on parameters in the format `@...@`, much like in the `maven-invoker-plugin`. 
 Use something like this if you want to clearly separate from Docker builds args.
-Property replacement works for Dockerfile only.
-For replacing other data in associated files targeted for the Docker image, please use the maven-resource-plugin to copy them over before. 
+This form of property replacement works for Dockerfile only.
+For replacing other data in other files targeted for the Docker image, please use the `maven-resource-plugin` or an <<build-assembly,assembly configuration>> with filtering to make them available in the docker build context. 
 
 .Example
 The following example uses a Dockerfile in the directory

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -1,10 +1,22 @@
 package io.fabric8.maven.docker.assembly;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-import io.fabric8.maven.docker.config.*;
-import io.fabric8.maven.docker.util.*;
+import io.fabric8.maven.docker.config.ArchiveCompression;
+import io.fabric8.maven.docker.config.Arguments;
+import io.fabric8.maven.docker.config.AssemblyConfiguration;
+import io.fabric8.maven.docker.config.AssemblyMode;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.util.DockerFileUtil;
+import io.fabric8.maven.docker.util.EnvUtil;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.docker.util.MojoParameters;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
@@ -30,8 +42,6 @@ import org.codehaus.plexus.archiver.util.DefaultFileSet;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.interpolation.fixed.FixedStringSearchInterpolator;
-
-import com.google.common.base.Function;
 
 /**
  * Tool for creating a docker image tar ball including a Dockerfile for building

--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -230,8 +230,7 @@ public class BuildService {
             File fullDockerFilePath = buildConfig.getAbsoluteDockerFilePath(buildContext.getMojoParameters());
             fromImage = DockerFileUtil.extractBaseImage(
                 fullDockerFilePath,
-                buildContext.getMojoParameters().getProject().getProperties(),
-                buildConfig.getFilter());
+                DockerFileUtil.createInterpolator(buildContext.getMojoParameters(), buildConfig.getFilter()));
         } catch (IOException e) {
             // Cant extract base image, so we wont try an auto pull. An error will occur later anyway when
             // building the image, so we are passive here.

--- a/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
@@ -43,7 +43,6 @@ public class DockerFileUtil {
      *
      * @param dockerFile file from where to extract the base image
      * @param interpolator interpolator for replacing properties
-     * @param filter @return the base image name or <code>null</code> if none is found.
      */
     public static String extractBaseImage(File dockerFile, FixedStringSearchInterpolator interpolator) throws IOException {
         List<String[]> fromLines = extractLines(dockerFile, "FROM", interpolator);

--- a/src/test/resources/interpolate/at/Dockerfile_1
+++ b/src/test/resources/interpolate/at/Dockerfile_1
@@ -1,3 +1,3 @@
 FROM @base@
-LABEL name ${name} @age@ ${ext} blub @unknown@ @
+LABEL name ${name} @age@ ${ext} blub @unknown@ @project.artifactId@ @
 ENV @name@ @ext@

--- a/src/test/resources/interpolate/at/Dockerfile_1.expected
+++ b/src/test/resources/interpolate/at/Dockerfile_1.expected
@@ -1,3 +1,3 @@
 FROM java
-LABEL name ${name} 42 ${ext} blub @unknown@ @
+LABEL name ${name} 42 ${ext} blub @unknown@ docker-maven-plugin @
 ENV guenther png

--- a/src/test/resources/interpolate/var/Dockerfile_1
+++ b/src/test/resources/interpolate/var/Dockerfile_1
@@ -1,3 +1,5 @@
 FROM ${base}
-LABEL name ${name} @age@ ${ext} ${unknown}
+LABEL name ${name} @age@ ${ext} ${unknown} ${project.artifactId}
 ENV ${name} ${age}
+ENV cli=${cliOverride}
+USER ${user.name}

--- a/src/test/resources/interpolate/var/Dockerfile_1.expected
+++ b/src/test/resources/interpolate/var/Dockerfile_1.expected
@@ -1,3 +1,5 @@
 FROM java
-LABEL name guenther @age@ png ${unknown}
+LABEL name guenther @age@ png ${unknown} docker-maven-plugin
 ENV guenther 42
+ENV cli=cliValue
+USER somebody


### PR DESCRIPTION
Replaces the regex-based property interpolation with the plexus classes
used typically by maven to perform interpolation.  This allows
references to things like ${project.build.directory} in the Dockerfile.
[fixes #871]

Signed-off-by: Scott Coplin <coplin.6@osu.edu>