### PR TITLE
Fix warning that results when providing new --chown COPY flag

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,6 +8,7 @@
   - Preserve leading whitespace in logs (#875)
   - Maven property interpolation in Dockerfiles (#877)
   - Allow parameters for the log prefix (#890)
+  - Fix warning when COPY and/or ADD with parameters are used (#884)
   
 * **0.22.1** (2017-08-28)
   - Allow Docker compose version "2", too ([#829](https://github.com/fabric8io/docker-maven-plugin/issues/829))

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -186,22 +186,37 @@ public class DockerAssemblyManager {
         }
     }
 
-    private void verifyGivenDockerfile(File dockerFile, BuildImageConfiguration buildConfig, FixedStringSearchInterpolator interpolator, Logger log) throws IOException {
+    // visible for testing
+    boolean verifyGivenDockerfile(File dockerFile, BuildImageConfiguration buildConfig, FixedStringSearchInterpolator interpolator, Logger log) throws IOException {
         AssemblyConfiguration assemblyConfig = buildConfig.getAssemblyConfiguration();
         if (assemblyConfig != null) {
             String name = assemblyConfig.getName();
             for (String keyword : new String[] { "ADD", "COPY" }) {
                 List<String[]> lines = DockerFileUtil.extractLines(dockerFile, keyword, interpolator);
                 for (String[] line : lines) {
-                    // contains an ADD/COPY ... targetDir .... All good.
-                    if (!line[0].startsWith("#") && line.length > 1 && line[1].contains(name)) {
-                        return;
+                    if (!line[0].startsWith("#")) {
+                        // Skip command flags like --chown
+                        int i;
+                        for (i = 1; i < line.length; i++) {
+                            String component = line[i];
+                            if (!component.startsWith("--")) {
+                                break;
+                            }
+                        }
+
+                        // contains an ADD/COPY ... targetDir .... All good.
+                        if (i < line.length && line[i].contains(name)) {
+                            return true;
+                        }
                     }
                 }
             }
             log.warn("Dockerfile %s does not contain an ADD or COPY directive to include assembly created at %s. Ignoring assembly.",
                      dockerFile.getPath(), name);
+            return false;
         }
+
+        return true;
     }
 
     /**

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -187,10 +187,13 @@ public class DockerAssemblyManager {
     }
 
     // visible for testing
-    boolean verifyGivenDockerfile(File dockerFile, BuildImageConfiguration buildConfig, FixedStringSearchInterpolator interpolator, Logger log) throws IOException {
+    void verifyGivenDockerfile(File dockerFile, BuildImageConfiguration buildConfig, FixedStringSearchInterpolator interpolator, Logger log) throws IOException {
         AssemblyConfiguration assemblyConfig = buildConfig.getAssemblyConfiguration();
-        if (assemblyConfig != null) {
-            String name = assemblyConfig.getName();
+        if (assemblyConfig == null) {
+            return;
+        }
+
+        String name = assemblyConfig.getName();
             for (String keyword : new String[] { "ADD", "COPY" }) {
                 List<String[]> lines = DockerFileUtil.extractLines(dockerFile, keyword, interpolator);
                 for (String[] line : lines) {
@@ -206,17 +209,13 @@ public class DockerAssemblyManager {
 
                         // contains an ADD/COPY ... targetDir .... All good.
                         if (i < line.length && line[i].contains(name)) {
-                            return true;
+                            return;
                         }
                     }
                 }
             }
-            log.warn("Dockerfile %s does not contain an ADD or COPY directive to include assembly created at %s. Ignoring assembly.",
-                     dockerFile.getPath(), name);
-            return false;
-        }
-
-        return true;
+        log.warn("Dockerfile %s does not contain an ADD or COPY directive to include assembly created at %s. Ignoring assembly.",
+                 dockerFile.getPath(), name);
     }
 
     /**

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyManagerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyManagerTest.java
@@ -1,6 +1,9 @@
 package io.fabric8.maven.docker.assembly;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Properties;
 
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.util.MojoParameters;
@@ -23,6 +26,7 @@ import io.fabric8.maven.docker.util.AnsiLogger;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DockerAssemblyManagerTest {
 
@@ -81,5 +85,62 @@ public class DockerAssemblyManagerTest {
                         .build();
 
         assemblyManager.getAssemblyFiles("testImage", buildConfig, mojoParams, new AnsiLogger(new SystemStreamLog(),true,true));
+    }
+
+    @Test
+    public void testCopyValidVerifyGivenDockerfile(@Injectable final MavenProject project) throws IOException {
+        new Expectations() {{
+            project.getProperties();
+            result = new Properties();
+            times = 2;
+        }};
+
+        BuildImageConfiguration buildConfig =
+                new BuildImageConfiguration.Builder()
+                        .assembly(new AssemblyConfiguration.Builder()
+                                .descriptorRef("artifact")
+                                .build())
+                        .build();
+
+        boolean ret = assemblyManager.verifyGivenDockerfile(new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_valid.test").getPath()), buildConfig, project, new AnsiLogger(new SystemStreamLog(), true, true));
+        assertTrue(ret);
+    }
+
+    @Test
+    public void testCopyInvalidVerifyGivenDockerfile(@Injectable final MavenProject project) throws IOException {
+        new Expectations() {{
+            project.getProperties();
+            result = new Properties();
+            times = 2;
+        }};
+
+        BuildImageConfiguration buildConfig =
+                new BuildImageConfiguration.Builder()
+                        .assembly(new AssemblyConfiguration.Builder()
+                                .descriptorRef("artifact")
+                                .build())
+                        .build();
+
+        boolean ret = assemblyManager.verifyGivenDockerfile(new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_invalid.test").getPath()), buildConfig, project, new AnsiLogger(new SystemStreamLog(), true, true));
+        assertFalse(ret);
+    }
+
+    @Test
+    public void testCopyChownValidVerifyGivenDockerfile(@Injectable final MavenProject project) throws IOException {
+        new Expectations() {{
+            project.getProperties();
+            result = new Properties();
+            times = 2;
+        }};
+
+        BuildImageConfiguration buildConfig =
+                new BuildImageConfiguration.Builder()
+                        .assembly(new AssemblyConfiguration.Builder()
+                                .descriptorRef("artifact")
+                                .build())
+                        .build();
+
+        boolean ret = assemblyManager.verifyGivenDockerfile(new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_chown_valid.test").getPath()), buildConfig, project, new AnsiLogger(new SystemStreamLog(), true, true));
+        assertTrue(ret);
     }
 }

--- a/src/test/resources/docker/Dockerfile_assembly_verify_copy_chown_valid.test
+++ b/src/test/resources/docker/Dockerfile_assembly_verify_copy_chown_valid.test
@@ -1,0 +1,2 @@
+FROM image
+COPY --chown=app maven/* ./

--- a/src/test/resources/docker/Dockerfile_assembly_verify_copy_invalid.test
+++ b/src/test/resources/docker/Dockerfile_assembly_verify_copy_invalid.test
@@ -1,0 +1,2 @@
+FROM image
+COPY nonassembly/* ./

--- a/src/test/resources/docker/Dockerfile_assembly_verify_copy_valid.test
+++ b/src/test/resources/docker/Dockerfile_assembly_verify_copy_valid.test
@@ -1,0 +1,2 @@
+FROM image
+COPY maven/* ./


### PR DESCRIPTION
This fixes logging an invalid warning that results when providing the new `--chown` flag to the `COPY` command in a custom Dockerfile.