### PR TITLE
Extended Authentication: allow usage of temporary security credentials

### DIFF
--- a/src/main/asciidoc/inc/_authentication.adoc
+++ b/src/main/asciidoc/inc/_authentication.adoc
@@ -173,5 +173,5 @@ The `docker:push` and `docker:pull` goals automatically execute this exchange fo
 
 You can use any IAM access key with the necessary permissions in any of the locations mentioned above except `~/.docker/config.json`.
 Use the IAM *Access key ID* as the username and the *Secret access key* as the password.
-In case you're using temporary security credentials provided by the AWS Security Token Service (AWS STS), you have to provide the *security token* as well!
+In case you're using temporary security credentials provided by the AWS Security Token Service (AWS STS), you have to provide the *security token* as well.
 To do so, either specify the `docker.authToken` system property or provide an `<auth>` element alongside username & password in the `authConfig`.

--- a/src/main/asciidoc/inc/_authentication.adoc
+++ b/src/main/asciidoc/inc/_authentication.adoc
@@ -173,3 +173,5 @@ The `docker:push` and `docker:pull` goals automatically execute this exchange fo
 
 You can use any IAM access key with the necessary permissions in any of the locations mentioned above except `~/.docker/config.json`.
 Use the IAM *Access key ID* as the username and the *Secret access key* as the password.
+In case you're using temporary security credentials provided by the AWS Security Token Service (AWS STS), you have to provide the *security token* as well!
+To do so, either specify the `docker.authToken` system property or provide an `<auth>` element alongside username & password in the `authConfig`.

--- a/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
@@ -63,6 +63,10 @@ public class AuthConfig {
         return password;
     }
 
+    public String getAuth() {
+        return auth;
+    }
+
     public String toHeaderValue() {
         return authEncoded;
     }

--- a/src/main/java/io/fabric8/maven/docker/access/ecr/AwsSigner4.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ecr/AwsSigner4.java
@@ -18,6 +18,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 
 import io.fabric8.maven.docker.access.AuthConfig;
+import org.codehaus.plexus.util.StringUtils;
 
 /**
  * AwsSigner4 implementation that signs requests with the AWS4 signing protocol. Refer to the AWS docs for mor details.
@@ -57,6 +58,10 @@ class AwsSigner4 {
             request.addHeader("X-Amz-Date", sr.getSigningDateTime());
         }
         request.addHeader("Authorization", task4(sr, credentials));
+        final String securityToken = credentials.getAuth();
+        if (StringUtils.isNotEmpty(securityToken)) {
+            request.addHeader("X-Amz-Security-Token", securityToken);
+        }
     }
 
     /**

--- a/src/test/java/io/fabric8/maven/docker/access/ecr/AwsSigner4RequestTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ecr/AwsSigner4RequestTest.java
@@ -1,9 +1,11 @@
 package io.fabric8.maven.docker.access.ecr;
 
+import io.fabric8.maven.docker.access.util.RequestUtil;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.junit.Assert;
 import org.junit.Test;
@@ -63,6 +65,19 @@ public class AwsSigner4RequestTest {
         Assert.assertEquals(TASK3, dst.toString());
 
         Assert.assertEquals(TASK4, signer.task4(sr, credentials));
+    }
+
+    @Test
+    public void includesAuthTokenAsAwsSecurityToken() {
+        HttpUriRequest request = RequestUtil.newGet("https://someService.us-east-1.amazonaws.com/");
+        request.setHeader("host", request.getURI().getHost());
+        String awsSecurityToken = "securityToken";
+        AuthConfig credentials = new AuthConfig("awsAccessKeyId", "awsSecretAccessKey", null, awsSecurityToken);
+
+        AwsSigner4 signer = new AwsSigner4("us-east-1", "someService");
+        signer.sign(request, credentials, new Date());
+
+        Assert.assertEquals(request.getFirstHeader("X-Amz-Security-Token").getValue(), awsSecurityToken);
     }
 
 }


### PR DESCRIPTION
In order to use temporary security credentials provided by the AWS
Security Token Service (AWS STS) to sign requests, the session token has
to be included.