### PR TITLE
Add new naming strategy "auto"

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -8,24 +8,47 @@ package io.fabric8.maven.docker;
  * the License.
  */
 
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
-
 import com.google.common.util.concurrent.MoreExecutors;
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.ExecException;
 import io.fabric8.maven.docker.access.PortMapping;
-import io.fabric8.maven.docker.config.*;
+import io.fabric8.maven.docker.config.ConfigHelper;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.config.LogConfiguration;
+import io.fabric8.maven.docker.config.NamingStrategy;
+import io.fabric8.maven.docker.config.NetworkConfig;
+import io.fabric8.maven.docker.config.RunImageConfiguration;
+import io.fabric8.maven.docker.config.WaitConfiguration;
 import io.fabric8.maven.docker.log.LogDispatcher;
 import io.fabric8.maven.docker.model.Container;
-import io.fabric8.maven.docker.service.*;
+import io.fabric8.maven.docker.service.ImagePullManager;
+import io.fabric8.maven.docker.service.QueryService;
+import io.fabric8.maven.docker.service.RegistryService;
+import io.fabric8.maven.docker.service.RunService;
+import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.StartOrderResolver;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.StringUtils;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -72,6 +95,19 @@ public class StartMojo extends AbstractDockerMojo {
      */
     @Parameter(property = "docker.autoCreateCustomNetworks", defaultValue = "false")
     protected boolean autoCreateCustomNetworks;
+
+    /**
+     * Default value for the naming strategy for containers.
+     */
+    @Parameter(property = "docker.namingStrategy", defaultValue = "auto")
+    protected NamingStrategy namingStrategy;
+
+    /**
+     * Container prefix for the naming strategy auto, the final container name will be
+     * &lt;prefix&gt;_&lt;image name&gt;
+     */
+    @Parameter(property = "docker.containerPrefix", defaultValue = "${project.name}")
+    protected String containerPrefix;
 
     // property file to write out with port mappings
     @Parameter
@@ -244,7 +280,7 @@ public class StartMojo extends AbstractDockerMojo {
         startingContainers.submit(new Callable<StartedContainer>() {
             @Override
             public StartedContainer call() throws Exception {
-                final String containerId = runService.createAndStartContainer(image, portMapping, getPomLabel(), projProperties, project.getBasedir());
+                final String containerId = runService.createAndStartContainer(image, portMapping, namingStrategy, containerPrefix, getPomLabel(), projProperties, project.getBasedir());
 
                 // Update port-mapping writer
                 portMappingPropertyWriteHelper.add(portMapping, runConfig.getPortPropertyFile());

--- a/src/main/java/io/fabric8/maven/docker/WatchMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/WatchMojo.java
@@ -16,11 +16,11 @@ package io.fabric8.maven.docker;/*
  */
 
 import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.NamingStrategy;
 import io.fabric8.maven.docker.config.WatchMode;
 import io.fabric8.maven.docker.service.BuildService;
 import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.service.WatchService;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -66,6 +66,19 @@ public class WatchMojo extends AbstractBuildSupportMojo {
     @Parameter(property = "docker.autoCreateCustomNetworks", defaultValue = "false")
     protected boolean autoCreateCustomNetworks;
 
+    /**
+     * Default value for the naming strategy for containers.
+     */
+    @Parameter(property = "docker.namingStrategy", defaultValue = "auto")
+    protected NamingStrategy namingStrategy;
+
+    /**
+     * Container prefix for the naming strategy auto, the final container name will be
+     * &lt;prefix&gt;_&lt;image name&gt;
+     */
+    @Parameter(property = "docker.containerPrefix", defaultValue = "${project.name}")
+    protected String containerPrefix;
+
     @Override
     protected synchronized void executeInternal(ServiceHub hub) throws DockerAccessException,
                                                                        MojoExecutionException {
@@ -83,6 +96,8 @@ public class WatchMojo extends AbstractBuildSupportMojo {
                 .watchPostGoal(watchPostGoal)
                 .watchPostExec(watchPostExec)
                 .autoCreateCustomNetworks(autoCreateCustomNetworks)
+                .defaultNamingStrategy(namingStrategy)
+                .containerPrefix(containerPrefix)
                 .keepContainer(keepContainer)
                 .keepRunning(keepRunning)
                 .removeVolumes(removeVolumes)

--- a/src/main/java/io/fabric8/maven/docker/config/NamingStrategy.java
+++ b/src/main/java/io/fabric8/maven/docker/config/NamingStrategy.java
@@ -1,0 +1,20 @@
+package io.fabric8.maven.docker.config;
+
+/**
+ * @author marcus
+ * @since 1.0.0
+ */ // Naming scheme for how to name container
+public enum NamingStrategy {
+    /**
+     * No extra naming
+     */
+    none,
+    /**
+     * Use the alias as defined in the configuration
+     */
+    alias,
+    /**
+     * Use the image name plus a prefix
+     */
+    auto
+}

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -1,15 +1,13 @@
 package io.fabric8.maven.docker.config;
 
+import io.fabric8.maven.docker.util.DeepCopy;
+import io.fabric8.maven.docker.util.EnvUtil;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-
-import io.fabric8.maven.docker.util.DeepCopy;
-import org.apache.maven.plugins.annotations.Parameter;
-
-import io.fabric8.maven.docker.util.EnvUtil;
-
-import javax.annotation.Nonnull;
 
 /**
  * @author roland
@@ -292,20 +290,8 @@ public class RunImageConfiguration implements Serializable {
         return tmpfs;
     }
 
-    // Naming scheme for how to name container
-    public enum NamingStrategy {
-        /**
-         * No extra naming
-         */
-        none,
-        /**
-         * Use the alias as defined in the configuration
-         */
-        alias
-    }
-
     public NamingStrategy getNamingStrategy() {
-        return namingStrategy == null ? NamingStrategy.none : namingStrategy;
+        return namingStrategy;
     }
 
     public String getExposedPropertyKey() {

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -17,22 +17,46 @@ package io.fabric8.maven.docker.service;
  * limitations under the License.
  */
 
-import java.io.File;
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-
+import io.fabric8.maven.docker.access.ContainerCreateConfig;
+import io.fabric8.maven.docker.access.ContainerHostConfig;
+import io.fabric8.maven.docker.access.ContainerNetworkingConfig;
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.ExecException;
+import io.fabric8.maven.docker.access.NetworkCreateConfig;
+import io.fabric8.maven.docker.access.PortMapping;
+import io.fabric8.maven.docker.config.Arguments;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.config.NamingStrategy;
+import io.fabric8.maven.docker.config.NetworkConfig;
+import io.fabric8.maven.docker.config.RestartPolicy;
+import io.fabric8.maven.docker.config.RunImageConfiguration;
+import io.fabric8.maven.docker.config.RunVolumeConfiguration;
+import io.fabric8.maven.docker.log.LogOutputSpecFactory;
 import io.fabric8.maven.docker.model.Container;
 import io.fabric8.maven.docker.model.ContainerDetails;
 import io.fabric8.maven.docker.model.ExecDetails;
-import io.fabric8.maven.docker.log.LogOutputSpecFactory;
-import io.fabric8.maven.docker.access.*;
-import io.fabric8.maven.docker.config.*;
 import io.fabric8.maven.docker.model.Network;
-import io.fabric8.maven.docker.util.*;
-import io.fabric8.maven.docker.wait.WaitUtil;
+import io.fabric8.maven.docker.util.ContainerName;
+import io.fabric8.maven.docker.util.EnvUtil;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.docker.util.PomLabel;
+import io.fabric8.maven.docker.util.StartOrderResolver;
 import io.fabric8.maven.docker.wait.WaitTimeoutException;
+import io.fabric8.maven.docker.wait.WaitUtil;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 
 import static io.fabric8.maven.docker.util.VolumeBindingUtil.resolveRelativeVolumeBindings;
 
@@ -99,21 +123,25 @@ public class RunService {
      * Create and start a container with the given image configuration.
      * @param imageConfig image configuration holding the run information and the image name
      * @param portMapping container port mapping
-     * @param mavenProps properties to fill in with dynamically assigned ports
+     * @param defaultNamingStrategy default naming strategy if any
+     * @param containerPrefix the container prefix
      * @param pomLabel label to tag the started container with
      *
+     * @param mavenProps properties to fill in with dynamically assigned ports
      * @return the container id
      *
      * @throws DockerAccessException if access to the docker backend fails
      */
     public String createAndStartContainer(ImageConfiguration imageConfig,
                                           PortMapping portMapping,
+                                          final NamingStrategy defaultNamingStrategy,
+                                          final String containerPrefix,
                                           PomLabel pomLabel,
                                           Properties mavenProps,
                                           File baseDir) throws DockerAccessException {
         RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
         String imageName = imageConfig.getName();
-        String containerName = calculateContainerName(imageConfig.getAlias(), runConfig.getNamingStrategy());
+        String containerName = ContainerName.calculate(imageConfig.getAlias(), runConfig.getNamingStrategy(), defaultNamingStrategy, containerPrefix, imageName);
         ContainerCreateConfig config = createContainerConfig(imageName, runConfig, portMapping, pomLabel, mavenProps, baseDir);
 
         String id = docker.createContainer(config, containerName);
@@ -378,17 +406,6 @@ public class RunService {
             }
         }
         return list;
-    }
-
-
-    private String calculateContainerName(String alias, RunImageConfiguration.NamingStrategy namingStrategy) {
-        if (namingStrategy == RunImageConfiguration.NamingStrategy.none) {
-            return null;
-        }
-        if (alias == null) {
-            throw new IllegalArgumentException("A naming scheme 'alias' requires an image alias to be set");
-        }
-        return alias;
     }
 
     // checkAllContainers: false = only running containers are considered

--- a/src/main/java/io/fabric8/maven/docker/util/ContainerName.java
+++ b/src/main/java/io/fabric8/maven/docker/util/ContainerName.java
@@ -1,0 +1,42 @@
+package io.fabric8.maven.docker.util;
+
+import com.google.common.base.MoreObjects;
+import io.fabric8.maven.docker.config.NamingStrategy;
+
+/**
+ * @author marcus
+ * @since 1.0.0
+ */
+public abstract class ContainerName {
+
+    private ContainerName() {
+        // utility class
+    }
+
+    public static String calculate(String alias,
+                                   NamingStrategy namingStrategy,
+                                   NamingStrategy defaultNamingStrategy,
+                                   String containerPrefix,
+                                   String imageName) {
+        final NamingStrategy activeNamingStrategy = MoreObjects.firstNonNull(namingStrategy, defaultNamingStrategy);
+
+        switch (activeNamingStrategy) {
+            case alias:
+                if (alias == null) {
+                    throw new IllegalArgumentException("A naming scheme 'alias' requires an image alias to be set");
+                }
+                return alias;
+            case auto:
+                if (containerPrefix == null) {
+                    throw new IllegalArgumentException("A naming scheme 'auto' requires a container prefix to be set");
+                }
+                final String validImageName = new ImageName(imageName).getSimpleName().replaceAll("[^a-zA-Z0-9_.-]+", "_");
+                return containerPrefix + "_" + validImageName;
+            case none:
+                return null;
+            default:
+                throw new IllegalArgumentException("Naming scheme '" + activeNamingStrategy + "' not handled");
+        }
+    }
+
+}

--- a/src/test/java/io/fabric8/maven/docker/config/handler/AbstractConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/AbstractConfigHandlerTest.java
@@ -1,13 +1,14 @@
 package io.fabric8.maven.docker.config.handler;
 
-import static org.junit.Assert.assertEquals;
+import io.fabric8.maven.docker.config.NamingStrategy;
+import io.fabric8.maven.docker.config.RestartPolicy;
+import io.fabric8.maven.docker.config.RunImageConfiguration;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import io.fabric8.maven.docker.config.RestartPolicy;
-import io.fabric8.maven.docker.config.RunImageConfiguration;
+import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractConfigHandlerTest {
 
@@ -17,7 +18,7 @@ public abstract class AbstractConfigHandlerTest {
 
     protected abstract String getEnvPropertyFile();
     
-    protected abstract RunImageConfiguration.NamingStrategy getRunNamingStrategy();
+    protected abstract NamingStrategy getRunNamingStrategy();
     
     protected abstract void validateEnv(Map<String, String> env);
     

--- a/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
@@ -1,15 +1,5 @@
 package io.fabric8.maven.docker.config.handler.compose;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.RestartPolicy;
 import io.fabric8.maven.docker.config.RunImageConfiguration;
@@ -26,6 +16,16 @@ import org.apache.maven.shared.filtering.MavenReaderFilter;
 import org.apache.maven.shared.filtering.MavenReaderFilterRequest;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -136,7 +136,7 @@ public class DockerComposeConfigHandlerTest {
         assertEquals(a("redis","link1"), runConfig.getLinks());
         assertEquals((Long) 1L, runConfig.getMemory());
         assertEquals((Long) 1L, runConfig.getMemorySwap());
-        assertEquals(RunImageConfiguration.NamingStrategy.none, runConfig.getNamingStrategy());
+        assertEquals(null, runConfig.getNamingStrategy());
         assertEquals(null,runConfig.getEnvPropertyFile());
 
         assertEquals(null, runConfig.getPortPropertyFile());

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -160,10 +160,10 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
     @Test
     public void testNamingScheme() throws Exception  {
-        String[] testData = new String[] {k(ConfigKey.NAME), "image", k(ConfigKey.NAMING_STRATEGY), RunImageConfiguration.NamingStrategy.alias.toString() };
+        String[] testData = new String[] {k(ConfigKey.NAME), "image", k(ConfigKey.NAMING_STRATEGY), NamingStrategy.alias.toString() };
 
         ImageConfiguration config = resolveExternalImageConfig(testData);
-        assertEquals(RunImageConfiguration.NamingStrategy.alias, config.getRunConfiguration().getNamingStrategy());
+        assertEquals(NamingStrategy.alias, config.getRunConfiguration().getNamingStrategy());
     }
 
     @Test
@@ -306,8 +306,8 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
     }
 
     @Override
-    protected RunImageConfiguration.NamingStrategy getRunNamingStrategy() {
-        return RunImageConfiguration.NamingStrategy.none;
+    protected NamingStrategy getRunNamingStrategy() {
+        return NamingStrategy.none;
     }
 
     @Override
@@ -401,7 +401,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals(a("redis"), runConfig.getLinks());
         assertEquals((Long) 1L, runConfig.getMemory());
         assertEquals((Long) 1L, runConfig.getMemorySwap());
-        Assert.assertEquals(RunImageConfiguration.NamingStrategy.none, runConfig.getNamingStrategy());
+        Assert.assertEquals(NamingStrategy.none, runConfig.getNamingStrategy());
         assertEquals("/tmp/envProps.txt",runConfig.getEnvPropertyFile());
         assertEquals("/tmp/props.txt", runConfig.getPortPropertyFile());
         assertEquals(a("8081:8080"), runConfig.getPorts());

--- a/src/test/java/io/fabric8/maven/docker/util/ContainerNameTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/ContainerNameTest.java
@@ -1,0 +1,69 @@
+package io.fabric8.maven.docker.util;
+
+import io.fabric8.maven.docker.config.NamingStrategy;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author marcus
+ * @since 1.0.0
+ */
+public class ContainerNameTest {
+
+    @Test
+    public void aliasWins() {
+        final String calculatedValue = ContainerName.calculate("alias", NamingStrategy.alias, NamingStrategy.auto, "prefix", "test.org/jolokia/jolokia_demo:latest");
+        assertEquals("alias", calculatedValue);
+    }
+
+    @Test
+    public void globalLevelAuto() {
+        final String calculatedValue = ContainerName.calculate("alias", null, NamingStrategy.auto, "prefix", "test.org/jolokia/jolokia_demo:latest");
+        assertEquals("prefix_jolokia_demo", calculatedValue);
+    }
+
+    @Test
+    public void imageLevelAuto() {
+        final String calculatedValue = ContainerName.calculate("alias", NamingStrategy.auto, NamingStrategy.none, "prefix", "test.org/jolokia/jolokia_demo:latest");
+        assertEquals("prefix_jolokia_demo", calculatedValue);
+    }
+
+    @Test
+    public void globalLevelAlias() {
+        final String calculatedValue = ContainerName.calculate("alias", null, NamingStrategy.alias, "prefix", "test.org/jolokia/jolokia_demo:latest");
+        assertEquals("alias", calculatedValue);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void globalLevelAliasRequiresAlias() {
+        ContainerName.calculate( null, null, NamingStrategy.alias, "prefix", "test.org/jolokia/jolokia_demo:latest");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void imagelLevelAliasRequiresAlias() {
+        ContainerName.calculate( null, NamingStrategy.alias, NamingStrategy.alias, "prefix", "test.org/jolokia/jolokia_demo:latest");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void globalLevelAutoRequiresPrefix() {
+        ContainerName.calculate( null, null, NamingStrategy.auto, null, "test.org/jolokia/jolokia_demo:latest");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void imageLevelAutoRequiresPrefix() {
+        ContainerName.calculate( null, NamingStrategy.auto, NamingStrategy.auto, null, "test.org/jolokia/jolokia_demo:latest");
+    }
+
+    @Test
+    public void globalLevelNone() {
+        final String calculatedValue = ContainerName.calculate( null, null, NamingStrategy.none, null, "test.org/jolokia/jolokia_demo:latest");
+        assertEquals(calculatedValue, null);
+    }
+
+    @Test
+    public void imageLevelNone() {
+        final String calculatedValue = ContainerName.calculate( null, NamingStrategy.none, null, null, "test.org/jolokia/jolokia_demo:latest");
+        assertEquals(calculatedValue, null);
+    }
+}


### PR DESCRIPTION
Enable a new default naming strategy "auto" to create container names based on
a prefix and the image simple name. Adding a global configration for the naming
strategy in order to change it on a global level and thus closing #931.

I don't know if that is a little bit over the top or very narrow minded from our use case point of view, feedback is more than welcome. 