### PR TITLE
Credentials helper version string fix

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/CredentialHelperClient.java
+++ b/src/main/java/io/fabric8/maven/docker/util/CredentialHelperClient.java
@@ -73,7 +73,7 @@ public class CredentialHelperClient {
         public String getVersion() throws IOException {
             execute();
             if (version == null) {
-                throw new IOException("No reply information returned by " + getCommandAsString());
+                log.info("The credentials helper \"%s\" didn't return a version string",CredentialHelperClient.this.credentialHelperName);
             }
             return version;
         }


### PR DESCRIPTION
Don't throw an exception if the credentials helper doesn't return a version string

Fixes #896

Signed-off-by: Giuseppe Iannello <giuseppe.iannello@brokenloop.net>