### PR TITLE
#862 - Fix for hanging wait on log

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -5,6 +5,7 @@
   - Simplified auto pull handling and moved to `imagePullPolicy` instead.
   - Initialize shutdown hook early to allow killing of containers when waiting for a condition (#921)
   - Fix for including in assembly in archive mode when using a Dockerfile (#916)
+  - Fix for hanging wait on log (#904)
 
 Please note that `autoPullMode` is deprecated now and the behaviour of the `autoPullMode == always` has been changed slightly so that now, it really always pulls the image from the registry.
 

--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -15,6 +15,14 @@ package io.fabric8.maven.docker.access.log;/*
  * limitations under the License.
  */
 
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import io.fabric8.maven.docker.access.DockerAccessException;
@@ -26,16 +34,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.log4j.Logger;
-import org.apache.log4j.spi.LoggerFactory;
-
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Extractor for parsing the response of a log request

--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -79,7 +79,6 @@ public class LogRequestor extends Thread implements LogGetHandle {
 
         this.callback = callback;
         this.exception = null;
-        // this.setDaemon(true);
     }
 
     /**

--- a/src/main/java/io/fabric8/maven/docker/wait/LogMatchCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/wait/LogMatchCallback.java
@@ -1,10 +1,10 @@
 package io.fabric8.maven.docker.wait;
 
+import java.util.regex.Pattern;
+
 import io.fabric8.maven.docker.access.log.LogCallback;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.docker.util.Timestamp;
-
-import java.util.regex.Pattern;
 
 class LogMatchCallback implements LogCallback {
 

--- a/src/main/java/io/fabric8/maven/docker/wait/LogMatchCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/wait/LogMatchCallback.java
@@ -1,0 +1,57 @@
+package io.fabric8.maven.docker.wait;
+
+import io.fabric8.maven.docker.access.log.LogCallback;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.docker.util.Timestamp;
+
+import java.util.regex.Pattern;
+
+class LogMatchCallback implements LogCallback {
+
+    private final Logger logger;
+    private final LogWaitCheckerCallback callback;
+    private final Pattern pattern;
+    private StringBuilder logBuffer;
+
+    LogMatchCallback(final Logger logger, final LogWaitCheckerCallback callback, final String patternString) {
+        this.logger = logger;
+        this.callback = callback;
+        this.pattern = Pattern.compile(patternString);
+        logBuffer = (pattern.flags() & Pattern.DOTALL) != 0 ? new StringBuilder() : null;
+    }
+
+    @Override
+    public void log(int type, Timestamp timestamp, String txt) throws DoneException {
+        logger.debug("LogWaitChecker: Trying to match '%s' [Pattern: %s] [thread: %d]",
+                  txt, pattern.pattern(), Thread.currentThread().getId());
+
+        final String toMatch;
+        if (logBuffer != null) {
+            logBuffer.append(txt).append("\n");
+            toMatch = logBuffer.toString();
+        } else {
+            toMatch = txt;
+        }
+
+        if (pattern.matcher(toMatch).find()) {
+            logger.debug("Found log-wait pattern in log output");
+            callback.matched();
+            throw new DoneException();
+        }
+    }
+
+    @Override
+    public void error(String error) {
+        logger.error("%s", error);
+    }
+
+    @Override
+    public void close() {
+        logger.debug("Closing LogWaitChecker callback");
+    }
+
+    @Override
+    public void open() {
+        logger.debug("Open LogWaitChecker callback");
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/wait/LogWaitChecker.java
+++ b/src/main/java/io/fabric8/maven/docker/wait/LogWaitChecker.java
@@ -1,46 +1,42 @@
 package io.fabric8.maven.docker.wait;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Pattern;
-
 import io.fabric8.maven.docker.access.DockerAccess;
-import io.fabric8.maven.docker.access.log.LogCallback;
 import io.fabric8.maven.docker.access.log.LogGetHandle;
 import io.fabric8.maven.docker.util.Logger;
-import io.fabric8.maven.docker.util.Timestamp;
+
+import java.util.concurrent.CountDownLatch;
 
 /**
  * @author roland
  * @since 25/03/2017
  */
-public class LogWaitChecker implements WaitChecker {
+public class LogWaitChecker implements WaitChecker, LogWaitCheckerCallback {
 
-    private final String logPattern;
     private final String containerId;
+    private final String logPattern;
     private final Logger log;
-    private final DockerAccess dockerAccess;
-    private boolean first;
-    private LogGetHandle logHandle;
-    private AtomicBoolean detected;
 
-    public LogWaitChecker(String pattern, DockerAccess dockerAccess, String containerId, Logger log) {
-        this.log = log;
-        this.dockerAccess = dockerAccess;
-        this.logPattern = pattern;
+    private final CountDownLatch latch;
+    private final LogGetHandle logHandle;
+
+    public LogWaitChecker(final String logPattern, final DockerAccess dockerAccess, final String containerId, final Logger log) {
         this.containerId = containerId;
-        first = true;
-        detected = new AtomicBoolean(false);
+        this.logPattern = logPattern;
+        this.log = log;
+
+        this.latch = new CountDownLatch(1);
+        this.logHandle = dockerAccess.getLogAsync(containerId, new LogMatchCallback(log, this, logPattern));
+    }
+
+    @Override
+    public void matched() {
+        latch.countDown();
+        log.info("Pattern '%s' matched for container %s", logPattern, containerId);
     }
 
     @Override
     public boolean check() {
-        if (first) {
-            final Pattern pattern = Pattern.compile(logPattern);
-            log.debug("LogWaitChecker: Pattern to match '%s'", logPattern);
-            logHandle = dockerAccess.getLogAsync(containerId, new LogMatchCallback(pattern));
-            first = false;
-        }
-        return detected.get();
+        return latch.getCount() == 0;
     }
 
     @Override
@@ -53,49 +49,5 @@ public class LogWaitChecker implements WaitChecker {
     @Override
     public String getLogLabel() {
         return "on log out '" + logPattern + "'";
-    }
-
-    private class LogMatchCallback implements LogCallback {
-
-        private final Pattern pattern;
-        StringBuilder logBuffer;
-
-        LogMatchCallback(Pattern pattern) {
-            this.pattern = pattern;
-            logBuffer = (pattern.flags() & Pattern.DOTALL) != 0 ? new StringBuilder() : null;
-        }
-
-        @Override
-        public void log(int type, Timestamp timestamp, String txt) throws DoneException {
-            log.debug("LogWaitChecker: Trying to match '%s' [Pattern: %s] [thread: %d]",
-                      txt, logPattern, Thread.currentThread().getId());
-            String toMatch;
-            if (logBuffer != null) {
-                logBuffer.append(txt).append("\n");
-                toMatch = logBuffer.toString();
-            } else {
-                toMatch = txt;
-            }
-            if (pattern.matcher(toMatch).find()) {
-                log.debug("Found log-wait pattern in log output");
-                detected.set(true);
-                throw new DoneException();
-            }
-        }
-
-        @Override
-        public void error(String error) {
-            log.error("%s", error);
-        }
-
-        @Override
-        public void close() {
-            log.debug("Closing LogWaitChecker callback");
-        }
-
-        @Override
-        public void open() {
-            // no-op
-        }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/wait/LogWaitChecker.java
+++ b/src/main/java/io/fabric8/maven/docker/wait/LogWaitChecker.java
@@ -1,10 +1,10 @@
 package io.fabric8.maven.docker.wait;
 
+import java.util.concurrent.CountDownLatch;
+
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.log.LogGetHandle;
 import io.fabric8.maven.docker.util.Logger;
-
-import java.util.concurrent.CountDownLatch;
 
 /**
  * @author roland

--- a/src/main/java/io/fabric8/maven/docker/wait/LogWaitCheckerCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/wait/LogWaitCheckerCallback.java
@@ -1,0 +1,5 @@
+package io.fabric8.maven.docker.wait;
+
+public interface LogWaitCheckerCallback {
+    void matched();
+}

--- a/src/main/java/io/fabric8/maven/docker/wait/LogWaitCheckerCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/wait/LogWaitCheckerCallback.java
@@ -1,5 +1,9 @@
 package io.fabric8.maven.docker.wait;
 
+
+/**
+ * Interface called during waiting on log when a log line matches
+ */
 public interface LogWaitCheckerCallback {
     void matched();
 }

--- a/src/test/java/io/fabric8/maven/docker/wait/ExitCodeCheckerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/wait/ExitCodeCheckerTest.java
@@ -3,7 +3,6 @@ package io.fabric8.maven.docker.wait;
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.model.Container;
 import io.fabric8.maven.docker.service.QueryService;
-import io.fabric8.maven.docker.service.ServiceHub;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.integration.junit4.JMockit;

--- a/src/test/java/io/fabric8/maven/docker/wait/LogMatchCallbackTest.java
+++ b/src/test/java/io/fabric8/maven/docker/wait/LogMatchCallbackTest.java
@@ -1,0 +1,71 @@
+package io.fabric8.maven.docker.wait;
+
+import io.fabric8.maven.docker.access.log.LogCallback;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.docker.util.Timestamp;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Test;
+
+public class LogMatchCallbackTest {
+    @Mocked
+    private Logger logger;
+
+    @Mocked
+    private LogWaitCheckerCallback callback;
+
+    @Test(expected = LogCallback.DoneException.class)
+    public void matchingSingleLineSucceeds() throws Exception {
+        final String patternString = "The start has finished right now";
+        final LogMatchCallback logMatchCallback = new LogMatchCallback(logger, callback, patternString);
+
+        new Expectations() {{
+            callback.matched();
+            times = 1;
+        }};
+
+        logMatchCallback.log(1, new Timestamp(), patternString);
+    }
+
+    @Test(expected = LogCallback.DoneException.class)
+    public void matchingMultipleLinesSucceeds() throws Exception {
+        final String patterString = "(?s)ready to accept connections.*\\n.*ready to accept connections";
+        final LogMatchCallback logMatchCallback = new LogMatchCallback(logger, callback, patterString);
+
+        new Expectations() {{
+            callback.matched();
+            times = 1;
+        }};
+
+        logMatchCallback.log(1, new Timestamp(), "LOG:  database system is ready to accept connections" );
+        logMatchCallback.log(1, new Timestamp(), "LOG:  autovacuum launcher started");
+        logMatchCallback.log(1, new Timestamp(), "LOG:  database system is shut down");
+        logMatchCallback.log(1, new Timestamp(), "LOG:  database system is ready to accept connections");
+    }
+
+    @Test
+    public void matchingLinesNonConformantToThePatternFails() throws Exception {
+        final String patterString = "The start has started right now";
+        final LogMatchCallback logMatchCallback = new LogMatchCallback(logger, callback, patterString);
+
+        new Expectations() {{
+            callback.matched();
+            times = 0;
+        }};
+
+        logMatchCallback.log(1, new Timestamp(), "LOG:  database system is ready to accept connections" );
+    }
+
+    @Test(expected = LogCallback.DoneException.class)
+    public void matchingPartitialLineSucceeds() throws Exception {
+        final String patterString = "waiting for connections";
+        final LogMatchCallback logMatchCallback = new LogMatchCallback(logger, callback, patterString);
+
+        new Expectations() {{
+            callback.matched();
+            times = 1;
+        }};
+
+        logMatchCallback.log(1, new Timestamp(), "2017-11-21T12:44:43.678+0000 I NETWORK  [initandlisten] waiting for connections on port 27017" );
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/wait/LogMatchCallbackTest.java
+++ b/src/test/java/io/fabric8/maven/docker/wait/LogMatchCallbackTest.java
@@ -8,6 +8,9 @@ import mockit.Mocked;
 import org.junit.Test;
 
 public class LogMatchCallbackTest {
+
+    private final String defaultPattern = "Hello, world!";
+
     @Mocked
     private Logger logger;
 
@@ -67,5 +70,41 @@ public class LogMatchCallbackTest {
         }};
 
         logMatchCallback.log(1, new Timestamp(), "2017-11-21T12:44:43.678+0000 I NETWORK  [initandlisten] waiting for connections on port 27017" );
+    }
+
+    @Test
+    public void errorMethodProducesLogMessage() {
+        final LogMatchCallback logMatchCallback = new LogMatchCallback(logger, callback, defaultPattern);
+
+        new Expectations() {{
+            logger.error(anyString, anyString);
+            times = 1;
+        }};
+
+        logMatchCallback.error("The message");
+    }
+
+    @Test
+    public void openMethodProducesLogMessage() {
+        final LogMatchCallback logMatchCallback = new LogMatchCallback(logger, callback, "");
+
+        new Expectations() {{
+            logger.debug(anyString);
+            times = 1;
+        }};
+
+        logMatchCallback.open();
+    }
+
+    @Test
+    public void closeMethodProducesLogMessage() {
+        final LogMatchCallback logMatchCallback = new LogMatchCallback(logger, callback, "");
+
+        new Expectations() {{
+            logger.debug(anyString);
+            times = 1;
+        }};
+
+        logMatchCallback.close();
     }
 }

--- a/src/test/java/io/fabric8/maven/docker/wait/LogWaitCheckerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/wait/LogWaitCheckerTest.java
@@ -3,15 +3,15 @@ package io.fabric8.maven.docker.wait;
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.log.LogCallback;
 import io.fabric8.maven.docker.access.log.LogGetHandle;
-import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.Logger;
-import io.fabric8.maven.docker.util.Timestamp;
-import mockit.*;
+import mockit.Expectations;
+import mockit.Mocked;
 import mockit.integration.junit4.JMockit;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author roland
@@ -21,64 +21,42 @@ import static org.assertj.core.api.Assertions.*;
 public class LogWaitCheckerTest {
 
     @Mocked
-    Logger log;
+    private Logger logger;
 
-    private static String CONTAINER_ID = "1234";
+    @Mocked
+    private DockerAccess access;
 
+    @Mocked
+    private LogGetHandle handle;
 
-    @Test
-    public void simple() {
+    private LogWaitChecker logWaitChecker;
 
-        DockerAccess access = prepareDockerAccess(true, "The start has finished right now");
-        LogWaitChecker wait =
-            new LogWaitChecker("start.*finished", access, CONTAINER_ID, log);
-        assertThat(wait.check()).isTrue();
-        wait.cleanUp();
+    @Before
+    public void setup() {
+        logWaitChecker = new LogWaitChecker("Hello, world!", access, "1", logger);
     }
 
     @Test
-    public void simpleNegative() {
+    public void checkerRegistersAsyncLogWhenCreated() {
 
-        DockerAccess access = prepareDockerAccess(false, "The start has started right now");
-        LogWaitChecker wait =
-            new LogWaitChecker("start.*finished", access, CONTAINER_ID, log);
-        assertThat(wait.check()).isFalse();
-        wait.cleanUp();
+        new Expectations() {{
+            access.getLogAsync(anyString, withInstanceOf(LogCallback.class));
+            times = 1;
+        }};
+
+        final LogWaitChecker logWaitChecker =
+                new LogWaitChecker("Hello, world!", access, "1", logger);
     }
 
     @Test
-    public void multiLine() {
-        DockerAccess access = prepareDockerAccess(true,
-                                                  "LOG:  database system is ready to accept connections",
-                                                  "LOG:  autovacuum launcher started",
-                                                  "LOG:  database system is shut down",
-                                                  "LOG:  database system is ready to accept connections");
-        LogWaitChecker wait =
-            new LogWaitChecker("(?s)ready to accept connections.*\\n.*ready to accept connections", access, CONTAINER_ID, log);
-        assertThat(wait.check()).isTrue();
-        wait.cleanUp();
+    public void checkingAfterMatchingSucceeds() {
+        logWaitChecker.matched();
+
+        assertThat(logWaitChecker.check()).isTrue();
     }
 
-    private DockerAccess prepareDockerAccess(final boolean success, final String ... logLines) {
-        return new MockUp<DockerAccess>() {
-                @Mock
-                LogGetHandle getLogAsync(String containerId, LogCallback callback) throws LogCallback.DoneException {
-                    assertThat(containerId).isEqualTo(CONTAINER_ID);
-                    try {
-                        for (String logTxt : logLines) {
-                            callback.log(1, new Timestamp(), logTxt);
-                        }
-                        if (success) {
-                            fail("Should have matched");
-                        }
-                    } catch (LogCallback.DoneException exp) {
-                        if (!success) {
-                            fail("No 'done' expected");
-                        }
-                    }
-                    return null;
-                }
-            }.getMockInstance();
+    @Test
+    public void checkingWithoutMatchingFails() {
+        assertThat(logWaitChecker.check()).isFalse();
     }
-
 }

--- a/src/test/java/io/fabric8/maven/docker/wait/LogWaitCheckerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/wait/LogWaitCheckerTest.java
@@ -33,6 +33,8 @@ public class LogWaitCheckerTest {
 
     @Before
     public void setup() {
+
+        presetExpections();
         logWaitChecker = new LogWaitChecker("Hello, world!", access, "1", logger);
     }
 
@@ -50,6 +52,7 @@ public class LogWaitCheckerTest {
 
     @Test
     public void checkingAfterMatchingSucceeds() {
+
         logWaitChecker.matched();
 
         assertThat(logWaitChecker.check()).isTrue();
@@ -57,6 +60,34 @@ public class LogWaitCheckerTest {
 
     @Test
     public void checkingWithoutMatchingFails() {
+
         assertThat(logWaitChecker.check()).isFalse();
+    }
+
+    @Test
+    public void checkerClosesLogHandle() {
+
+        new Expectations() {{
+            handle.finish();
+            times = 1;
+        }};
+
+        logWaitChecker.cleanUp();
+    }
+
+    @Test
+    public void checkerReturnsValidLogLabel() {
+
+        final String expectedLogLabel = "on log out '" + "Hello, world!" + "'";
+        assertThat(logWaitChecker.getLogLabel()).isEqualTo(expectedLogLabel);
+    }
+
+    private void presetExpections() {
+
+        new Expectations() {{
+            access.getLogAsync(anyString, withInstanceOf(LogCallback.class));
+            times = 1;
+            result = handle;
+        }};
     }
 }


### PR DESCRIPTION
Fixed entity stream closing
Added callback mechanism to signal wait lock condition to main thread including tests
Changed mocked DockerAccess dependency including expectations in LogWaitChecker tests