### PR TITLE
feature: Use log prefix as format

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -7,7 +7,8 @@
   - Fix registry auth config in plugin configuration (#858)
   - Preserve leading whitespace in logs (#875)
   - Maven property interpolation in Dockerfiles (#877)
-
+  - Allow parameters for the log prefix (#890)
+  
 * **0.22.1** (2017-08-28)
   - Allow Docker compose version "2", too ([#829](https://github.com/fabric8io/docker-maven-plugin/issues/829))
   - Allow a registry to be set programmatically ([#853](https://github.com/fabric8io/docker-maven-plugin/issues/853))

--- a/samples/data-jolokia/pom.xml
+++ b/samples/data-jolokia/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>dmp-sample-data-jolokia</artifactId>
-  <version>0.22.1</version>
+  <version>0.22-SNAPSHOT</version>
   <!-- add custom lifecycle -->
   <packaging>docker</packaging>
 

--- a/src/main/asciidoc/inc/start/_logging.adoc
+++ b/src/main/asciidoc/inc/start/_logging.adoc
@@ -10,7 +10,15 @@ When running containers the standard output and standard error of the container 
 | If set to `false` log output is disabled. This is useful if you want to disable log output by default but want to use the other configuration options when log output is switched on on the command line with `-Ddocker.showLogs`. Logging is enabled by default if a `<log>` section is given.
 
 | *prefix*
-| Prefix to use for the log output in order to identify the container. By default the image `alias` is used or alternatively the container `id`.
+a| Prefix to use for the log output in order to identify the container. You can use placeholders in the prefix which are replaced on the fly:
+
+* `%a`: Alias of the image, or, if not set, the short container id.
+* `%c`: Short container id (i.e. the first 6 chars of the container id
+* `%C`: The full container id
+* `%n`: The image name
+* `%z`: An empty string
+
+By default the format is "`%a> `".
 
 | *date*
 a| Dateformat to use for log timestamps. If `<date>` is not given no timestamp will be shown. The date specification can be either a constant or a date format. The recognized constants are:

--- a/src/main/java/io/fabric8/maven/docker/log/DefaultLogCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/log/DefaultLogCallback.java
@@ -83,6 +83,7 @@ public class DefaultLogCallback implements LogCallback {
     public void error(String error) {
         ps().println(error);
     }
+
     private void addLogEntry(PrintStream ps, LogEntry logEntry) {
         // TODO: Add the entry to a queue, and let the queue be picked up with a small delay from an extra
         // thread which then can sort the entries by time before printing it out in order to avoid race conditions.

--- a/src/main/java/io/fabric8/maven/docker/log/LogOutputSpec.java
+++ b/src/main/java/io/fabric8/maven/docker/log/LogOutputSpec.java
@@ -66,7 +66,7 @@ public class LogOutputSpec {
     }
 
     public String getPrompt(boolean withColor,Timestamp timestamp) {
-        return formatTimestamp(timestamp,withColor) + formatPrefix(prefix, withColor) + "> ";
+        return formatTimestamp(timestamp,withColor) + formatPrefix(prefix, withColor);
     }
 
     public String getFile(){

--- a/src/main/java/io/fabric8/maven/docker/log/LogOutputSpecFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/log/LogOutputSpecFactory.java
@@ -15,15 +15,20 @@ package io.fabric8.maven.docker.log;/*
  * limitations under the License.
  */
 
+import java.util.HashMap;
+import java.util.Map;
+
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.LogConfiguration;
 import io.fabric8.maven.docker.config.RunImageConfiguration;
+import io.fabric8.maven.docker.util.FormatParameterReplacer;
 
 /**
  * @author roland
  * @since 26/09/15
  */
 public class LogOutputSpecFactory {
+    private static final String DEFAULT_PREFIX_FORMAT = "%a> ";
     private boolean useColor;
     private boolean logStdout;
     private String logDate;
@@ -41,7 +46,7 @@ public class LogOutputSpecFactory {
         LogConfiguration logConfig = extractLogConfiguration(imageConfiguration);
 
         addLogFormat(builder, logConfig);
-        addPrefix(builder, logConfig.getPrefix(), imageConfiguration.getAlias(), containerId);
+        addPrefix(builder, logConfig.getPrefix(), imageConfiguration, containerId);
         builder.file(logConfig.getFileLocation())
                .useColor(useColor)
                .logStdout(logStdout)
@@ -50,15 +55,58 @@ public class LogOutputSpecFactory {
         return builder.build();
     }
 
-    private void addPrefix(LogOutputSpec.Builder builder, String logPrefix, String alias, String containerId) {
-        String prefix = logPrefix;
-        if (prefix == null) {
-            prefix = alias;
+    private void addPrefix(LogOutputSpec.Builder builder, String logPrefix, ImageConfiguration imageConfig, String containerId) {
+        String prefixFormat = logPrefix;
+        if (prefixFormat == null) {
+            prefixFormat = DEFAULT_PREFIX_FORMAT;
         }
-        if (prefix == null) {
-            prefix = containerId.substring(0, 6);
-        }
-        builder.prefix(prefix);
+        FormatParameterReplacer formatParameterReplacer = new FormatParameterReplacer(getPrefixFormatParameterLookups(imageConfig, containerId));
+        builder.prefix(formatParameterReplacer.replace(prefixFormat));
+    }
+
+    private Map<String, FormatParameterReplacer.Lookup> getPrefixFormatParameterLookups(final ImageConfiguration imageConfig, final String containerId) {
+        Map<String, FormatParameterReplacer.Lookup> ret = new HashMap<>();
+
+        ret.put("z", new FormatParameterReplacer.Lookup() {
+            @Override
+            public String lookup() {
+                return "";
+            }
+        });
+
+        ret.put("c", new FormatParameterReplacer.Lookup() {
+            @Override
+            public String lookup() {
+                return containerId.substring(0, 6);
+            }
+        });
+
+        ret.put("C", new FormatParameterReplacer.Lookup() {
+            @Override
+            public String lookup() {
+                return containerId;
+            }
+        });
+
+        ret.put("a", new FormatParameterReplacer.Lookup() {
+            @Override
+            public String lookup() {
+                String alias = imageConfig.getAlias();
+                if (alias != null) {
+                    return alias;
+                }
+                return containerId.substring(0, 6);
+            }
+        });
+
+        ret.put("n", new FormatParameterReplacer.Lookup() {
+            @Override
+            public String lookup() {
+                return imageConfig.getName();
+            }
+        });
+
+        return ret;
     }
 
     private void addLogFormat(LogOutputSpec.Builder builder, LogConfiguration logConfig) {

--- a/src/main/java/io/fabric8/maven/docker/util/FormatParameterReplacer.java
+++ b/src/main/java/io/fabric8/maven/docker/util/FormatParameterReplacer.java
@@ -1,0 +1,51 @@
+package io.fabric8.maven.docker.util;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author roland
+ * @since 04.11.17
+ */
+public class FormatParameterReplacer {
+
+    // Detect format elements within the name
+    private final Pattern formatIdentifierPattern = Pattern.compile("^(.*?)%([^a-zA-Z]*)([a-zA-Z])(.*)$");
+
+    private final Map<String, Lookup> lookupMap;
+
+    public FormatParameterReplacer(Map<String, Lookup> lookupMap) {
+        this.lookupMap = lookupMap;
+    }
+
+    public synchronized String replace(String input) {
+        StringBuilder ret = new StringBuilder();
+        while (true) {
+            Matcher matcher = formatIdentifierPattern.matcher(input);
+            if (!matcher.matches()) {
+                ret.append(input);
+                return ret.toString();
+            }
+            ret.append(matcher.group(1));
+            ret.append(formatElement(matcher.group(2),matcher.group(3)));
+            input = matcher.group(4);
+        }
+    }
+
+    private String formatElement(String options, String what) {
+        FormatParameterReplacer.Lookup lookup = lookupMap.get(what);
+        if (lookup == null) {
+            throw new IllegalArgumentException(String.format("No image name format element '%%%s' known", what) );
+        }
+        String val = lookup.lookup();
+        return String.format("%" + (options != null ? options : "") + "s",val);
+    }
+
+
+    // Lookup abstraction
+    public interface Lookup {
+        String lookup();
+    }
+
+}

--- a/src/test/java/io/fabric8/maven/docker/log/DefaultLogCallbackTest.java
+++ b/src/test/java/io/fabric8/maven/docker/log/DefaultLogCallbackTest.java
@@ -36,7 +36,7 @@ public class DefaultLogCallbackTest {
     public void before() throws IOException {
         file = File.createTempFile("logcallback", ".log");
         file.deleteOnExit();
-        spec = new LogOutputSpec.Builder().prefix("callback-test")
+        spec = new LogOutputSpec.Builder().prefix("callback-test> ")
                                           .file(file.toString()).build();
         callback = new DefaultLogCallback(spec);
         callback.open();
@@ -76,7 +76,7 @@ public class DefaultLogCallbackTest {
         PrintStream stdout = System.out;
         try {
             System.setOut(ps);
-            spec = new LogOutputSpec.Builder().prefix("stdout")
+            spec = new LogOutputSpec.Builder().prefix("stdout> ")
                     .build();
             callback = new DefaultLogCallback(spec);
             callback.open();

--- a/src/test/java/io/fabric8/maven/docker/log/LogOutputSpecFactoryTest.java
+++ b/src/test/java/io/fabric8/maven/docker/log/LogOutputSpecFactoryTest.java
@@ -1,0 +1,57 @@
+package io.fabric8.maven.docker.log;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.config.LogConfiguration;
+import io.fabric8.maven.docker.config.RunImageConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author roland
+ * @since 04.11.17
+ */
+@RunWith(Parameterized.class)
+public class LogOutputSpecFactoryTest {
+
+    private static String ALIAS = "fcn";
+    private static String NAME = "rhuss/fcn:1.0";
+    private static String CONTAINER_ID = "1234567890";
+
+    @Parameterized.Parameters(name = "{index}: format \"{0}\" --> \"{1}\"")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "%z", "" },
+            { null, ALIAS + "> "},
+            { "%c", CONTAINER_ID.substring(0,6) },
+            { "%C: ", CONTAINER_ID + ": " },
+            { "%n -- ", NAME + " -- " },
+            { "%z%c%n%C %a", CONTAINER_ID.substring(0,6) + NAME + CONTAINER_ID + " " + ALIAS }
+           });
+    }
+
+    @Parameterized.Parameter(0)
+    public String prefixFormat;
+
+    @Parameterized.Parameter(1)
+    public String expectedPrefix;
+
+    @Test
+    public void prefix() {
+        LogOutputSpec spec = createSpec(prefixFormat);
+        assertEquals(expectedPrefix, spec.getPrompt(false, null));
+    }
+
+    private LogOutputSpec createSpec(String prefix) {
+        LogOutputSpecFactory factory = new LogOutputSpecFactory(false, false, null);
+        LogConfiguration logConfig = new LogConfiguration.Builder().prefix(prefix).build();
+        RunImageConfiguration runConfig = new RunImageConfiguration.Builder().log(logConfig).build();
+        ImageConfiguration imageConfiguration = new ImageConfiguration.Builder().alias(ALIAS).name(NAME).runConfig(runConfig).build();
+        return factory.createSpec(CONTAINER_ID,imageConfiguration);
+    }
+}


### PR DESCRIPTION
This replaces #876 as its a bit more flexible and does not require a new configuration option.
You can use now a prefix `%z` for an empty string