### PR TITLE
Issue #925: Push called multiple times for the same image

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/ServiceHub.java
+++ b/src/main/java/io/fabric8/maven/docker/service/ServiceHub.java
@@ -57,7 +57,7 @@ public class ServiceHub {
 
         if (dockerAccess != null) {
             queryService = new QueryService(dockerAccess);
-            registryService = new RegistryService(dockerAccess, logger);
+            registryService = new RegistryService(dockerAccess, queryService, logger);
             runService = new RunService(dockerAccess, queryService, containerTracker, logSpecFactory, logger);
             buildService = new BuildService(dockerAccess, queryService, registryService, archiveService, logger);
             volumeService = new VolumeService(dockerAccess);

--- a/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
@@ -11,6 +11,7 @@ import io.fabric8.maven.docker.util.AuthConfigFactory;
 import io.fabric8.maven.docker.util.AutoPullMode;
 import io.fabric8.maven.docker.util.ImageName;
 import io.fabric8.maven.docker.util.Logger;
+import mockit.Injectable;
 import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.Before;
@@ -46,13 +47,16 @@ public class RegistryServiceTest {
     @Mocked
     private AuthConfigFactory authConfigFactory;
 
+    @Injectable
+    private QueryService queryService;
+
     @Before
     public void setup() {
         reset();
     }
 
     private void reset() {
-        registryService = new RegistryService(docker, logger);
+        registryService = new RegistryService(docker, queryService, logger);
         cacheStore = new TestCacheStore();
         authConfig = new HashMap();
 


### PR DESCRIPTION
A small fix to the `push` goal that ensures we don't attempt to push the
same image more than once (i.e. if it is tagged multiple times).

Signed-off-by: Glenn J. Mason <glenn@glennji.com>