### PR TITLE
[Extended Authentication] Enable usage of system properties for HttpClient 

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuth.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuth.java
@@ -91,7 +91,7 @@ public class EcrExtendedAuth {
     }
 
     CloseableHttpClient createClient() {
-        return HttpClients.createDefault();
+        return HttpClients.custom().useSystemProperties().build();
     }
 
     private JSONObject executeRequest(CloseableHttpClient client, HttpPost request) throws IOException, MojoExecutionException {


### PR DESCRIPTION
This allows using Extended Authentication behind a proxy, as it advices
the HttpClient to use the JVM's standard system properties for
proxies (https://docs.oracle.com/javase/6/docs/technotes/guides/net/proxies.html).