### PR TITLE
More reliably clean up failed/aborted containers

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -121,6 +121,12 @@ public class StartMojo extends AbstractDockerMojo {
             // Queue of images to start as containers
             final Queue<ImageConfiguration> imagesStarting = new ArrayDeque<>();
 
+            // Prepare the shutdown hook for stopping containers if we are going to follow them.  Add the hook before starting any
+            // of the containers so that partial or aborted starts will behave the same as fully-successful ones.
+            if (follow) {
+                runService.addShutdownHookForStoppingContainers(keepContainer, removeVolumes, autoCreateCustomNetworks);
+            }
+
             // Loop until every image has been started and the start of all images has been completed
             while (!hasBeenAllImagesStarted(imagesWaitingToStart, imagesStarting)) {
 
@@ -155,7 +161,6 @@ public class StartMojo extends AbstractDockerMojo {
             portMappingPropertyWriteHelper.write();
 
             if (follow) {
-                runService.addShutdownHookForStoppingContainers(keepContainer, removeVolumes, autoCreateCustomNetworks);
                 wait();
             }
 


### PR DESCRIPTION
Moves the shutdown hook in the StartMojo earlier so that containers that
will be cleaned up even if they haven't been fully started per their
wait conditions.  This is especially likely to occur on aborted builds.
[fixes #921]

Signed-off-by: Scott Coplin <coplin.6@osu.edu>