### PR TITLE
#911 Fix NPE in LogCallback

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/log/DefaultLogCallback.java
+++ b/src/main/java/io/fabric8/maven/docker/log/DefaultLogCallback.java
@@ -19,6 +19,7 @@ import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.io.Files;
 import io.fabric8.maven.docker.access.log.LogCallback;
 import io.fabric8.maven.docker.util.Timestamp;
 
@@ -46,6 +47,7 @@ public class DefaultLogCallback implements LogCallback {
             } else {
                 SharedPrintStream cachedPs = printStreamMap.get(file);
                 if (cachedPs == null) {
+                    Files.createParentDirs(new File(file));
                     PrintStream ps = new PrintStream(new FileOutputStream(file), true);
                     cachedPs = new SharedPrintStream(ps);
                     printStreamMap.put(file, cachedPs);

--- a/src/main/java/io/fabric8/maven/docker/log/SharedPrintStream.java
+++ b/src/main/java/io/fabric8/maven/docker/log/SharedPrintStream.java
@@ -24,7 +24,7 @@ class SharedPrintStream {
     boolean close() {
         int nrUsers = numUsers.decrementAndGet();
         if (nrUsers == 0 && printStream != System.out) {
-            printStream.close();;
+            printStream.close();
             return true;
         } else {
             return false;

--- a/src/test/java/io/fabric8/maven/docker/log/DefaultLogCallbackTest.java
+++ b/src/test/java/io/fabric8/maven/docker/log/DefaultLogCallbackTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.*;
 import java.util.*;
@@ -12,6 +13,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.io.Files;
 import org.apache.maven.shared.utils.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -145,6 +147,18 @@ public class DefaultLogCallbackTest {
 
         // expect empty set
         assertThat(indexes, is(empty()));
+    }
+
+    @Test
+    public void shouldCreateParentDirs() throws IOException {
+        File dir = Files.createTempDir();
+        dir.deleteOnExit();
+        file = new File(dir, "non/existing/dirs/file.log");
+        spec = new LogOutputSpec.Builder().prefix("callback-test> ")
+                .file(file.toString()).build();
+        callback = new DefaultLogCallback(spec);
+        callback.open();
+        assertTrue(file.exists());
     }
 
     private class LoggerTask implements Runnable {


### PR DESCRIPTION
Attempt to fix #911 

Root cause: `${project.build.directory}` (`target/`) doesn't exist and because of this an exception is thrown when attempting to create the SharedPrintStream to `target/postgres.log`; the catch block tries to log to this SharedPrintStream which wasn't constructed

Solution: create the dirs leading to the log file before opening the stream