### PR TITLE
Fix NPE in network config

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/NetworkConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/config/NetworkConfig.java
@@ -20,7 +20,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.fabric8.maven.docker.access.ContainerNetworkingConfig;
 import org.apache.maven.plugins.annotations.Parameter;
 
 /**
@@ -126,7 +125,7 @@ public class NetworkConfig implements Serializable {
     }
 
     public boolean hasAliases() {
-        return !aliases.isEmpty();
+        return aliases != null && !aliases.isEmpty();
     }
 
     // ==============================================================================


### PR DESCRIPTION
If property based configuration was used, and network mode was set to custom, `aliases` is by default set to null if no aliases are specified, causing NPE.

Example:
```
    <properties>
....
        <docker.network.mode>custom</docker.network.mode>
        <docker.network.name>some-net</docker.network.name>
    </properties>
```

```
mvn docker:build -e
...
[ERROR] Failed to execute goal io.fabric8:docker-maven-plugin:0.23.0:run (default-cli) on project xxxxx: Execution default-cli of goal io.fabric8:docker-maven-plugin:0.23.0:run failed. NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal io.fabric8:docker-maven-plugin:0.23.0:run (default-cli) on project xxxx: Execution default-cli of goal io.fabric8:docker-maven-plugin:0.23.0:run failed.
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:224)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:120)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:355)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:216)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:160)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-cli of goal io.fabric8:docker-maven-plugin:0.23.0:run failed.
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:143)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	... 19 more
Caused by: java.lang.NullPointerException
	at io.fabric8.maven.docker.config.NetworkConfig.hasAliases(NetworkConfig.java:129)
	at io.fabric8.maven.docker.service.RunService.createContainerConfig(RunService.java:267)
	at io.fabric8.maven.docker.service.RunService.createAndStartContainer(RunService.java:107)
	at io.fabric8.maven.docker.StartMojo$1.call(StartMojo.java:238)
	at io.fabric8.maven.docker.StartMojo$1.call(StartMojo.java:235)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:117)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:38)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:77)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutorService.execute(MoreExecutors.java:260)
	at java.util.concurrent.ExecutorCompletionService.submit(ExecutorCompletionService.java:181)
	at io.fabric8.maven.docker.StartMojo.startImage(StartMojo.java:235)
	at io.fabric8.maven.docker.StartMojo.executeInternal(StartMojo.java:132)
	at io.fabric8.maven.docker.AbstractDockerMojo.execute(AbstractDockerMojo.java:222)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
	... 20 more
[ERROR] 
