### PR TITLE
stop and remove using regex names

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -11,6 +11,7 @@
   - Enhance @sha256 digest for tags in FROM (image_name:image_tag@sha256<digest>) ([#541](https://github.com/fabric8io/docker-maven-plugin/issues/541))
   - Support docker SHELL setting for runCmds (#1157)
   - Added 'autoRemove' option for running containers (#1179)
+  - Stop and remove using regex names (#900)
   - Added support for AWS EC2 instance roles when pushing to AWS ECR (#1186)
   - Add support for auto-pulling multiple base image for multi stage builds (#1057)
   - Fix usage of credential helper that do not support 'version' command (#1159)

--- a/src/main/java/io/fabric8/maven/docker/StopMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StopMojo.java
@@ -10,9 +10,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.ExecException;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.NetworkConfig;
+import io.fabric8.maven.docker.config.RunImageConfiguration;
 import io.fabric8.maven.docker.log.LogDispatcher;
 import io.fabric8.maven.docker.model.Container;
 import io.fabric8.maven.docker.model.Network;
@@ -121,18 +123,18 @@ public class StopMojo extends AbstractDockerMojo {
             	List<String> imageNames = queryService.findImageNamesByRegex(image.getNameRegex());
                 List<Container> containers = new ArrayList<Container>();
             	for(String imageName : imageNames) {
-            		List<Container> foundContainers = queryService.getContainersForImage(imageName);
+            		List<Container> foundContainers = queryService.getContainersForImage(imageName, true);
             		containers.addAll(foundContainers);
             	}
                 return containers;
             }
             else {
-                return queryService.getContainersForImage(image.getName());
+                return queryService.getContainersForImage(image.getName(), true);
             }
         }
     }
 
-    private boolean shouldStopContainer(Container container, PomLabel pomLabel, ImageConfiguration image) {
+    private boolean shouldStopContainer(Container container, GavLabel gavLabel) {
         if (isStopAllContainers()) {
             return true;
         }

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -49,6 +49,16 @@ public interface DockerAccess {
     ExecDetails getExecContainer(String containerIdOrName) throws DockerAccessException;
 
     /**
+     * Get a container
+     *
+     * @param containerIdOrName container id or name
+     * @return <code>ContainerDetails<code> representing the container or null if none could be found
+     * @throws DockerAccessException if the container could not be inspected
+     */
+    List<Container> findContainerByRegex(String regexContainerIdOrName) throws DockerAccessException;
+
+
+    /**
      * Check whether the given name exists as image at the docker daemon
      *
      * @param name image name to check
@@ -56,6 +66,13 @@ public interface DockerAccess {
      */
     boolean hasImage(String name) throws DockerAccessException;
 
+    /**
+     * Check whether the given name exists as image at the docker daemon
+     *
+     * @param name image name to check
+     * @return true if the image exists
+     */
+    List<String> findImageByRegexName(String nameRegex) throws DockerAccessException;
     /**
      * Get the image id of a given name or <code>null</code> if no such image exists
      *

--- a/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
@@ -44,6 +44,11 @@ public final class UrlBuilder {
                 .build();
     }
 
+    public String listImages() {
+        return u("images/json").p("all", true)
+                .build();
+    }
+
     public String containerLogs(String containerId, boolean follow) {
         return u("containers/%s/logs", containerId)
                 .p("stdout",true)

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -1,6 +1,5 @@
 package io.fabric8.maven.docker.access.hc;
 
-<<<<<<< HEAD
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -343,7 +342,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
 
     @Override
     public List<Container> findContainerByRegex(String regexContainerIdOrName) throws DockerAccessException {
-        String url = urlBuilder.listContainers();
+        String url = urlBuilder.listContainers(true);
         Pattern p = Pattern.compile(regexContainerIdOrName);
         List<Container> containers = new ArrayList<>();
         List<String> matchingNames = new ArrayList<>();
@@ -352,13 +351,13 @@ public class DockerAccessWithHcClient implements DockerAccess {
             if (response.getStatusCode() == HTTP_NOT_FOUND) {
                 return containers;
             } else {
-                JSONArray array = new JSONArray(response.getBody());
+                JsonArray array = JsonFactory.newJsonArray(response.getBody());
 
-                for (int i = 0; i < array.length(); i++) {
-                    JSONObject container = array.getJSONObject(i);
-                    JSONArray names = container.getJSONArray("Names");
-                    for(int x = 0; x < names.length(); x++) {
-                        String name = names.getString(x);
+                for (int i = 0; i < array.size(); i++) {
+                    JsonObject container = array.get(i).getAsJsonObject();
+                    JsonArray names = container.get("Names").getAsJsonArray();
+                    for(int x = 0; x < names.size(); x++) {
+                        String name = names.get(x).getAsString();
                         if(name.startsWith("/")) {
                             name = name.substring(1);
                         }
@@ -776,18 +775,18 @@ public class DockerAccessWithHcClient implements DockerAccess {
             if (response.getStatusCode() == HTTP_NOT_FOUND) {
                 return imageNames;
             }
-            JSONArray imageDetails = new JSONArray(response.getBody());
+            JsonArray imageDetails = JsonFactory.newJsonArray(response.getBody());
 
-            for(int i=0;i<imageDetails.length();i++) {
-                JSONObject image = imageDetails.getJSONObject(i);
-                if(!image.has("RepoTags") || image.isNull("RepoTags")) {
+            for(int i=0; i < imageDetails.size(); i++) {
+                JsonObject image = imageDetails.get(i).getAsJsonObject();
+                if(!image.has("RepoTags") || image.get("RepoTags").isJsonNull()) {
                     log.debug("Invalid RepoTags found on %s", image.get("Id"));
                     continue;
                 }
                 try{
-                    JSONArray tags = image.getJSONArray("RepoTags");
-                    for(int x=0;x<tags.length();x++) {
-                        String tag = tags.getString(x);
+                    JsonArray tags = image.get("RepoTags").getAsJsonArray();
+                    for(int x=0; x < tags.size(); x++) {
+                        String tag = tags.get(x).getAsString();
                         if(p.matcher(tag).matches()) {
                             imageNames.add(tag);
                         }

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -104,7 +104,6 @@ public class DockerAssemblyManager {
      */
     public File createDockerTarArchive(String imageName, final MojoParameters params, final BuildImageConfiguration buildConfig, Logger log, ArchiverCustomizer finalCustomizer)
             throws MojoExecutionException {
-
         final BuildDirs buildDirs = createBuildDirs(imageName, params);
         final AssemblyConfiguration assemblyConfig = buildConfig.getAssemblyConfiguration();
 

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -22,7 +22,13 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
     private String name;
 
     @Parameter
+    private String nameRegex;
+
+    @Parameter
     private String alias;
+
+    @Parameter
+    private String aliasRegex;
 
     @Parameter
     private RunImageConfiguration run;
@@ -67,7 +73,7 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
     }
 
     @Override
-	public String getAlias() {
+    public String getAlias() {
         return alias;
     }
 
@@ -223,5 +229,21 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
             config.watch = watchConfig;
             return this;
         }
+    }
+
+    public String getNameRegex() {
+        return nameRegex;
+    }
+
+    public void setNameRegex(String nameRegex) {
+        this.nameRegex = nameRegex;
+    }
+
+    public String getAliasRegex() {
+        return aliasRegex;
+    }
+
+    public void setAliasRegex(String aliasRegex) {
+        this.aliasRegex = aliasRegex;
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/service/QueryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/QueryService.java
@@ -42,6 +42,20 @@ public class QueryService {
     }
 
     /**
+     * Find containers by the given regex name
+     * @param nameRegex of container to lookup
+     * @return the List of containers found or empty List if no container is available.
+     * @throws DockerAccessException in case of an remote error
+     */
+    public List<Container> findContainersByRegex(final String regexContainerIdOrName) throws DockerAccessException {
+        return docker.findContainerByRegex(regexContainerIdOrName);
+    }
+
+    public List<String> findImageNamesByRegex(String nameRegex) throws DockerAccessException {
+        return docker.findImageByRegexName(nameRegex);
+    }
+
+    /**
      * Get a container running for a given container name.
      * @param containerIdOrName name of container to lookup
      * @return the container found or <code>null</code> if no container is available.


### PR DESCRIPTION
So we use the maven artifactID as the image name and the version number as the tag for naming our images and containers, the problem is once the version number changes, we can no longer stop or remove old images to deploy the new ones.  

This was a quick fix we put together, i don't know how useful this would be to others, But thought i'd at least throw it out there.  If it's not useful feel free to close.

Usage:
Enabled stop and remove using regex.

```
<properties>
        <docker.stopUsingRegex>true</docker.stopUsingRegex>
        <docker.removeUsingRegex>true</docker.removeUsingRegex>
...
```

Then under the image tags:

  ```
<image>
    <alias>${project.artifactId}_${project.version}</alias>
    <aliasRegex>${project.artifactId}.*${revision.branch}-${revision.type}</aliasRegex>
    <name>${project.artifactId}:${project.version}</name>
    <nameRegex>${project.artifactId}.*${revision.branch}-${revision.type}</nameRegex>
....
```