### PR TITLE
Add separate properties for build.env.build and run.env

### DIFF
--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -42,8 +42,9 @@
     <postgres.docker.name>postgres:9.5.2</postgres.docker.name>
     <postgres.docker.log.prefix>postgres</postgres.docker.log.prefix>
     <postgres.docker.ports.1>${itest.postgres.port}:5432</postgres.docker.ports.1>
-    <postgres.docker.env.POSTGRES_USER>superuser</postgres.docker.env.POSTGRES_USER>
-    <postgres.docker.env.POSTGRES_PASSWORD>superuser-password</postgres.docker.env.POSTGRES_PASSWORD>
+    <postgres.docker.env.POSTGRES_DB>localhost</postgres.docker.env.POSTGRES_DB>
+    <postgres.docker.runEnv.POSTGRES_USER>superuser</postgres.docker.runEnv.POSTGRES_USER>
+    <postgres.docker.runEnv.POSTGRES_PASSWORD>superuser-password</postgres.docker.runEnv.POSTGRES_PASSWORD>
     <postgres.docker.wait.time>10000</postgres.docker.wait.time>
     <postgres.docker.wait.log>PostgreSQL init process complete</postgres.docker.wait.log>
   </properties>

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -94,10 +94,16 @@ when a `docker.from` or a `docker.fromExt` is set.
 | Property part for the exposed container properties like internal IP addresses as described in <<start-overview, docker:start>>.
 
 | *docker.env.VARIABLE*
-| Sets an environment variable. E.g. `<docker.env.JAVA_OPTS>-Xmx512m</docker.env.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is used both for building images and running containers. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
+| Sets an environment variable used in build and run. E.g. `<docker.env.JAVA_OPTS>-Xmx512m</docker.env.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is used both for building images and running containers. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
+
+| *docker.buildEnv.VARIABLE*
+| Sets an environment variable used in build only. E.g. `<docker.buildEnv.JAVA_OPTS>-Xmx512m</docker.buildEnv.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is building images only. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
+
+| *docker.runEnv.VARIABLE*
+| Sets an environment variable used in run only. E.g. `<docker.runEnv.JAVA_OPTS>-Xmx512m</docker.runEnv.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is used both for running containers only. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
 
 | *docker.envPropertyFile*
-| specifies the path to a property file whose properties are used as environment variables. The environment variables takes precedence over any other environment variables specified.
+| specifies the path to a property file whose properties are used as environment variables in run. The environment variables takes precedence over any other environment variables specified.
 
 | *docker.extraHosts.idx*
 | List of `host:ip` to add to `/etc/hosts`

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -53,6 +53,8 @@ public enum ConfigKey {
     ENTRYPOINT,
     ENV,
     ENV_PROPERTY_FILE,
+    ENV_BUILD("buildEnv"),
+    ENV_RUN("runEnv"),
     EXPOSED_PROPERTY_KEY,
     EXTRA_HOSTS,
     FILTER,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -24,6 +24,7 @@ import org.apache.maven.project.MavenProject;
 import io.fabric8.maven.docker.config.handler.ExternalConfigHandler;
 import io.fabric8.maven.docker.util.EnvUtil;
 
+import org.codehaus.plexus.util.CollectionUtils;
 import static io.fabric8.maven.docker.config.handler.property.ConfigKey.*;
 import static io.fabric8.maven.docker.util.EnvUtil.*;
 
@@ -84,7 +85,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .optimise(withPrefix(prefix, OPTIMISE, properties))
                 .entryPoint(withPrefix(prefix, ENTRYPOINT, properties))
                 .assembly(extractAssembly(prefix, properties))
-                .env(mapWithPrefix(prefix, ENV, properties))
+                .env(CollectionUtils.mergeMaps(
+                        mapWithPrefix(prefix, ENV_BUILD, properties),
+                        mapWithPrefix(prefix, ENV, properties)
+                ))
                 .args(mapWithPrefix(prefix, ARGS, properties))
                 .labels(mapWithPrefix(prefix,LABELS,properties))
                 .ports(extractPortValues(prefix, properties))
@@ -122,7 +126,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .dnsSearch(listWithPrefix(prefix, DNS_SEARCH, properties))
                 .domainname(withPrefix(prefix, DOMAINNAME, properties))
                 .entrypoint(withPrefix(prefix, ENTRYPOINT, properties))
-                .env(mapWithPrefix(prefix, ENV, properties))
+                .env(CollectionUtils.mergeMaps(
+                        mapWithPrefix(prefix, ENV_RUN, properties),
+                        mapWithPrefix(prefix, ENV, properties)
+                ))
                 .labels(mapWithPrefix(prefix,LABELS,properties))
                 .envPropertyFile(withPrefix(prefix, ENV_PROPERTY_FILE, properties))
                 .extraHosts(listWithPrefix(prefix, EXTRA_HOSTS, properties))

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -146,6 +146,57 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         }
     }
 
+
+    @Test
+    public void testSpecificEnv() throws Exception {
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.from", "baase",
+                        "docker.name","demo",
+                        "docker.buildEnv.HOME", "/tmp",
+                        "docker.runEnv.root.dir", "/bla"
+                ));
+
+        assertEquals(1,configs.size());
+        ImageConfiguration calcConfig = configs.get(0);
+
+        Map<String, String> env;
+
+        env = calcConfig.getBuildConfiguration().getEnv();
+        assertEquals(1,env.size());
+        assertEquals("/tmp",env.get("HOME"));
+
+        env = calcConfig.getRunConfiguration().getEnv();
+        assertEquals(1,env.size());
+        assertEquals("/bla",env.get("root.dir"));
+    }
+
+    @Test
+    public void testMergedEnv() throws Exception {
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.from", "baase",
+                        "docker.name","demo",
+                        "docker.env.HOME", "/tmp",
+                        "docker.buildEnv.HOME", "/var/tmp",
+                        "docker.runEnv.root.dir", "/bla"
+                ));
+
+        assertEquals(1,configs.size());
+        ImageConfiguration calcConfig = configs.get(0);
+
+        Map<String, String> env;
+
+        env = calcConfig.getBuildConfiguration().getEnv();
+        assertEquals(1,env.size());
+        assertEquals("/var/tmp",env.get("HOME"));
+
+        env = calcConfig.getRunConfiguration().getEnv();
+        assertEquals(2,env.size());
+        assertEquals("/tmp",env.get("HOME"));
+        assertEquals("/bla",env.get("root.dir"));
+    }
+
     @Test
     public void testAssembly() throws Exception {
         List<ImageConfiguration> configs = resolveImage(imageConfiguration, props(getTestAssemblyData()));


### PR DESCRIPTION
Addresses #386, discussed in #938

Note that it was not possible to use "env.run/build", which would have
matched well with other properties, because we already have the "env"
matcher (which would have matched env.run too, injecting bad
properties).