### PR TITLE
Add support for docker.runEnv properties and -D flags

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
@@ -66,6 +66,9 @@ public class ContainerCreateConfig {
             addPropertiesFromFile(envPropsFile, envProps);
         }
 
+        // Props from Maven environment takes highest precedence.
+        addEnvironmentFromMavenProperties(envProps, mavenProps);
+
         if (envProps.size() > 0) {
             addEnvironment(envProps);
         }
@@ -168,4 +171,10 @@ public class ContainerCreateConfig {
             throw new IllegalArgumentException(String.format("Error while loading environment properties: %s", e.getMessage()), e);
         }
     }
+
+    private void addEnvironmentFromMavenProperties(Map envProps, Map mavenProps) {
+        String argPrefix = "docker.runEnv";
+        EnvUtil.extractMavenAndSystemProperties(argPrefix, mavenProps, false, envProps);
+    }
+
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -314,7 +314,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
     }
 
     private Map<String, String> mapWithPrefix(String prefix, ConfigKey key, Properties properties) {
-        return extractFromPropertiesAsMap(key.asPropertyKey(prefix), properties);
+        return extractFromPropertiesAsMap(key.asPropertyKey(prefix), properties, true);
     }
 
     private String withPrefix(String prefix, ConfigKey key, Properties properties) {

--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -163,29 +163,14 @@ public class BuildService {
     }
 
     private Map<String, String> addBuildArgs(BuildContext buildContext) {
-        Map<String, String> buildArgsFromProject = addBuildArgsFromProperties(buildContext.getMojoParameters().getProject().getProperties());
-        Map<String, String> buildArgsFromSystem = addBuildArgsFromProperties(System.getProperties());
-        return ImmutableMap.<String, String>builder()
-                .putAll(buildContext.getBuildArgs() != null ? buildContext.getBuildArgs() : Collections.<String, String>emptyMap())
-                .putAll(buildArgsFromProject)
-                .putAll(buildArgsFromSystem)
-                .build();
-    }
-
-    private Map<String, String> addBuildArgsFromProperties(Properties properties) {
-        String argPrefix = "docker.buildArg.";
+        String argPrefix = "docker.buildArg";
         Map<String, String> buildArgs = new HashMap<>();
-        for (Object keyObj : properties.keySet()) {
-            String key = (String) keyObj;
-            if (key.startsWith(argPrefix)) {
-                String argKey = key.replaceFirst(argPrefix, "");
-                String value = properties.getProperty(key);
 
-                if (!isEmpty(value)) {
-                    buildArgs.put(argKey, value);
-                }
-            }
-        }
+        if(buildContext.getBuildArgs() != null)
+            buildArgs.putAll(buildContext.getBuildArgs());
+
+        EnvUtil.extractMavenAndSystemProperties(argPrefix, buildContext.getMojoParameters().getProject().getProperties(), false, buildArgs);
+
         log.debug("Build args set %s", buildArgs);
         return buildArgs;
     }
@@ -246,11 +231,6 @@ public class BuildService {
             return buildConfig.nocache();
         }
     }
-
-    private boolean isEmpty(String str) {
-        return str == null || str.isEmpty();
-    }
-
 
     // ===========================================
 

--- a/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
@@ -99,11 +99,71 @@ public class EnvUtilTest {
         Properties props = getTestProperties(
                 "bla.hello","world",
                 "bla.max","morlock",
-                "blub.not","aMap");
-        Map<String,String> result = EnvUtil.extractFromPropertiesAsMap("bla", props);
+                "blub.not","aMap",
+                "bla.empty", "");
+
+        Map<String,String> result = EnvUtil.extractFromPropertiesAsMap("bla", props, true);
+        assertEquals(3,result.size());
+        assertEquals("world",result.get("hello"));
+        assertEquals("morlock",result.get("max"));
+        assertEquals("",result.get("empty"));
+
+        result = EnvUtil.extractFromPropertiesAsMap("bla", props, false);
         assertEquals(2,result.size());
         assertEquals("world",result.get("hello"));
         assertEquals("morlock",result.get("max"));
+    }
+
+    @Test
+    public void extractFromMap() {
+        Map<String, String> src = getTestMap(
+                "bla.hello","world",
+                "bla.max","morlock",
+                "blub.not","aMap",
+                "bla.empty", "");
+
+        Map<String, String> result = new HashMap<>();
+        EnvUtil.extractFromMap("bla", src, true, result);
+        assertEquals(3,result.size());
+        assertEquals("world",result.get("hello"));
+        assertEquals("morlock",result.get("max"));
+        assertEquals("",result.get("empty"));
+
+        // test sending to Properties
+        Properties resultP = new Properties();
+        EnvUtil.extractFromMap("bla", src, false, resultP);
+        assertEquals(2,resultP.size());
+        assertEquals("world",resultP.get("hello"));
+        assertEquals("morlock",resultP.get("max"));
+    }
+
+    @Test
+    public void extractMavenAndSystemProperties() {
+        Properties src = getTestProperties(
+                "bla.hello","world",
+                "bla.max","morlock",
+                "blub.not","aMap",
+                "bla.empty", "");
+
+        System.setProperty("bla.sysprop", "someSysProp");
+        System.setProperty("bla.emptyprop", "");
+
+        Map<String, String> result = new HashMap<>();
+        EnvUtil.extractMavenAndSystemProperties("bla", src, true, result);
+        assertEquals(5,result.size());
+        assertEquals("world",result.get("hello"));
+        assertEquals("morlock",result.get("max"));
+        assertEquals("someSysProp",result.get("sysprop"));
+        assertEquals("",result.get("emptyprop"));
+        assertEquals("",result.get("empty"));
+
+        // test properties alternative, which is also Map
+        Properties resultP = new Properties();
+        EnvUtil.extractMavenAndSystemProperties("bla", src, false, resultP);
+        assertEquals(3,resultP.size());
+        assertEquals("world",resultP.get("hello"));
+        assertEquals("morlock",resultP.get("max"));
+        assertEquals("someSysProp",result.get("sysprop"));
     }
 
     @Test
@@ -185,6 +245,14 @@ public class EnvUtilTest {
         Properties ret = new Properties();
         for (int i = 0; i < vals.length; i+=2) {
             ret.setProperty(vals[i],vals[i+1]);
+        }
+        return ret;
+    }
+
+    private Map<String, String> getTestMap(String ... vals) {
+        Map<String, String> ret = new HashMap();
+        for (int i = 0; i < vals.length; i+=2) {
+            ret.put(vals[i],vals[i+1]);
         }
         return ret;
     }


### PR DESCRIPTION
**Background:**
When running in an environment which requires http_proxy to be set in a container, it's usually environment specific and not something to be specified in an image or the project's POM file.

Since there is already "specific" support for `docker.buildArg` through properties & -D flags, I thought it would not be too weird to add a docker.runEnv as well. Ideally I'd want to have all things configurable with property overrides (without requiring externalized config), but that is a much greater change I recon.

**Example:**
Instead of adding 
```
<run>
  <env>
    <http_proxy>http://example.com:8080</http_proxy>
  </env
</run>
```
hardcoded in every project POM,

I can instead add
```
<properties>
  <docker.runEnv.http_proxy>http://example.com:8080</docker.runEnv.http_proxy>
</properties>
```
in either my .m2 settings.xml, 

or, I could add as -D flag during build (for example in my default Jenkins template)
```
mvn .... -Ddocker.runEnv.http_proxy=http://example.com:8080
```

**Change**
This moves helper methods used for existing `docker.buildArg` into EnvUtil and uses the same when creating the `ContainerCreateConfig` in `RunService`.
