### PR TITLE
Merging Properties and POM based configuration

### DIFF
--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -42,8 +42,9 @@
     <postgres.docker.name>postgres:9.5.2</postgres.docker.name>
     <postgres.docker.log.prefix>postgres</postgres.docker.log.prefix>
     <postgres.docker.ports.1>${itest.postgres.port}:5432</postgres.docker.ports.1>
-    <postgres.docker.env.POSTGRES_USER>superuser</postgres.docker.env.POSTGRES_USER>
-    <postgres.docker.env.POSTGRES_PASSWORD>superuser-password</postgres.docker.env.POSTGRES_PASSWORD>
+    <postgres.docker.env.POSTGRES_DB>localhost</postgres.docker.env.POSTGRES_DB>
+    <postgres.docker.envRun.POSTGRES_USER>superuser</postgres.docker.envRun.POSTGRES_USER>
+    <postgres.docker.envRun.POSTGRES_PASSWORD>superuser-password</postgres.docker.envRun.POSTGRES_PASSWORD>
     <postgres.docker.wait.time>10000</postgres.docker.wait.time>
     <postgres.docker.wait.log>PostgreSQL init process complete</postgres.docker.wait.log>
   </properties>

--- a/src/main/asciidoc/inc/build/_buildargs.adoc
+++ b/src/main/asciidoc/inc/build/_buildargs.adoc
@@ -1,4 +1,4 @@
-
+[[property-buildargs]]
 As described in section <<build-configuration,Configuration>> for external Dockerfiles https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables-build-arg[Docker build arg] can be used. In addition to the
 configuration within the plugin configuration you can also use properties to specify them:
 

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -94,10 +94,16 @@ when a `docker.from` or a `docker.fromExt` is set.
 | Property part for the exposed container properties like internal IP addresses as described in <<start-overview, docker:start>>.
 
 | *docker.env.VARIABLE*
-| Sets an environment variable. E.g. `<docker.env.JAVA_OPTS>-Xmx512m</docker.env.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is used both for building images and running containers. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
+| Sets an environment variable used in build and run. E.g. `<docker.env.JAVA_OPTS>-Xmx512m</docker.env.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is used both for building images and running containers. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
+
+| *docker.envBuild.VARIABLE*
+| Sets an environment variable used in build only. E.g. `<docker.envBuild.JAVA_OPTS>-Xmx512m</docker.envBuild.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is building images only. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
+
+| *docker.envRun.VARIABLE*
+| Sets an environment variable used in run only. E.g. `<docker.envRun.JAVA_OPTS>-Xmx512m</docker.envRun.JAVA_OPTS>` sets the environment variable `JAVA_OPTS`. Multiple such entries can be provided. This environment is used both for running containers only. The value cannot be empty but can contain Maven property names which are resolved before the Dockerfile is created.
 
 | *docker.envPropertyFile*
-| specifies the path to a property file whose properties are used as environment variables. The environment variables takes precedence over any other environment variables specified.
+| specifies the path to a property file whose properties are used as environment variables in run. The environment variables takes precedence over any other environment variables specified.
 
 | *docker.extraHosts.idx*
 | List of `host:ip` to add to `/etc/hosts`

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -5,6 +5,17 @@ configuration. Such a property based configuration can be selected
 with an `<type>` of `properties`. As extra configuration a prefix for the
 properties can be defined which by default is `docker`.
 
+For single-image configurations it is also possible to active property
+based configuration via an externally set property.
+
+By default, property based configuration uses only properties, ignoring
+any `<build>` and `<run>` sections. To combine values from both sources,
+use the <<combining-property-config,property mode configuration>>.
+
+Properties are read from the Maven project (defined in `<properties>` or global
+Maven configuration from `settings.xml`) and, since 0.25.0, from any `-D`
+flags given to Maven (takes priority over project properties).
+
 .Example
 [source,xml]
 ----
@@ -12,6 +23,7 @@ properties can be defined which by default is `docker`.
   <external>
      <type>properties</type>
      <prefix>docker</prefix> <!-- this is the default -->
+     <mode>only</mode> <!-- this is the default -->
   </external>
 </image>
 ----
@@ -20,6 +32,7 @@ Given this example configuration a single image configuration is built
 up from the following properties, which correspond to the corresponding
 values in the `<build>` and `<run>` sections. A build configuration is only created
 when a `docker.from` or a `docker.fromExt` is set.
+
 
 .External properties
 [cols="1,5"]
@@ -56,6 +69,9 @@ when a `docker.from` or a `docker.fromExt` is set.
 
 | *docker.bind.idx*
 | Sets a list of paths to bind/expose in the container
+
+| *docker.buildArg.VARIABLE*
+| Set a ARG to be available during build of image. *Note*: this is handled separately from external configuration, and is always available. See <<property-buildargs,Build Args>> for more details.
 
 | *docker.capAdd.idx*
 | List of kernel capabilities to add to the container
@@ -134,6 +150,9 @@ when a `docker.from` or a `docker.fromExt` is set.
 
 | *docker.hostname*
 | Container hostname
+
+| *docker.imagePropertyConfiguration*
+| Special property to activate property configuration without altering XML file (see <<combining-property-config,Combining property and XML config>>).
 
 | *docker.imagePullPolicy.build*
 | Specific pull policy used when building images. See <<image-pull-policy,imagePullPolicy>> for the possible values.
@@ -280,14 +299,65 @@ when a `docker.from` or a `docker.fromExt` is set.
 | Current Working dir for commands to run in when running containers
 |===
 
-Any other `<run>` or `<build>` sections are ignored when this handler
-is used. Multiple property configuration handlers can be used if they
+Multiple property configuration handlers can be used if they
 use different prefixes. As stated above the environment and ports
 configuration are both used for running container and building
 images. If you need a separate configuration you should use explicit
 run and build configuration sections.
 
-.Example
+[[combining-property-config]]
+.Combining property and XML configuration
+By default the property handler will only consider properties and ignore any other image
+configuration in the XML/POM file. This can be changed by adding the `<mode>`
+configuration (since version 0.25.0), which can have one of the following values:
+
+.Property mode
+[cols="1,5"]
+|===
+|`only`
+| Only look at properties, ignore any `<run>` or `<build>` sections for this image. This is the default, and also the behavior in versions before 0.25.0.
+
+|`override`
+| Use property if set, else fall back to value found in `<run>` or `<build>` sections for this image.
+
+|`fallback`
+| Use value found in `<run>` or `<build>` sections for this image, else fall back to to property value.
+
+|`skip`
+| Effectively disable properties, same as not specifying the `<external>` section at all.
+|===
+
+For single-image configurations it is also possible to active property
+configuration by setting the property `docker.imagePropertyConfiguration` to a
+valid `property mode`, without adding a `<external>` section.
+This will use properties with default prefix.
+This can be useful if most of configuration is specified in XML/POM file, but there
+is need to override certain configuration values without altering the POM file.
+
+.Merging POM and property values
+For some fields it may be desired to merge values from both POM and properties. For example, in a certain run environment
+we might want to inject a `http_proxy` environment variable, but we do not want to add this to the POM file.
+
+This is solved using a *Combine policy* which can be either `replace` or `merge`. Merge is only available for
+configuration of Map or List type. For scalar values such as strings and integers, it is not supported.
+For Maps, both sources are merged, with the priority source taking precedence. For Lists, they are concatenated, with values
+from the priority source being added first.
+
+Combine policy is specified per configuration key/property, and the default in most cases is currently `replace`. The following
+keys have `merge` as default policy:
+
+* docker.args
+* docker.envBuild
+* docker.envRun
+* docker.labels
+* docker.ports
+* docker.tags
+
+This can be overridden individually for all configuration keys (of map/list type) by setting an additional property suffixed `._combine`.
+For example, to not merge ports, set `docker.ports._combine=replace`, and to enable merging of dns, set `docker.dns._combine=merge`.
+
+
+.Example, properties only
 [source,xml]
 ----
 <properties>
@@ -320,3 +390,51 @@ run and build configuration sections.
   </plugins>
 </build>
 ----
+
+.Example, combining properties and XML/POM configuration
+[source,xml]
+----
+<properties>
+  <docker.assembly.descriptor>src/main/docker-assembly.xml</docker.assembly.descriptor>
+  <docker.env.CATALINA_OPTS>-Xmx32m</docker.env.CATALINA_OPTS>
+  <docker.label.version>${project.version}</docker.label.version>
+  <docker.ports.jolokia.port>8080</docker.ports.jolokia.port>
+  <docker.wait.url>http://localhost:${jolokia.port}/jolokia</docker.wait.url>
+</properties>
+
+<build>
+  <plugins>
+    <plugin>
+      <groupId>io.fabric8</groupId>
+      <artifactId>docker-maven-plugin</artifactId>
+      <configuration>
+        <images>
+          <image>
+            <external>
+              <type>properties</type>
+              <prefix>docker</prefix>
+              <mode>override</mode>
+            </external>
+
+            <name>jolokia/demo</name>
+            <alias>service</alias>
+
+            <build>
+              <from>consol/tomcat:7.0</from>
+              <labels>
+                <software>tomcat</software>
+              </labels>
+            </build>
+          </image>
+        </images>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+----
+
+This would build the same image as the previous example.
+If instead built with `mvn docker:build -Pdocker.from=console/tomcat:8.0 -Ddocker.tags.0=tc8-test` it would build from that image instead, and also add that tag to the image.
+
+If `-Ddocker.labels.status=beta` is added, the image would be given two labels: `status=beta` and `software=tomcat`.
+If `-Ddocker.labels._combine=replace` is added, the image would be given one label only: `status=beta`.

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -1,9 +1,7 @@
 package io.fabric8.maven.docker;
 
 import java.io.File;
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.DockerAccessException;
@@ -211,6 +209,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
             authConfigFactory.setLog(log);
 
             LogOutputSpecFactory logSpecFactory = new LogOutputSpecFactory(useColor, logStdout, logDate);
+
+            ConfigHelper.validateExternalPropertyActivation(project, images);
 
             // The 'real' images configuration to use (configured images + externally resolved images)
             this.minimalApiVersion = initImageConfiguration(getBuildTimestamp());

--- a/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/AssemblyConfiguration.java
@@ -62,6 +62,11 @@ public class AssemblyConfiguration implements Serializable {
     @Parameter
     private Boolean ignorePermissions;
 
+    @Deprecated
+    public Boolean getIgnorePermissions() {
+        return ignorePermissions;
+    }
+
     @Parameter
     private AssemblyMode mode;
 
@@ -70,6 +75,10 @@ public class AssemblyConfiguration implements Serializable {
 
     @Parameter
     private String tarLongFileMode;
+
+    public Boolean getExportTargetDir() {
+        return exportTargetDir;
+    }
 
     public Boolean exportTargetDir() {
         if (exportTargetDir != null) {
@@ -120,6 +129,10 @@ public class AssemblyConfiguration implements Serializable {
         return mode != null ? mode : AssemblyMode.dir;
     }
 
+    public String getModeRaw() {
+        return mode != null ? mode.name() : null;
+    }
+
     public String getTarLongFileMode() {
         return tarLongFileMode;
     }
@@ -134,6 +147,10 @@ public class AssemblyConfiguration implements Serializable {
 
      public PermissionMode getPermissions() {
         return permissions != null ? permissions : PermissionMode.keep;
+    }
+
+    public String getPermissionsRaw() {
+        return permissions != null ? permissions.name() : null;
     }
 
     public String getName() {

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -1,10 +1,8 @@
 package io.fabric8.maven.docker.config;
 
-import java.awt.*;
 import java.io.File;
 import java.io.Serializable;
 import java.util.*;
-import java.util.List;
 
 import io.fabric8.maven.docker.util.*;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -47,7 +45,7 @@ public class BuildImageConfiguration implements Serializable {
      * How interpolation of a dockerfile should be performed
      */
     @Parameter
-    private String filter = DEFAULT_FILTER;
+    private String filter;
 
     /**
      * Base Image
@@ -83,13 +81,13 @@ public class BuildImageConfiguration implements Serializable {
     private List<String> runCmds;
 
     @Parameter
-    private String cleanup = DEFAULT_CLEANUP;
+    private String cleanup;
 
     @Parameter
-    private boolean nocache = false;
+    private Boolean nocache;
 
     @Parameter
-    private boolean optimise = false;
+    private Boolean optimise;
 
     @Parameter
     private List<String> volumes;
@@ -129,7 +127,7 @@ public class BuildImageConfiguration implements Serializable {
     private AssemblyConfiguration assembly;
 
     @Parameter
-    private boolean skip = false;
+    private Boolean skip;
 
     @Parameter
     private ArchiveCompression compression = ArchiveCompression.none;
@@ -154,7 +152,23 @@ public class BuildImageConfiguration implements Serializable {
         return dockerArchiveFile;
     }
 
+    public String getDockerFileRaw() {
+        return dockerFile;
+    }
+
+    public String getDockerArchiveRaw() {
+        return dockerArchive;
+    }
+
+    public String getDockerFileDirRaw() {
+        return dockerFileDir;
+    }
+
     public String getFilter() {
+        return filter != null ? filter : DEFAULT_FILTER;
+    }
+
+    public String getFilterRaw() {
         return filter;
     }
 
@@ -221,19 +235,35 @@ public class BuildImageConfiguration implements Serializable {
         return command;
     }
 
+    public String getCleanup() {
+        return cleanup;
+    }
+
     public CleanupMode cleanupMode() {
-        return CleanupMode.parse(cleanup);
+        return CleanupMode.parse(cleanup != null ? cleanup : DEFAULT_CLEANUP);
     }
 
     public boolean nocache() {
-        return nocache;
+        return nocache != null ? nocache : false;
     }
 
     public boolean optimise() {
-        return optimise;
+        return optimise != null ? optimise : false;
     }
 
     public boolean skip() {
+        return skip != null ? skip : false;
+    }
+
+    public Boolean getNoCache() {
+        return nocache;
+    }
+
+    public Boolean getOptimise() {
+        return optimise;
+    }
+
+    public Boolean getSkip() {
         return skip;
     }
 
@@ -305,11 +335,7 @@ public class BuildImageConfiguration implements Serializable {
         }
 
         public Builder filter(String filter) {
-            if (filter == null) {
-                config.filter = DEFAULT_FILTER;
-            } else {
-                config.filter = filter;
-            }
+            config.filter = filter;
             return this;
         }
 
@@ -395,11 +421,7 @@ public class BuildImageConfiguration implements Serializable {
         }
 
         public Builder cleanup(String cleanup) {
-            if (cleanup == null) {
-                config.cleanup = DEFAULT_CLEANUP;
-            } else {
-                config.cleanup = cleanup;
-            }
+            config.cleanup = cleanup;
             return this;
         }
 
@@ -412,17 +434,13 @@ public class BuildImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder nocache(String nocache) {
-            if (nocache != null) {
-                config.nocache = Boolean.valueOf(nocache);
-            }
+        public Builder nocache(Boolean nocache) {
+            config.nocache = nocache;
             return this;
         }
 
-        public Builder optimise(String optimise) {
-            if (optimise != null) {
-                config.optimise = Boolean.valueOf(optimise);
-            }
+        public Builder optimise(Boolean optimise) {
+            config.optimise = optimise;
             return this;
         }
 
@@ -443,10 +461,8 @@ public class BuildImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder skip(String skip) {
-            if (skip != null) {
-                config.skip = Boolean.valueOf(skip);
-            }
+        public Builder skip(Boolean skip) {
+            config.skip = skip;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
@@ -20,6 +20,8 @@ import java.util.*;
 
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.Logger;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.StringUtils;
 
 /**
@@ -30,6 +32,9 @@ import org.apache.maven.shared.utils.StringUtils;
  * @since 17/05/16
  */
 public class ConfigHelper {
+    // Property which can be set to activate externalConfiguration through properties.
+    // Only works for single image project.
+    public static final String EXTERNALCONFIG_ACTIVATION_PROPERTY = "docker.imagePropertyConfiguration";
 
     private ConfigHelper() {}
 
@@ -59,6 +64,22 @@ public class ConfigHelper {
                         StringUtils.join(imageNames.iterator(), ","), imageNameFilter);
         }
         return filtered;
+    }
+
+    public static void validateExternalPropertyActivation(MavenProject project, List<ImageConfiguration> images) throws MojoFailureException {
+        String prop = getExternalConfigActivationProperty(project);
+        if(prop == null) {
+            return;
+        }
+
+        if(images.size() > 1) {
+            throw new MojoFailureException("Configuration error: Cannot use property "+EXTERNALCONFIG_ACTIVATION_PROPERTY+" on projects with multiple images.");
+        }
+    }
+
+    public static String getExternalConfigActivationProperty(MavenProject project) {
+        Properties properties = EnvUtil.getPropertiesWithSystemOverrides(project);
+        return properties.getProperty(EXTERNALCONFIG_ACTIVATION_PROPERTY);
     }
 
     /**

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -52,6 +52,15 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
         this.name = name;
     }
 
+    /**
+     * Override externalConfiguration when defined via special property.
+     *
+     * @param externalConfiguration Map with alternative config
+     */
+    public void setExternalConfiguration(Map<String, String> externalConfiguration) {
+        this.external = externalConfiguration;
+    }
+
     @Override
 	public String getAlias() {
         return alias;

--- a/src/main/java/io/fabric8/maven/docker/config/NetworkConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/config/NetworkConfig.java
@@ -128,6 +128,14 @@ public class NetworkConfig implements Serializable {
         return aliases != null && !aliases.isEmpty();
     }
 
+    public Mode getMode() {
+        return mode;
+    }
+
+    public String getName() {
+        return name;
+    }
+
     // ==============================================================================
 
     // Mode used for determining the network

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -5,9 +5,8 @@ import java.util.List;
 import java.util.Map;
 
 import io.fabric8.maven.docker.util.DeepCopy;
-import org.apache.maven.plugins.annotations.Parameter;
-
 import io.fabric8.maven.docker.util.EnvUtil;
+import org.apache.maven.plugins.annotations.Parameter;
 
 import javax.annotation.Nonnull;
 
@@ -18,6 +17,10 @@ import javax.annotation.Nonnull;
 public class RunImageConfiguration implements Serializable {
 
     static final RunImageConfiguration DEFAULT = new RunImageConfiguration();
+
+    public boolean isDefault() {
+        return this == RunImageConfiguration.DEFAULT;
+    }
 
     /**
      * Environment variables to set when starting the container. key: variable name, value: env value
@@ -144,7 +147,7 @@ public class RunImageConfiguration implements Serializable {
     private List<UlimitConfig> ulimits;
 
     @Parameter
-    private boolean skip = false;
+    private Boolean skip;
 
     /**
      * Policy for pulling the image to start
@@ -257,6 +260,11 @@ public class RunImageConfiguration implements Serializable {
         return dns;
     }
 
+    @Deprecated
+    public String getNetRaw() {
+        return net;
+    }
+
     public NetworkConfig getNetworkingConfig() {
         if (network != null) {
             return network;
@@ -308,6 +316,11 @@ public class RunImageConfiguration implements Serializable {
         return namingStrategy == null ? NamingStrategy.none : namingStrategy;
     }
 
+    public NamingStrategy getNamingStrategyRaw() {
+        return namingStrategy;
+
+    }
+
     public String getExposedPropertyKey() {
         return exposedPropertyKey;
     }
@@ -320,7 +333,15 @@ public class RunImageConfiguration implements Serializable {
         return (restartPolicy == null) ? RestartPolicy.DEFAULT : restartPolicy;
     }
 
+    public RestartPolicy getRestartPolicyRaw() {
+        return restartPolicy;
+    }
+
     public boolean skip() {
+        return skip != null ? skip : false;
+    }
+
+    public Boolean getSkip() {
         return skip;
     }
 
@@ -533,10 +554,8 @@ public class RunImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder skip(String skip) {
-            if (skip != null) {
-                config.skip = Boolean.valueOf(skip);
-            }
+        public Builder skip(Boolean skip) {
+            config.skip = skip;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/UlimitConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/config/UlimitConfig.java
@@ -67,4 +67,15 @@ public class UlimitConfig implements Serializable {
         }
         return Integer.parseInt(number);
     }
+
+    public String serialize() {
+        if(hard != null && soft != null)
+            return name + "="+hard+":"+soft;
+        else if(hard != null)
+            return name + "="+hard;
+        else if(soft != null)
+            return name + "=:"+soft;
+        else
+            return null;
+    }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/WaitConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/WaitConfiguration.java
@@ -21,7 +21,7 @@ public class WaitConfiguration implements Serializable {
     public static final String DEFAULT_STATUS_RANGE = String.format("%d..%d", DEFAULT_MIN_STATUS, DEFAULT_MAX_STATUS);
 
     @Parameter
-    private int time;
+    private Integer time;
 
     /**
      * @deprecated Use &lt;http&gt;&lturl&gt;&lt;/url&gt;&lt;/http&gt; instead
@@ -38,23 +38,23 @@ public class WaitConfiguration implements Serializable {
     @Parameter
     private TcpConfiguration tcp;
 
-    @Parameter boolean healthy;
+    @Parameter Boolean healthy;
 
     @Parameter
     private String log;
 
     @Parameter
-    private int shutdown;
+    private Integer shutdown;
 
     @Parameter
-    private int kill;
+    private Integer kill;
 
     @Parameter
     private Integer exit;
 
     public WaitConfiguration() {}
 
-    private WaitConfiguration(int time, ExecConfiguration exec, HttpConfiguration http, TcpConfiguration tcp, boolean healthy, String log, int shutdown, int kill, Integer exit) {
+    private WaitConfiguration(Integer time, ExecConfiguration exec, HttpConfiguration http, TcpConfiguration tcp, Boolean healthy, String log, Integer shutdown, Integer kill, Integer exit) {
         this.time = time;
         this.exec = exec;
         this.http = http;
@@ -66,9 +66,7 @@ public class WaitConfiguration implements Serializable {
         this.exit = exit;
     }
 
-    public int getTime() {
-        return time;
-    }
+    public Integer getTime() { return time; }
 
     public String getUrl() {
         return http != null ? http.getUrl() : url;
@@ -86,32 +84,30 @@ public class WaitConfiguration implements Serializable {
         return tcp;
     }
 
-    public boolean getHealthy() {
-        return healthy;
-    }
-
     public String getLog() {
         return log;
-    }
-
-    public int getShutdown() {
-        return shutdown;
-    }
-
-    public int getKill() {
-        return kill;
     }
 
     public Integer getExit() {
         return exit;
     }
 
+    public Integer getShutdown() {
+        return shutdown;
+    }
+
+    public Integer getKill() {
+        return kill;
+    }
+
+    public Boolean getHealthy() { return healthy; }
+
     // =============================================================================
 
     public static class Builder {
-        private int time = 0,shutdown = 0, kill = 0;
+        private Integer time, shutdown, kill;
         private String url,log,status;
-        boolean healthy;
+        Boolean healthy;
         private String method;
         private String preStop;
         private String postStart;
@@ -141,7 +137,7 @@ public class WaitConfiguration implements Serializable {
             return this;
         }
 
-        public Builder healthy(boolean healthy) {
+        public Builder healthy(Boolean healthy) {
             this.healthy = healthy;
             return this;
         }
@@ -151,12 +147,12 @@ public class WaitConfiguration implements Serializable {
             return this;
         }
 
-        public Builder shutdown(int shutdown) {
+        public Builder shutdown(Integer shutdown) {
             this.shutdown = shutdown;
             return this;
         }
 
-        public Builder kill(int kill) {
+        public Builder kill(Integer kill) {
             this.kill = kill;
             return this;
         }

--- a/src/main/java/io/fabric8/maven/docker/config/WatchImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/WatchImageConfiguration.java
@@ -11,7 +11,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 public class WatchImageConfiguration implements Serializable {
 
     @Parameter
-    private int interval = 5000; // default
+    private Integer interval;
 
     @Parameter
     private WatchMode mode;
@@ -25,6 +25,10 @@ public class WatchImageConfiguration implements Serializable {
     public WatchImageConfiguration() {};
 
     public int getInterval() {
+        return interval != null ? interval : 5000;
+    }
+
+    public Integer getIntervalRaw() {
         return interval;
     }
 
@@ -56,7 +60,7 @@ public class WatchImageConfiguration implements Serializable {
             }
         }
 
-        public Builder interval(int interval) {
+        public Builder interval(Integer interval) {
             c.interval = interval;
             return this;
         }
@@ -70,6 +74,11 @@ public class WatchImageConfiguration implements Serializable {
 
         public Builder postGoal(String goal) {
             c.postGoal = goal;
+            return this;
+        }
+
+        public Builder postExec(String exec) {
+            c.postExec = exec;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/ImageConfigResolver.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/ImageConfigResolver.java
@@ -17,6 +17,7 @@ package io.fabric8.maven.docker.config.handler;/*
 
 import java.util.*;
 
+import io.fabric8.maven.docker.config.ConfigHelper;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.handler.compose.DockerComposeConfigHandler;
 import io.fabric8.maven.docker.config.handler.property.PropertyConfigHandler;
@@ -36,7 +37,6 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationExce
 
 @Component(role = ImageConfigResolver.class, instantiationStrategy = "singleton")
 public class ImageConfigResolver implements Initializable {
-
     // Map type to handler
     private Map<String,ExternalConfigHandler> registry;
 
@@ -64,7 +64,9 @@ public class ImageConfigResolver implements Initializable {
     /**
      * Resolve an image configuration. If it contains a reference to an external configuration
      * the corresponding resolver is called and the resolved image configurations are returned (can
-     * be multiple). If no reference to an external configuration is found, the original configuration
+     * be multiple).
+     *
+     * If no reference to an external configuration is found, the original configuration
      * is returned directly.
      *
      * @param unresolvedConfig the configuration to resolve
@@ -75,9 +77,10 @@ public class ImageConfigResolver implements Initializable {
      * or when the type is not known (i.e. no handler is registered for this type).
      */
     public List<ImageConfiguration> resolve(ImageConfiguration unresolvedConfig, MavenProject project, MavenSession session) {
-        Map<String,String> referenceConfig = unresolvedConfig.getExternalConfig();
-        if (referenceConfig != null) {
-            String type = referenceConfig.get("type");
+        injectExternalConfigActivation(unresolvedConfig, project);
+        Map<String,String> externalConfig = unresolvedConfig.getExternalConfig();
+        if (externalConfig != null) {
+            String type = externalConfig.get("type");
             if (type == null) {
                 throw new IllegalArgumentException(unresolvedConfig.getDescription() + ": No config type given");
             }
@@ -88,6 +91,23 @@ public class ImageConfigResolver implements Initializable {
             return handler.resolve(unresolvedConfig, project, session);
         } else {
             return Collections.singletonList(unresolvedConfig);
+        }
+    }
+
+    private void injectExternalConfigActivation(ImageConfiguration unresolvedConfig, MavenProject project) {
+        // Allow external activation of property configuration
+        String mode = ConfigHelper.getExternalConfigActivationProperty(project);
+
+        if(mode == null) {
+            return;
+        }
+
+        Map<String, String> externalConfig = unresolvedConfig.getExternalConfig();
+        if(externalConfig == null) {
+            externalConfig = new HashMap<>();
+            externalConfig.put("type", propertyConfigHandler.getType());
+            externalConfig.put("mode", mode);
+            unresolvedConfig.setExternalConfiguration(externalConfig);
         }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -24,7 +24,7 @@ package io.fabric8.maven.docker.config.handler.property;/*
 public enum ConfigKey {
 
     ALIAS,
-    ARGS,
+    ARGS(ValueCombinePolicy.Merge),
     ASSEMBLY_BASEDIR("assembly.baseDir"),
     ASSEMBLY_DESCRIPTOR("assembly.descriptor"),
     ASSEMBLY_DESCRIPTOR_REF("assembly.descriptorRef"),
@@ -53,8 +53,8 @@ public enum ConfigKey {
     ENTRYPOINT,
     ENV,
     ENV_PROPERTY_FILE,
-    ENV_BUILD("envBuild"),
-    ENV_RUN("envRun"),
+    ENV_BUILD("envBuild", ValueCombinePolicy.Merge),
+    ENV_RUN("envRun", ValueCombinePolicy.Merge),
     EXPOSED_PROPERTY_KEY,
     EXTRA_HOSTS,
     FILTER,
@@ -69,7 +69,7 @@ public enum ConfigKey {
     HOSTNAME,
     IMAGE_PULL_POLICY_BUILD("imagePullPolicy.build"),
     IMAGE_PULL_POLICY_RUN("imagePullPolicy.run"),
-    LABELS,
+    LABELS(ValueCombinePolicy.Merge),
     LINKS,
     LOG_ENABLED("log.enabled"),
     LOG_PREFIX("log.prefix"),
@@ -87,7 +87,7 @@ public enum ConfigKey {
     NETWORK_NAME("network.name"),
     NETWORK_ALIAS("network.alias"),
     PORT_PROPERTY_FILE,
-    PORTS,
+    PORTS(ValueCombinePolicy.Merge),
     PRIVILEGED,
     REGISTRY,
     RESTART_POLICY_NAME("restartPolicy.name"),
@@ -97,7 +97,7 @@ public enum ConfigKey {
     SHMSIZE,
     SKIP_BUILD("skip.build"),
     SKIP_RUN("skip.run"),
-    TAGS,
+    TAGS(ValueCombinePolicy.Merge),
     TMPFS,
     ULIMITS,
     USER,
@@ -105,6 +105,7 @@ public enum ConfigKey {
     VOLUMES_FROM,
     WAIT_LOG("wait.log"),
     WAIT_TIME("wait.time"),
+    WAIT_HEALTHY("wait.healthy"),
     WAIT_URL("wait.url"),
     WAIT_HTTP_URL("wait.http.url"),
     WAIT_HTTP_METHOD("wait.http.method"),
@@ -121,22 +122,34 @@ public enum ConfigKey {
     WATCH_INTERVAL("watch.interval"),
     WATCH_MODE("watch.mode"),
     WATCH_POSTGOAL("watch.postGoal"),
+    WATCH_POSTEXEC("watch.postExec"),
     WORKDIR,
     WORKING_DIR;
 
     ConfigKey() {
-        this.key = toVarName(name());
+        this(ValueCombinePolicy.Replace);
     }
 
     ConfigKey(String key) {
-        this.key = key;
+        this(key, ValueCombinePolicy.Replace);
     }
 
-    private String key;
+    ConfigKey(ValueCombinePolicy valueCombinePolicy) {
+        this.key = toVarName(name());
+        this.valueCombinePolicy = valueCombinePolicy;
+    }
+
+    ConfigKey(String key, ValueCombinePolicy valueCombinePolicy) {
+        this.key = key;
+        this.valueCombinePolicy = valueCombinePolicy;
+    }
+
+    private final String key;
+    private final ValueCombinePolicy valueCombinePolicy;
 
     public static String DEFAULT_PREFIX = "docker";
 
-    // Convert to camle case
+    // Convert to camel case
     private String toVarName(String s) {
         String[] parts = s.split("_");
         String var = parts[0].toLowerCase();
@@ -153,5 +166,9 @@ public enum ConfigKey {
 
     public String asPropertyKey() {
         return DEFAULT_PREFIX + "." + key;
+    }
+
+    public ValueCombinePolicy getValueCombinePolicy() {
+        return valueCombinePolicy;
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -53,6 +53,8 @@ public enum ConfigKey {
     ENTRYPOINT,
     ENV,
     ENV_PROPERTY_FILE,
+    ENV_BUILD("envBuild"),
+    ENV_RUN("envRun"),
     EXPOSED_PROPERTY_KEY,
     EXTRA_HOSTS,
     FILTER,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -24,6 +24,7 @@ import org.apache.maven.project.MavenProject;
 import io.fabric8.maven.docker.config.handler.ExternalConfigHandler;
 import io.fabric8.maven.docker.util.EnvUtil;
 
+import org.codehaus.plexus.util.CollectionUtils;
 import static io.fabric8.maven.docker.config.handler.property.ConfigKey.*;
 import static io.fabric8.maven.docker.util.EnvUtil.*;
 
@@ -84,7 +85,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .optimise(withPrefix(prefix, OPTIMISE, properties))
                 .entryPoint(withPrefix(prefix, ENTRYPOINT, properties))
                 .assembly(extractAssembly(prefix, properties))
-                .env(mapWithPrefix(prefix, ENV, properties))
+                .env(CollectionUtils.mergeMaps(
+                        mapWithPrefix(prefix, ENV_BUILD, properties),
+                        mapWithPrefix(prefix, ENV, properties)
+                ))
                 .args(mapWithPrefix(prefix, ARGS, properties))
                 .labels(mapWithPrefix(prefix,LABELS,properties))
                 .ports(extractPortValues(prefix, properties))
@@ -122,7 +126,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .dnsSearch(listWithPrefix(prefix, DNS_SEARCH, properties))
                 .domainname(withPrefix(prefix, DOMAINNAME, properties))
                 .entrypoint(withPrefix(prefix, ENTRYPOINT, properties))
-                .env(mapWithPrefix(prefix, ENV, properties))
+                .env(CollectionUtils.mergeMaps(
+                        mapWithPrefix(prefix, ENV_RUN, properties),
+                        mapWithPrefix(prefix, ENV, properties)
+                ))
                 .labels(mapWithPrefix(prefix,LABELS,properties))
                 .envPropertyFile(withPrefix(prefix, ENV_PROPERTY_FILE, properties))
                 .extraHosts(listWithPrefix(prefix, EXTRA_HOSTS, properties))

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -18,15 +18,13 @@ package io.fabric8.maven.docker.config.handler.property;/*
 import java.util.*;
 
 import io.fabric8.maven.docker.config.*;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.project.MavenProject;
-
 import io.fabric8.maven.docker.config.handler.ExternalConfigHandler;
 import io.fabric8.maven.docker.util.EnvUtil;
-
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.CollectionUtils;
+
 import static io.fabric8.maven.docker.config.handler.property.ConfigKey.*;
-import static io.fabric8.maven.docker.util.EnvUtil.*;
 
 /**
  * @author roland
@@ -42,23 +40,27 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
     }
 
     @Override
-    public List<ImageConfiguration> resolve(ImageConfiguration config, MavenProject project, MavenSession session)
+    public List<ImageConfiguration> resolve(ImageConfiguration fromConfig, MavenProject project, MavenSession session)
         throws IllegalArgumentException {
-        String prefix = getPrefix(config);
-        Properties properties = project.getProperties();
+        Map<String, String> externalConfig = fromConfig.getExternalConfig();
+        String prefix = getPrefix(externalConfig);
+        Properties properties = EnvUtil.getPropertiesWithSystemOverrides(project);
+        PropertyMode propertyMode = PropertyMode.parse(externalConfig.get("mode"));
+        ValueProvider valueProvider = new ValueProvider(prefix, properties, propertyMode);
 
+        RunImageConfiguration run = extractRunConfiguration(fromConfig, valueProvider);
+        BuildImageConfiguration build = extractBuildConfiguration(fromConfig, valueProvider);
+        WatchImageConfiguration watch = extractWatchConfig(fromConfig, valueProvider);
+        String name = valueProvider.getString(NAME, fromConfig.getName());
+        String alias = valueProvider.getString(ALIAS, fromConfig.getAlias());
 
-        RunImageConfiguration run = extractRunConfiguration(prefix,properties);
-        BuildImageConfiguration build = extractBuildConfiguration(prefix,properties);
-        WatchImageConfiguration watch = extractWatchConfig(prefix, properties);
-
-        String name = extractName(prefix, properties);
-        String alias = withPrefix(prefix, ALIAS, properties);
+        if (name == null)
+            throw new IllegalArgumentException(String.format("Mandatory property [%s] is not defined", NAME));
 
         return Collections.singletonList(
                 new ImageConfiguration.Builder()
                         .name(name)
-                        .alias(alias != null ? alias : config.getAlias())
+                        .alias(alias)
                         .runConfig(run)
                         .buildConfig(build)
                         .watchConfig(watch)
@@ -66,147 +68,144 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
     }
 
     // Enable build config only when a `.from.`, `.dockerFile.`, or `.dockerFileDir.` is configured
-    private boolean buildConfigured(String prefix, Properties properties) {
-        return withPrefix(prefix, FROM, properties) != null ||
-                mapWithPrefix(prefix, FROM_EXT, properties) != null ||
-                withPrefix(prefix, DOCKER_FILE, properties) != null ||
-                withPrefix(prefix, DOCKER_FILE_DIR, properties) != null;
+    private boolean buildConfigured(BuildImageConfiguration config, ValueProvider valueProvider) {
+        return valueProvider.getString(FROM, config == null ? null : config.getFrom()) != null ||
+                valueProvider.getMap(FROM_EXT, config == null ? null : config.getFromExt()) != null ||
+                valueProvider.getString(DOCKER_FILE, config == null || config.getDockerFile() == null ? null : config.getDockerFile().getAbsolutePath()) != null ||
+                valueProvider.getString(DOCKER_FILE_DIR, config == null || config.getDockerArchive() == null ? null : config.getDockerArchive().getAbsolutePath()) != null;
     }
 
 
-    private BuildImageConfiguration extractBuildConfiguration(String prefix, Properties properties) {
-        if (!buildConfigured(prefix, properties)) {
+    private BuildImageConfiguration extractBuildConfiguration(ImageConfiguration fromConfig, ValueProvider valueProvider) {
+        BuildImageConfiguration config = fromConfig.getBuildConfiguration();
+        if (!buildConfigured(config, valueProvider)) {
             return null;
         }
+
         return new BuildImageConfiguration.Builder()
-                .cmd(withPrefix(prefix, CMD, properties))
-                .cleanup(withPrefix(prefix, CLEANUP, properties))
-                .nocache(withPrefix(prefix, NOCACHE, properties))
-                .optimise(withPrefix(prefix, OPTIMISE, properties))
-                .entryPoint(withPrefix(prefix, ENTRYPOINT, properties))
-                .assembly(extractAssembly(prefix, properties))
+                .cmd(extractArguments(valueProvider, CMD, config == null ? null : config.getCmd()))
+                .cleanup(valueProvider.getString(CLEANUP, config == null ? null : config.getCleanup()))
+                .nocache(valueProvider.getBoolean(NOCACHE, config == null ? null : config.getNoCache()))
+                .optimise(valueProvider.getBoolean(OPTIMISE, config == null ? null : config.getOptimise()))
+                .entryPoint(extractArguments(valueProvider, ENTRYPOINT, config == null ? null : config.getEntryPoint()))
+                .assembly(extractAssembly(config == null ? null : config.getAssemblyConfiguration(), valueProvider))
                 .env(CollectionUtils.mergeMaps(
-                        mapWithPrefix(prefix, ENV_BUILD, properties),
-                        mapWithPrefix(prefix, ENV, properties)
+                        valueProvider.getMap(ENV_BUILD, config == null ? null : config.getEnv()),
+                        valueProvider.getMap(ENV, Collections.<String, String>emptyMap())
                 ))
-                .args(mapWithPrefix(prefix, ARGS, properties))
-                .labels(mapWithPrefix(prefix,LABELS,properties))
-                .ports(extractPortValues(prefix, properties))
-                .runCmds(extractRunCommands(prefix,properties))
-                .from(withPrefix(prefix, FROM, properties))
-                .fromExt(mapWithPrefix(prefix,FROM_EXT,properties))
-                .registry(withPrefix(prefix, REGISTRY, properties))
-                .volumes(listWithPrefix(prefix, VOLUMES, properties))
-                .tags(listWithPrefix(prefix, TAGS, properties))
-                .maintainer(withPrefix(prefix, MAINTAINER, properties))
-                .workdir(withPrefix(prefix, WORKDIR, properties))
-                .skip(withPrefix(prefix, SKIP_BUILD, properties))
-                .imagePullPolicy(withPrefix(prefix, IMAGE_PULL_POLICY_BUILD, properties))
-                .dockerArchive(withPrefix(prefix, DOCKER_ARCHIVE, properties))
-                .buildOptions(mapWithPrefix(prefix, BUILD_OPTIONS, properties))
-                .dockerFile(withPrefix(prefix, DOCKER_FILE, properties))
-                .dockerFileDir(withPrefix(prefix, DOCKER_FILE_DIR, properties))
-                .filter(withPrefix(prefix, FILTER, properties))
-                .user(withPrefix(prefix, USER, properties))
-                .healthCheck(extractHealthCheck(prefix, properties))
+                .args(valueProvider.getMap(ARGS, config == null ? null : config.getArgs()))
+                .labels(valueProvider.getMap(LABELS, config == null ? null : config.getLabels()))
+                .ports(extractPortValues(config == null ? null : config.getPorts(), valueProvider))
+                .runCmds(valueProvider.getList(RUN, config == null ? null : config.getRunCmds()))
+                .from(valueProvider.getString(FROM, config == null ? null : config.getFrom()))
+                .fromExt(valueProvider.getMap(FROM_EXT, config == null ? null : config.getFromExt()))
+                .registry(valueProvider.getString(REGISTRY, config == null ? null : config.getRegistry()))
+                .volumes(valueProvider.getList(VOLUMES, config == null ? null : config.getVolumes()))
+                .tags(valueProvider.getList(TAGS, config == null ? null : config.getTags()))
+                .maintainer(valueProvider.getString(MAINTAINER, config == null ? null : config.getMaintainer()))
+                .workdir(valueProvider.getString(WORKDIR, config == null ? null : config.getWorkdir()))
+                .skip(valueProvider.getBoolean(SKIP_BUILD, config == null ? null : config.getSkip()))
+                .imagePullPolicy(valueProvider.getString(IMAGE_PULL_POLICY_BUILD, config == null ? null : config.getImagePullPolicy()))
+                .dockerArchive(valueProvider.getString(DOCKER_ARCHIVE, config == null ? null : config.getDockerArchiveRaw()))
+                .dockerFile(valueProvider.getString(DOCKER_FILE, config == null ? null : config.getDockerFileRaw()))
+                .dockerFileDir(valueProvider.getString(DOCKER_FILE_DIR, config == null ? null : config.getDockerFileDirRaw()))
+                .buildOptions(valueProvider.getMap(BUILD_OPTIONS, config == null ? null : config.getBuildOptions()))
+                .filter(valueProvider.getString(FILTER, config == null ? null : config.getFilterRaw()))
+                .user(valueProvider.getString(USER, config == null ? null : config.getUser()))
+                .healthCheck(extractHealthCheck(config == null ? null : config.getHealthCheck(), valueProvider))
                 .build();
     }
 
-    private RunImageConfiguration extractRunConfiguration(String prefix, Properties properties) {
+    private RunImageConfiguration extractRunConfiguration(ImageConfiguration fromConfig, ValueProvider valueProvider) {
+        RunImageConfiguration config = fromConfig.getRunConfiguration();
+        if(config.isDefault())
+            config = null;
 
         return new RunImageConfiguration.Builder()
-                .capAdd(listWithPrefix(prefix, CAP_ADD, properties))
-                .capDrop(listWithPrefix(prefix, CAP_DROP, properties))
-                .securityOpts(listWithPrefix(prefix, SECURITY_OPTS, properties))
-                .cmd(withPrefix(prefix, CMD, properties))
-                .dns(listWithPrefix(prefix, DNS, properties))
-                .dependsOn(listWithPrefix(prefix, DEPENDS_ON, properties))
-                .net(withPrefix(prefix, NET, properties))
-                .network(extractNetworkConfig(prefix, properties))
-                .dnsSearch(listWithPrefix(prefix, DNS_SEARCH, properties))
-                .domainname(withPrefix(prefix, DOMAINNAME, properties))
-                .entrypoint(withPrefix(prefix, ENTRYPOINT, properties))
+                .capAdd(valueProvider.getList(CAP_ADD, config == null ? null : config.getCapAdd()))
+                .capDrop(valueProvider.getList(CAP_DROP, config == null ? null : config.getCapDrop()))
+                .securityOpts(valueProvider.getList(SECURITY_OPTS, config == null ? null : config.getSecurityOpts()))
+                .cmd(extractArguments(valueProvider, CMD, config == null ? null : config.getCmd()))
+                .dns(valueProvider.getList(DNS, config == null ? null : config.getDns()))
+                .dependsOn(valueProvider.getList(DEPENDS_ON, config == null ? null : config.getDependsOn()))
+                .net(valueProvider.getString(NET, config == null ? null : config.getNetRaw()))
+                .network(extractNetworkConfig(config == null ? null : config.getNetworkingConfig(), valueProvider))
+                .dnsSearch(valueProvider.getList(DNS_SEARCH, config == null ? null : config.getDnsSearch()))
+                .domainname(valueProvider.getString(DOMAINNAME, config == null ? null : config.getDomainname()))
+                .entrypoint(extractArguments(valueProvider, ENTRYPOINT, config == null ? null : config.getEntrypoint()))
                 .env(CollectionUtils.mergeMaps(
-                        mapWithPrefix(prefix, ENV_RUN, properties),
-                        mapWithPrefix(prefix, ENV, properties)
+                        valueProvider.getMap(ENV_RUN, config == null ? null : config.getEnv()),
+                        valueProvider.getMap(ENV, Collections.<String, String>emptyMap())
                 ))
-                .labels(mapWithPrefix(prefix,LABELS,properties))
-                .envPropertyFile(withPrefix(prefix, ENV_PROPERTY_FILE, properties))
-                .extraHosts(listWithPrefix(prefix, EXTRA_HOSTS, properties))
-                .hostname(withPrefix(prefix, HOSTNAME, properties))
-                .links(listWithPrefix(prefix, LINKS, properties))
-                .memory(longWithPrefix(prefix, MEMORY, properties))
-                .memorySwap(longWithPrefix(prefix, MEMORY_SWAP, properties))
-                .namingStrategy(withPrefix(prefix, NAMING_STRATEGY, properties))
-                .exposedPropertyKey(withPrefix(prefix, EXPOSED_PROPERTY_KEY, properties))
-                .portPropertyFile(withPrefix(prefix, PORT_PROPERTY_FILE, properties))
-                .ports(listWithPrefix(prefix, PORTS, properties))
-                .shmSize(longWithPrefix(prefix, SHMSIZE, properties))
-                .privileged(booleanWithPrefix(prefix, PRIVILEGED, properties))
-                .restartPolicy(extractRestartPolicy(prefix, properties))
-                .user(withPrefix(prefix, USER, properties))
-                .workingDir(withPrefix(prefix, WORKING_DIR, properties))
-                .log(extractLogConfig(prefix,properties))
-                .wait(extractWaitConfig(prefix, properties))
-                .volumes(extractVolumeConfig(prefix, properties))
-                .skip(withPrefix(prefix, SKIP_RUN, properties))
-                .imagePullPolicy(withPrefix(prefix, IMAGE_PULL_POLICY_RUN, properties))
-                .ulimits(extractUlimits(prefix, properties))
-                .tmpfs(listWithPrefix(prefix, TMPFS, properties))
+                .labels(valueProvider.getMap(LABELS, config == null ? null : config.getLabels()))
+                .envPropertyFile(valueProvider.getString(ENV_PROPERTY_FILE, config == null ? null : config.getEnvPropertyFile()))
+                .extraHosts(valueProvider.getList(EXTRA_HOSTS, config == null ? null : config.getExtraHosts()))
+                .hostname(valueProvider.getString(HOSTNAME, config == null ? null : config.getHostname()))
+                .links(valueProvider.getList(LINKS, config == null ? null : config.getLinks()))
+                .memory(valueProvider.getLong(MEMORY, config == null ? null : config.getMemory()))
+                .memorySwap(valueProvider.getLong(MEMORY_SWAP, config == null ? null : config.getMemorySwap()))
+                .namingStrategy(valueProvider.getString(NAMING_STRATEGY, config == null || config.getNamingStrategyRaw() == null ? null : config.getNamingStrategyRaw().name()))
+                .exposedPropertyKey(valueProvider.getString(EXPOSED_PROPERTY_KEY, config == null ? null : config.getExposedPropertyKey()))
+                .portPropertyFile(valueProvider.getString(PORT_PROPERTY_FILE, config == null ? null : config.getPortPropertyFile()))
+                .ports(valueProvider.getList(PORTS, config == null ? null : config.getPorts()))
+                .shmSize(valueProvider.getLong(SHMSIZE, config == null ? null : config.getShmSize()))
+                .privileged(valueProvider.getBoolean(PRIVILEGED, config == null ? null : config.getPrivileged()))
+                .restartPolicy(extractRestartPolicy(config == null ? null : config.getRestartPolicy(), valueProvider))
+                .user(valueProvider.getString(USER, config == null ? null : config.getUser()))
+                .workingDir(valueProvider.getString(WORKING_DIR, config == null ? null : config.getWorkingDir()))
+                .log(extractLogConfig(config == null ? null : config.getLogConfiguration(), valueProvider))
+                .wait(extractWaitConfig(config == null ? null : config.getWaitConfiguration(), valueProvider))
+                .volumes(extractVolumeConfig(config == null ? null : config.getVolumeConfiguration(), valueProvider))
+                .skip(valueProvider.getBoolean(SKIP_RUN, config == null ? null : config.getSkip()))
+                .imagePullPolicy(valueProvider.getString(IMAGE_PULL_POLICY_RUN, config == null ? null : config.getImagePullPolicy()))
+                .ulimits(extractUlimits(config == null ? null : config.getUlimits(), valueProvider))
+                .tmpfs(valueProvider.getList(TMPFS, config == null ? null : config.getTmpfs()))
                 .build();
     }
 
-    private NetworkConfig extractNetworkConfig(String prefix, Properties properties) {
+    private NetworkConfig extractNetworkConfig(NetworkConfig config, ValueProvider valueProvider) {
         return new NetworkConfig.Builder()
-            .mode(withPrefix(prefix, NETWORK_MODE, properties))
-            .name(withPrefix(prefix, NETWORK_NAME, properties))
-            .aliases(listWithPrefix(prefix,NETWORK_ALIAS, properties))
+            .mode(valueProvider.getString(NETWORK_MODE, config == null || config.getMode() == null ? null : config.getMode().name()))
+            .name(valueProvider.getString(NETWORK_NAME, config == null ? null : config.getName()))
+            .aliases(valueProvider.getList(NETWORK_ALIAS, config == null ? null : config.getAliases()))
             .build();
     }
 
     @SuppressWarnings("deprecation")
-    private AssemblyConfiguration extractAssembly(String prefix, Properties properties) {
+    private AssemblyConfiguration extractAssembly(AssemblyConfiguration config, ValueProvider valueProvider) {
         return new AssemblyConfiguration.Builder()
-                .targetDir(withPrefix(prefix, ASSEMBLY_BASEDIR, properties))
-                .descriptor(withPrefix(prefix, ASSEMBLY_DESCRIPTOR, properties))
-                .descriptorRef(withPrefix(prefix, ASSEMBLY_DESCRIPTOR_REF, properties))
-                .dockerFileDir(withPrefix(prefix, ASSEMBLY_DOCKER_FILE_DIR, properties))
-                .exportBasedir(booleanWithPrefix(prefix, ASSEMBLY_EXPORT_BASEDIR, properties))
-                .ignorePermissions(booleanWithPrefix(prefix, ASSEMBLY_IGNORE_PERMISSIONS, properties))
-                .permissions(withPrefix(prefix, ASSEMBLY_PERMISSIONS, properties))
-                .user(withPrefix(prefix, ASSEMBLY_USER, properties))
-                .mode(withPrefix(prefix, ASSEMBLY_MODE, properties))
-                .tarLongFileMode(withPrefix(prefix, ASSEMBLY_TARLONGFILEMODE, properties))
+                .targetDir(valueProvider.getString(ASSEMBLY_BASEDIR, config == null ? null : config.getTargetDir()))
+                .descriptor(valueProvider.getString(ASSEMBLY_DESCRIPTOR, config == null ? null : config.getDescriptor()))
+                .descriptorRef(valueProvider.getString(ASSEMBLY_DESCRIPTOR_REF, config == null ? null : config.getDescriptorRef()))
+                .dockerFileDir(valueProvider.getString(ASSEMBLY_DOCKER_FILE_DIR, config == null ? null : config.getDockerFileDir()))
+                .exportBasedir(valueProvider.getBoolean(ASSEMBLY_EXPORT_BASEDIR, config == null ? null : config.getExportTargetDir()))
+                .ignorePermissions(valueProvider.getBoolean(ASSEMBLY_IGNORE_PERMISSIONS, config == null ? null : config.getIgnorePermissions()))
+                .permissions(valueProvider.getString(ASSEMBLY_PERMISSIONS, config == null ? null : config.getPermissionsRaw()))
+                .user(valueProvider.getString(ASSEMBLY_USER, config == null ? null : config.getUser()))
+                .mode(valueProvider.getString(ASSEMBLY_MODE, config == null ? null : config.getModeRaw()))
+                .tarLongFileMode(valueProvider.getString(ASSEMBLY_TARLONGFILEMODE, config == null ? null : config.getTarLongFileMode()))
                 .build();
     }
 
-    private HealthCheckConfiguration extractHealthCheck(String prefix, Properties properties) {
-        Map<String, String> healthCheckProperties = mapWithPrefix(prefix, HEALTHCHECK, properties);
+    private HealthCheckConfiguration extractHealthCheck(HealthCheckConfiguration config, ValueProvider valueProvider) {
+        Map<String, String> healthCheckProperties = valueProvider.getMap(HEALTHCHECK, Collections.<String, String>emptyMap());
         if (healthCheckProperties != null && healthCheckProperties.size() > 0) {
             return new HealthCheckConfiguration.Builder()
-                    .interval(withPrefix(prefix, HEALTHCHECK_INTERVAL, properties))
-                    .timeout(withPrefix(prefix, HEALTHCHECK_TIMEOUT, properties))
-                    .retries(intWithPrefix(prefix, HEALTHCHECK_RETRIES, properties))
-                    .mode(withPrefix(prefix, HEALTHCHECK_MODE, properties))
-                    .cmd(withPrefix(prefix, HEALTHCHECK_CMD, properties))
+                    .interval(valueProvider.getString(HEALTHCHECK_INTERVAL, config == null ? null : config.getInterval()))
+                    .timeout(valueProvider.getString(HEALTHCHECK_TIMEOUT, config == null ? null : config.getTimeout()))
+                    .retries(valueProvider.getInteger(HEALTHCHECK_RETRIES, config == null ? null : config.getRetries()))
+                    .mode(valueProvider.getString(HEALTHCHECK_MODE, config == null || config.getMode() == null ? null : config.getMode().name()))
+                    .cmd(extractArguments(valueProvider, HEALTHCHECK_CMD, config == null ? null : config.getCmd()))
                     .build();
-        }
-
-        return null;
-    }
-
-    private String extractName(String prefix, Properties properties) throws IllegalArgumentException {
-        String name = withPrefix(prefix, NAME, properties);
-        if (name == null) {
-            throw new IllegalArgumentException(String.format("Mandatory property [%s] is not defined", NAME));
-        }
-        return name;
+        }else
+            return config;
     }
 
     // Extract only the values of the port mapping
-    private List<String> extractPortValues(String prefix, Properties properties) {
+
+    private List<String> extractPortValues(List<String> config, ValueProvider valueProvider) {
         List<String> ret = new ArrayList<>();
-        List<String> ports = listWithPrefix(prefix, PORTS, properties);
+        List<String> ports = valueProvider.getList(PORTS, config);
         if (ports == null) {
             return null;
         }
@@ -217,66 +216,86 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return ret;
     }
 
+    private String extractArguments(ValueProvider valueProvider, ConfigKey configKey, Arguments alternative) {
+        String rawAlternative = null;
+        if(alternative != null)
+            rawAlternative = alternative.getShell();
 
-    private List<String> extractRunCommands(String prefix, Properties properties) {
-        return listWithPrefix(prefix, RUN, properties);
+        return valueProvider.getString(configKey, rawAlternative);
     }
 
-    private RestartPolicy extractRestartPolicy(String prefix, Properties properties) {
+    private RestartPolicy extractRestartPolicy(RestartPolicy config, ValueProvider valueProvider) {
         return new RestartPolicy.Builder()
-                .name(withPrefix(prefix, RESTART_POLICY_NAME, properties))
-                .retry(asInt(withPrefix(prefix, RESTART_POLICY_RETRY, properties)))
+                .name(valueProvider.getString(RESTART_POLICY_NAME, config == null ? null : config.getName()))
+                .retry(valueProvider.getInt(RESTART_POLICY_RETRY, config == null || config.getRetry() == 0 ? null : config.getRetry()))
                 .build();
     }
 
-    private LogConfiguration extractLogConfig(String prefix, Properties properties) {
+    private LogConfiguration extractLogConfig(LogConfiguration config, ValueProvider valueProvider) {
         LogConfiguration.Builder builder = new LogConfiguration.Builder()
-            .color(withPrefix(prefix, LOG_COLOR, properties))
-            .date(withPrefix(prefix, LOG_DATE, properties))
-            .prefix(withPrefix(prefix, LOG_PREFIX, properties))
-            .logDriverName(withPrefix(prefix, LOG_DRIVER_NAME, properties))
-            .logDriverOpts(mapWithPrefix(prefix, LOG_DRIVER_OPTS, properties));
-        Boolean enabled = booleanWithPrefix(prefix, LOG_ENABLED, properties);
+            .color(valueProvider.getString(LOG_COLOR, config == null ? null : config.getColor()))
+            .date(valueProvider.getString(LOG_DATE, config == null ? null : config.getDate()))
+            .prefix(valueProvider.getString(LOG_PREFIX, config == null ? null : config.getPrefix()))
+            .logDriverName(valueProvider.getString(LOG_DRIVER_NAME, config == null || config.getDriver() == null ? null : config.getDriver().getName()))
+            .logDriverOpts(valueProvider.getMap(LOG_DRIVER_OPTS, config == null || config.getDriver() == null ? null : config.getDriver().getOpts()));
+        Boolean enabled = valueProvider.getBoolean(LOG_ENABLED, config == null ? null : config.isEnabled());
         if (enabled != null) {
             builder.enabled(enabled);
         }
         return builder.build();
     }
 
-    private WaitConfiguration extractWaitConfig(String prefix, Properties properties) {
-        String url = withPrefix(prefix,WAIT_HTTP_URL,properties);
+    private WaitConfiguration extractWaitConfig(WaitConfiguration config, ValueProvider valueProvider) {
+        String url = valueProvider.getString(WAIT_HTTP_URL, config == null ? null : config.getUrl());
         if (url == null) {
             // Fallback to deprecated old URL
-            url = withPrefix(prefix,WAIT_URL,properties);
+            url = valueProvider.getString(WAIT_URL, config == null ? null : config.getUrl());
         }
+        WaitConfiguration.ExecConfiguration exec = config == null ? null : config.getExec();
+        WaitConfiguration.TcpConfiguration tcp = config == null ? null : config.getTcp();
+        WaitConfiguration.HttpConfiguration http = config == null ? null : config.getHttp();
+
         return new WaitConfiguration.Builder()
-                .time(asInt(withPrefix(prefix, WAIT_TIME,properties)))
+                .time(valueProvider.getInt(WAIT_TIME, config == null ? null : config.getTime()))
+                .healthy(valueProvider.getBoolean(WAIT_HEALTHY, config == null ? null : config.getHealthy()))
                 .url(url)
-                .preStop(withPrefix(prefix, WAIT_EXEC_PRE_STOP, properties))
-                .postStart(withPrefix(prefix, WAIT_EXEC_POST_START, properties))
-                .breakOnError(booleanWithPrefix(prefix, WAIT_EXEC_BREAK_ON_ERROR, properties))
-                .method(withPrefix(prefix, WAIT_HTTP_METHOD, properties))
-                .status(withPrefix(prefix, WAIT_HTTP_STATUS, properties))
-                .log(withPrefix(prefix, WAIT_LOG, properties))
-                .kill(asInt(withPrefix(prefix, WAIT_KILL, properties)))
-                .exit(asInteger(withPrefix(prefix, WAIT_EXIT, properties)))
-                .shutdown(asInt(withPrefix(prefix, WAIT_SHUTDOWN, properties)))
-                .tcpHost(withPrefix(prefix, WAIT_TCP_HOST, properties))
-                .tcpPorts(asIntList(listWithPrefix(prefix, WAIT_TCP_PORT, properties)))
-                .tcpMode(withPrefix(prefix, WAIT_TCP_MODE, properties))
+                .preStop(valueProvider.getString(WAIT_EXEC_PRE_STOP, exec == null ? null : exec.getPreStop()))
+                .postStart(valueProvider.getString(WAIT_EXEC_POST_START, exec == null ? null : exec.getPostStart()))
+                .breakOnError(valueProvider.getBoolean(WAIT_EXEC_BREAK_ON_ERROR, exec == null ? null : exec.isBreakOnError()))
+                .method(valueProvider.getString(WAIT_HTTP_METHOD, http == null ? null : http.getMethod()))
+                .status(valueProvider.getString(WAIT_HTTP_STATUS, http == null ? null : http.getStatus()))
+                .log(valueProvider.getString(WAIT_LOG, config == null ? null : config.getLog()))
+                .kill(valueProvider.getInteger(WAIT_KILL, config == null ? null : config.getKill()))
+                .exit(valueProvider.getInteger(WAIT_EXIT, config == null ? null : config.getExit()))
+                .shutdown(valueProvider.getInteger(WAIT_SHUTDOWN, config == null ? null : config.getShutdown()))
+                .tcpHost(valueProvider.getString(WAIT_TCP_HOST, tcp == null ? null : tcp.getHost()))
+                .tcpPorts(valueProvider.getIntList(WAIT_TCP_PORT, tcp == null ? null : tcp.getPorts()))
+                .tcpMode(valueProvider.getString(WAIT_TCP_MODE, tcp == null || tcp.getMode() == null ? null : tcp.getMode().name()))
                 .build();
     }
 
-    private WatchImageConfiguration extractWatchConfig(String prefix, Properties properties) {
+    private WatchImageConfiguration extractWatchConfig(ImageConfiguration fromConfig, ValueProvider valueProvider) {
+        WatchImageConfiguration config = fromConfig.getWatchConfiguration();
+
         return new WatchImageConfiguration.Builder()
-                .interval(asInt(withPrefix(prefix, WATCH_INTERVAL, properties)))
-                .postGoal(withPrefix(prefix, WATCH_POSTGOAL, properties))
-                .mode(withPrefix(prefix, WATCH_POSTGOAL, properties))
+                .interval(valueProvider.getInteger(WATCH_INTERVAL, config == null ? null : config.getIntervalRaw()))
+                .postGoal(valueProvider.getString(WATCH_POSTGOAL, config == null ? null : config.getPostGoal()))
+                .postExec(valueProvider.getString(WATCH_POSTEXEC, config == null ? null : config.getPostExec()))
+                .mode(valueProvider.getString(WATCH_POSTGOAL, config == null || config.getMode() == null ? null : config.getMode().name()))
                 .build();
     }
 
-    private List<UlimitConfig> extractUlimits(String prefix, Properties properties) {
-        List<String> ulimits = listWithPrefix(prefix, ConfigKey.ULIMITS, properties);
+    private List<UlimitConfig> extractUlimits(List<UlimitConfig> config, ValueProvider valueProvider) {
+        List<String> other = null;
+        if(config != null) {
+            other = new ArrayList<>();
+            // Convert back to string for potential merge
+            for (UlimitConfig ulimitConfig : config) {
+                other.add(ulimitConfig.serialize());
+            }
+        }
+
+        List<String> ulimits = valueProvider.getList(ConfigKey.ULIMITS, other);
         if (ulimits == null) {
             return null;
         }
@@ -287,64 +306,15 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return ret;
     }
 
-    private RunVolumeConfiguration extractVolumeConfig(String prefix, Properties properties) {
+    private RunVolumeConfiguration extractVolumeConfig(RunVolumeConfiguration config, ValueProvider valueProvider) {
         return new RunVolumeConfiguration.Builder()
-                .bind(listWithPrefix(prefix, BIND, properties))
-                .from(listWithPrefix(prefix, VOLUMES_FROM, properties))
+                .bind(valueProvider.getList(BIND, config == null ? null : config.getBind()))
+                .from(valueProvider.getList(VOLUMES_FROM, config == null ? null : config.getFrom()))
                 .build();
     }
 
-    private int asInt(String s) {
-        return s != null ? Integer.parseInt(s) : 0;
-    }
-
-    private Integer asInteger(String s) {
-        return s != null ? new Integer(s) : null;
-    }
-
-    private List<Integer> asIntList(List<String> strings) {
-        if (strings == null) {
-            return null;
-        }
-
-        List<Integer> ints = new ArrayList<>();
-        for (String s : strings) {
-            ints.add(asInt(s));
-        }
-
-        return ints;
-
-    }
-
-    private List<String> listWithPrefix(String prefix, ConfigKey key, Properties properties) {
-        return extractFromPropertiesAsList(key.asPropertyKey(prefix), properties);
-    }
-
-    private Map<String, String> mapWithPrefix(String prefix, ConfigKey key, Properties properties) {
-        return extractFromPropertiesAsMap(key.asPropertyKey(prefix), properties);
-    }
-
-    private String withPrefix(String prefix, ConfigKey key, Properties properties) {
-        return properties.getProperty(key.asPropertyKey(prefix));
-    }
-
-    private Integer intWithPrefix(String prefix, ConfigKey key, Properties properties) {
-        String prop = withPrefix(prefix, key, properties);
-        return prop == null ? null : Integer.valueOf(prop);
-    }
-
-    private Long longWithPrefix(String prefix, ConfigKey key, Properties properties) {
-        String prop = withPrefix(prefix, key, properties);
-        return prop == null ? null : Long.valueOf(prop);
-    }
-
-    private Boolean booleanWithPrefix(String prefix, ConfigKey key, Properties properties) {
-        String prop = withPrefix(prefix,key,properties);
-        return prop == null ? null : Boolean.valueOf(prop);
-    }
-
-    private String getPrefix(ImageConfiguration config) {
-        String prefix = config.getExternalConfig().get("prefix");
+    private String getPrefix(Map<String, String> externalCconfig) {
+        String prefix = externalCconfig.get("prefix");
         if (prefix == null) {
             prefix = "docker";
         }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyMode.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyMode.java
@@ -1,0 +1,36 @@
+package io.fabric8.maven.docker.config.handler.property;
+
+/**
+ * Identifies how the {@link PropertyConfigHandler} should treat properties vs configuration
+ * from POM file in the {@link ValueProvider}.
+ *
+ * @author Johan Ström
+ */
+enum PropertyMode {
+    Only,
+    Override,
+    Fallback,
+    Skip;
+
+    /**
+     * Given String, parse to a valid property mode.
+     *
+     * If null, the default Only is given.
+     *
+     * @param name null or a valid name
+     * @return PropertyMode
+     * @throws IllegalArgumentException if empty or invalid names
+     */
+    static PropertyMode parse(String name) {
+        if(name == null)
+            return PropertyMode.Only;
+
+        name = name.toLowerCase();
+        for (PropertyMode e : PropertyMode.values()) {
+            if (e.name().toLowerCase().equals(name)) {
+                return e;
+            }
+        }
+        throw new IllegalArgumentException("PropertyMode: invalid mode "+name+". Valid: "+values());
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ValueCombinePolicy.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ValueCombinePolicy.java
@@ -1,0 +1,28 @@
+package io.fabric8.maven.docker.config.handler.property;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Dictates how to combine values from different sources. See {@link PropertyConfigHandler} for details.
+ */
+public enum ValueCombinePolicy {
+    /**
+     * The prioritized value fully replaces any other values.
+     */
+    Replace,
+
+    /**
+     * All provided values are merged. This only makes sense for complex types such as lists and maps.
+     */
+    Merge;
+
+    public static ValueCombinePolicy fromString(String valueCombinePolicy) {
+        for (ValueCombinePolicy policy : values()) {
+            if (policy.name().equalsIgnoreCase(valueCombinePolicy)) {
+                return policy;
+            }
+        }
+        throw new IllegalArgumentException(String.format("No value combine policy %s known. Valid values are: %s",
+                valueCombinePolicy, StringUtils.join(values(), ", ")));
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ValueProvider.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ValueProvider.java
@@ -1,0 +1,282 @@
+package io.fabric8.maven.docker.config.handler.property;
+
+import java.util.*;
+
+import io.fabric8.maven.docker.util.EnvUtil;
+
+import static io.fabric8.maven.docker.util.EnvUtil.*;
+
+/**
+ * Helper to extract values from a set of Properties, potentially mixing it up with XML-based configuration based on the
+ * {@link PropertyMode} setting.
+ *
+ * Obtaining a value is done via data-type specific methods (such as {@link #getString}). The ConfigKey parameter
+ * tells us which property to look for, and how to handle combination of multiple values.
+ *
+ * For {@link PropertyMode#Only} we only look at the properties, ignoring any config value.
+ * For {@link PropertyMode#Skip} we only look at the config, ignoring any properties value.
+ * For {@link PropertyMode#Override} we use the property value if it is non-null, else the config value.
+ * For {@link PropertyMode#Fallback} we use the config value if it is non-null, else the property value.
+ *
+ * For Override and Fallback mode, merging may take place as dictated by the {@link ValueCombinePolicy}
+ * defined in the {@link ConfigKey}, or as overriden by the property &lt;prefix.someproperty&gt<b>._combine</b>
+ * ({@link EnvUtil#PROPERTY_COMBINE_POLICY_SUFFIX}).
+ *
+ * If {@link ValueCombinePolicy#Replace} is used, only the prioritized value (first non-null) is used.
+ * If {@link ValueCombinePolicy#Merge} is used, the merge method depends on the data type.
+ * For simple types (string, int, long, boolean) this is not supported and will throw exception.
+ * For Lists, the non-null values will be appended to each other (with values from first source added first)
+ * For Maps, all maps are merged into one map, with data from the first map taking precedence. *
+ *
+ * @author Johan Ström
+ */
+public class ValueProvider {
+    private String prefix;
+    private Properties properties;
+    private PropertyMode propertyMode;
+
+    private StringListValueExtractor stringListValueExtractor;
+    private IntListValueExtractor intListValueExtractor;
+    private MapValueExtractor mapValueExtractor;
+    private StringValueExtractor stringValueExtractor;
+    private IntValueExtractor intValueExtractor;
+    private LongValueExtractor longValueExtractor;
+    private BooleanValueExtractor booleanValueExtractor;
+
+    /**
+     * Initiates ValueProvider which is to work with data from the given properties.
+     *
+     * The PropertyMode controls which source(s) to consult, and in which order.
+     *
+     * @param prefix Only look at properties with this prefix.
+     * @param properties
+     * @param propertyMode Which source to prioritize
+     */
+    public ValueProvider(String prefix, Properties properties, PropertyMode propertyMode) {
+        this.prefix = prefix;
+        this.properties = properties;
+        this.propertyMode = propertyMode;
+
+        stringListValueExtractor = new StringListValueExtractor();
+        intListValueExtractor = new IntListValueExtractor();
+        mapValueExtractor = new MapValueExtractor();
+        stringValueExtractor = new StringValueExtractor();
+        intValueExtractor = new IntValueExtractor();
+        longValueExtractor = new LongValueExtractor();
+        booleanValueExtractor = new BooleanValueExtractor();
+    }
+
+    public String getString(ConfigKey key, String fromConfig) {
+        return stringValueExtractor.getFromPreferredSource(prefix, key, fromConfig);
+    }
+
+    public Integer getInteger(ConfigKey key, Integer fromConfig) {
+        return intValueExtractor.getFromPreferredSource(prefix, key, fromConfig);
+    }
+
+    public int getInt(ConfigKey key, Integer fromConfig) {
+        Integer integer = getInteger(key, fromConfig);
+        if(integer == null)
+            return 0;
+        return integer;
+    }
+
+    public Long getLong(ConfigKey key, Long fromConfig) {
+        return longValueExtractor.getFromPreferredSource(prefix, key, fromConfig);
+    }
+
+    public Boolean getBoolean(ConfigKey key, Boolean fromConfig) {
+        return booleanValueExtractor.getFromPreferredSource(prefix, key, fromConfig);
+    }
+
+    public List<String> getList(ConfigKey key, List<String> fromConfig) {
+        return stringListValueExtractor.getFromPreferredSource(prefix, key, fromConfig);
+    }
+
+    public List<Integer> getIntList(ConfigKey key, List<Integer> fromConfig) {
+        return intListValueExtractor.getFromPreferredSource(prefix, key, fromConfig);
+    }
+
+    public Map<String, String> getMap(ConfigKey key, Map<String, String> fromConfig) {
+        return mapValueExtractor.getFromPreferredSource(prefix, key, fromConfig);
+    }
+
+
+    /**
+     * Helper base class for picking values out of the the Properties class and/or config value.
+     *
+     * If there is only one source defined, we only use that. If multiple source are defined, the first one get's priority.
+     * If more than one value is specified, a merge policy as specified for the ConfigKey
+     */
+    private abstract class ValueExtractor<T> {
+        T getFromPreferredSource(String prefix, ConfigKey key, T fromConfig) {
+            if(propertyMode == PropertyMode.Skip)
+                return fromConfig;
+
+            List<T> values = new ArrayList<>();
+
+            // Find all non-null values, put into "values" with order based on the given propertyMode
+            T fromProperty = withPrefix(prefix, key, properties);
+
+            // Short-circuit
+            if(fromProperty == null && fromConfig == null) {
+                return null;
+            }
+
+            switch (propertyMode) {
+                case Only:
+                    return fromProperty;
+                case Override:
+                    if(fromProperty != null)
+                        values.add(fromProperty);
+                    if(fromConfig != null)
+                        values.add(fromConfig);
+                    break;
+                case Fallback:
+                    if(fromConfig != null)
+                        values.add(fromConfig);
+                    if(fromProperty != null)
+                        values.add(fromProperty);
+                    break;
+                default:
+                    throw new AssertionError("Invalid PropertyMode");
+            }
+
+            if(values.size() == 1) {
+                return values.get(0);
+            }
+
+            // values now has non-null values from both sources, in preference order.
+            // Let's merge according to the combine policy
+            ValueCombinePolicy combinePolicy = key.getValueCombinePolicy();
+            String overrideCombinePolicy = properties.getProperty(key.asPropertyKey(prefix) + "." + EnvUtil.PROPERTY_COMBINE_POLICY_SUFFIX);
+            if(overrideCombinePolicy != null) {
+                combinePolicy = ValueCombinePolicy.fromString(overrideCombinePolicy);
+            }
+
+            switch(combinePolicy) {
+                case Replace:
+                    return values.get(0);
+                case Merge:
+                    return merge(key, values);
+            }
+            return null;
+        }
+
+        /**
+         * Data type-specific extractor to read value from properties.
+         *
+         * @param prefix
+         * @param key
+         * @param properties
+         * @return
+         */
+        protected abstract T withPrefix(String prefix, ConfigKey key, Properties properties);
+
+        protected T merge(ConfigKey key, List<T> values) {
+            throw new IllegalArgumentException("Combine policy Merge is not available for "+key.asPropertyKey(prefix));
+        }
+    }
+
+
+
+
+    private class StringValueExtractor extends ValueExtractor<String> {
+        @Override
+        protected String withPrefix(String prefix, ConfigKey key, Properties properties) {
+            return properties.getProperty(key.asPropertyKey(prefix));
+        }
+    }
+
+    private class IntValueExtractor extends ValueExtractor<Integer> {
+        @Override
+        protected Integer withPrefix(String prefix, ConfigKey key, Properties properties) {
+            String prop = properties.getProperty(key.asPropertyKey(prefix));
+            return prop == null ? null : Integer.valueOf(prop);
+        }
+    }
+
+
+    private class LongValueExtractor extends ValueExtractor<Long> {
+        @Override
+        protected Long withPrefix(String prefix, ConfigKey key, Properties properties) {
+            String prop = properties.getProperty(key.asPropertyKey(prefix));
+            return prop == null ? null : Long.valueOf(prop);
+        }
+    }
+
+    private class BooleanValueExtractor extends ValueExtractor<Boolean> {
+        @Override
+        protected Boolean withPrefix(String prefix, ConfigKey key, Properties properties) {
+            String prop = properties.getProperty(key.asPropertyKey(prefix));
+            return prop == null ? null : Boolean.valueOf(prop);
+        }
+    }
+
+
+
+    private abstract class ListValueExtractor<T> extends ValueExtractor<List<T>> {
+        @Override
+        protected List<T> withPrefix(String prefix, ConfigKey key, Properties properties) {
+            List<String> strings = extractFromPropertiesAsList(key.asPropertyKey(prefix), properties);
+            if(strings == null) {
+                return null;
+            }
+            return process(strings);
+        }
+
+        protected abstract List<T> process(List<String> strings);
+
+        @Override
+        protected List<T> merge(ConfigKey key, List<List<T>> values) {
+            List<T> merged = new ArrayList<>();
+            for (List<T> value : values) {
+                merged.addAll(value);
+            }
+            return merged;
+        }
+    }
+
+    private class StringListValueExtractor extends ListValueExtractor<String> {
+        @Override
+        protected List<String> process(List<String> strings) {
+            return strings;
+        }
+    }
+
+    private class IntListValueExtractor extends ListValueExtractor<Integer> {
+        @Override
+        protected List<Integer> process(List<String> strings) {
+            List<Integer> ints = new ArrayList<>();
+            for (String s : strings) {
+                ints.add(s != null ? Integer.parseInt(s) : 0);
+            }
+            return ints;
+        }
+    }
+
+
+
+    private class MapValueExtractor extends ValueExtractor<Map<String, String>> {
+        @Override
+        protected Map<String, String> withPrefix(String prefix, ConfigKey key, Properties properties) {
+            return extractFromPropertiesAsMap(key.asPropertyKey(prefix), properties);
+        }
+
+        @Override
+        protected Map<String, String> merge(ConfigKey key, List<Map<String, String>> values) {
+            Map<String, String> merged = null;
+
+            // Iterate in reverse, the first entry in values has highest priority
+            for(int i = values.size() - 1; i >= 0; i--) {
+                Map<String, String> value = values.get(i);
+                if(merged == null) {
+                    merged = value;
+                } else {
+                    merged.putAll(value);
+                }
+            }
+            return merged;
+        }
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/service/ContainerTracker.java
+++ b/src/main/java/io/fabric8/maven/docker/service/ContainerTracker.java
@@ -199,8 +199,8 @@ public class ContainerTracker {
 
             RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
             WaitConfiguration waitConfig = runConfig != null ? runConfig.getWaitConfiguration() : null;
-            this.shutdownGracePeriod = waitConfig != null ? waitConfig.getShutdown() : 0;
-            this.killGracePeriod = waitConfig != null ? waitConfig.getKill() : 0;
+            this.shutdownGracePeriod = waitConfig != null && waitConfig.getShutdown() != null ? waitConfig.getShutdown() : 0;
+            this.killGracePeriod = waitConfig != null && waitConfig.getKill() != null ? waitConfig.getKill() : 0;
             if (waitConfig != null && waitConfig.getExec() != null) {
                 this.preStop = waitConfig.getExec().getPreStop();
                 this.breakOnError = waitConfig.getExec().isBreakOnError();

--- a/src/main/java/io/fabric8/maven/docker/service/WaitService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WaitService.java
@@ -69,7 +69,7 @@ public class WaitService {
 
     private int getTimeOut(ImageConfiguration imageConfig) {
         WaitConfiguration wait = getWaitConfiguration(imageConfig);
-        return wait != null ? wait.getTime() : 0;
+        return wait != null && wait.getTime() != null ? wait.getTime() : 0;
     }
 
     private String extractCheckerLog(List<WaitChecker> checkers) {
@@ -107,7 +107,7 @@ public class WaitService {
             }
         }
 
-        if (wait.getHealthy()) {
+        if (wait.getHealthy() == Boolean.TRUE) {
             checkers.add(new HealthCheckChecker(dockerAccess, containerId, imageConfig.getDescription(), log));
         }
 

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -27,8 +27,7 @@ import org.apache.maven.project.MavenProject;
 import org.junit.*;
 import org.junit.runner.RunWith;
 
-import static io.fabric8.maven.docker.config.BuildImageConfiguration.DEFAULT_CLEANUP;
-import static io.fabric8.maven.docker.config.BuildImageConfiguration.DEFAULT_FILTER;
+import static io.fabric8.maven.docker.config.BuildImageConfiguration.*;
 import static org.junit.Assert.*;
 
 /**
@@ -77,7 +76,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
     }
 
     @Test
-    public void testPorts() throws Exception {
+    public void testPorts() {
         List<ImageConfiguration> configs = resolveImage(
                 imageConfiguration,props(
                         "docker.name","demo",
@@ -100,6 +99,52 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertArrayEquals(new String[]{"8080", "9090", "80"}, ports);
     }
 
+
+    @Test
+    public void testPortsFromConfigAndProperties() {
+        imageConfiguration = new ImageConfiguration.Builder()
+                .externalConfig(new HashMap<String, String>())
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .ports(Arrays.asList("1234"))
+                        .build()
+                )
+                .runConfig(new RunImageConfiguration.Builder()
+                    .ports(Arrays.asList("jolokia.port:1234"))
+                    .build()
+                )
+                .build();
+
+        makeExternalConfigUse(PropertyMode.Override);
+
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.name","demo",
+                        "docker.ports.1", "9090",
+                        "docker.ports.2", "0.0.0.0:80:80",
+                        "docker.from", "busybox"
+                ));
+        assertEquals(1,configs.size());
+        RunImageConfiguration runConfig = configs.get(0).getRunConfiguration();
+        List<String> portsAsList = runConfig.getPorts();
+        String[] ports = new ArrayList<>(portsAsList).toArray(new String[portsAsList.size()]);
+        assertArrayEquals(new String[] {
+                "9090",
+                "0.0.0.0:80:80",
+                "jolokia.port:1234"
+        },ports);
+        BuildImageConfiguration buildConfig = configs.get(0).getBuildConfiguration();
+        ports = new ArrayList<>(buildConfig.getPorts()).toArray(new String[buildConfig.getPorts().size()]);
+        assertArrayEquals(new String[]{"9090", "80", "1234"}, ports);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidPropertyMode() {
+        makeExternalConfigUse(PropertyMode.Override);
+        imageConfiguration.getExternalConfig().put("mode", "invalid");
+
+        resolveImage(imageConfiguration,props());
+    }
+
     @Test
     public void testRunCommands() {
         List<ImageConfiguration> configs = resolveImage(
@@ -116,6 +161,62 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         BuildImageConfiguration buildConfig = configs.get(0).getBuildConfiguration();
         String[] runCommands = new ArrayList<>(buildConfig.getRunCmds()).toArray(new String[buildConfig.getRunCmds().size()]);
         assertArrayEquals(new String[]{"foo", "bar", "wibble"}, runCommands);
+    }
+
+    @Test
+    public void testRunCommandsFromPropertiesAndConfig() {
+        imageConfiguration = new ImageConfiguration.Builder()
+                .externalConfig(new HashMap<String, String>())
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .runCmds(Arrays.asList("some","ignored","value"))
+                        .build()
+                )
+                .build();
+
+        makeExternalConfigUse(PropertyMode.Override);
+
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.from", "base",
+                        "docker.name","demo",
+                        "docker.run.1", "propconf",
+                        "docker.run.2", "withrun",
+                        "docker.run.3", "used")
+        );
+
+        assertEquals(1, configs.size());
+
+        BuildImageConfiguration buildConfig = configs.get(0).getBuildConfiguration();
+        String[] runCommands = new ArrayList<>(buildConfig.getRunCmds()).toArray(new String[buildConfig.getRunCmds().size()]);
+        assertArrayEquals(new String[]{"propconf", "withrun", "used"}, runCommands);
+    }
+
+    @Test
+    public void testRunCommandsFromConfigAndProperties() {
+        imageConfiguration = new ImageConfiguration.Builder()
+                .externalConfig(new HashMap<String, String>())
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .runCmds(Arrays.asList("some","configured","value"))
+                        .build()
+                )
+                .build();
+
+        makeExternalConfigUse(PropertyMode.Fallback);
+
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.from", "base",
+                        "docker.name","demo",
+                        "docker.run.1", "this",
+                        "docker.run.2", "is",
+                        "docker.run.3", "ignored")
+        );
+
+        assertEquals(1, configs.size());
+
+        BuildImageConfiguration buildConfig = configs.get(0).getBuildConfiguration();
+        String[] runCommands = new ArrayList<>(buildConfig.getRunCmds()).toArray(new String[buildConfig.getRunCmds().size()]);
+        assertArrayEquals(new String[]{"some", "configured", "value"}, runCommands);
     }
 
     @Test
@@ -332,6 +433,45 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals(mode, config.getBuildConfiguration().cleanupMode());
     }
 
+
+    @Test
+    public void testUlimit() {
+        imageConfiguration = new ImageConfiguration.Builder()
+                .externalConfig(new HashMap<String, String>())
+                .runConfig(new RunImageConfiguration.Builder()
+                        .ulimits(Arrays.asList(
+                                new UlimitConfig("memlock", 100, 50),
+                                new UlimitConfig("nfile", 1024, 512)
+                        ))
+                        .build()
+                )
+                .build();
+
+        makeExternalConfigUse(PropertyMode.Override);
+
+        // TODO: Does Replace make sense here or should we Merge?
+        // If merge, it should probably have some more smarts on the ulimit name?
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        k(ConfigKey.NAME), "image",
+                        k(ConfigKey.FROM), "base",
+                        k(ConfigKey.ULIMITS)+".1", "memlock=10:10",
+                        k(ConfigKey.ULIMITS)+".2", "memlock=:-1",
+                        k(ConfigKey.ULIMITS)+".3", "memlock=1024:",
+                        k(ConfigKey.ULIMITS)+".4", "memlock=2048"
+                ));
+
+        assertEquals(1,configs.size());
+        RunImageConfiguration runConfig = configs.get(0).getRunConfiguration();
+        List<UlimitConfig> ulimits = runConfig.getUlimits();
+
+        assertEquals(4, ulimits.size());
+        assertUlimitEquals(ulimit("memlock",10,10),runConfig.getUlimits().get(0));
+        assertUlimitEquals(ulimit("memlock",null,-1),runConfig.getUlimits().get(1));
+        assertUlimitEquals(ulimit("memlock",1024,null),runConfig.getUlimits().get(2));
+        assertUlimitEquals(ulimit("memlock",2048,null),runConfig.getUlimits().get(3));
+    }
+
     @Test
     public void testNoAssembly() throws Exception {
         Properties props = props(k(ConfigKey.NAME), "image");
@@ -371,6 +511,16 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         return new ImageConfiguration.Builder()
                 .externalConfig(new HashMap<String, String>())
                 .build();
+    }
+
+
+    private void makeExternalConfigUse(PropertyMode mode) {
+        Map<String, String> externalConfig = imageConfiguration.getExternalConfig();
+        externalConfig.put("type", "properties");
+        if(mode != null)
+            externalConfig.put("mode", mode.name());
+        else
+            externalConfig.remove("mode");
     }
 
     private List<ImageConfiguration> resolveImage(ImageConfiguration image, final Properties properties) {
@@ -484,7 +634,8 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals("post_start_command", wait.getExec().getPostStart());
         assertEquals("pre_stop_command", wait.getExec().getPreStop());
         assertTrue(wait.getExec().isBreakOnError());
-        assertEquals(5, wait.getTime());
+        assertEquals(5, wait.getTime().intValue());
+        assertTrue(wait.getHealthy());
         assertEquals(0, wait.getExit().intValue());
 
         LogConfiguration config = runConfig.getLogConfiguration();
@@ -569,6 +720,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
             k(ConfigKey.WAIT_EXEC_POST_START), "post_start_command",
             k(ConfigKey.WAIT_EXEC_BREAK_ON_ERROR), "true",
             k(ConfigKey.WAIT_LOG), "pattern",
+            k(ConfigKey.WAIT_HEALTHY), "true",
             k(ConfigKey.WAIT_TIME), "5",
             k(ConfigKey.WAIT_EXIT), "0",
             k(ConfigKey.WAIT_URL), "http://foo.com",

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -146,6 +146,57 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         }
     }
 
+
+    @Test
+    public void testSpecificEnv() throws Exception {
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.from", "baase",
+                        "docker.name","demo",
+                        "docker.envBuild.HOME", "/tmp",
+                        "docker.envRun.root.dir", "/bla"
+                ));
+
+        assertEquals(1,configs.size());
+        ImageConfiguration calcConfig = configs.get(0);
+
+        Map<String, String> env;
+
+        env = calcConfig.getBuildConfiguration().getEnv();
+        assertEquals(1,env.size());
+        assertEquals("/tmp",env.get("HOME"));
+
+        env = calcConfig.getRunConfiguration().getEnv();
+        assertEquals(1,env.size());
+        assertEquals("/bla",env.get("root.dir"));
+    }
+
+    @Test
+    public void testMergedEnv() throws Exception {
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.from", "baase",
+                        "docker.name","demo",
+                        "docker.env.HOME", "/tmp",
+                        "docker.envBuild.HOME", "/var/tmp",
+                        "docker.envRun.root.dir", "/bla"
+                ));
+
+        assertEquals(1,configs.size());
+        ImageConfiguration calcConfig = configs.get(0);
+
+        Map<String, String> env;
+
+        env = calcConfig.getBuildConfiguration().getEnv();
+        assertEquals(1,env.size());
+        assertEquals("/var/tmp",env.get("HOME"));
+
+        env = calcConfig.getRunConfiguration().getEnv();
+        assertEquals(2,env.size());
+        assertEquals("/tmp",env.get("HOME"));
+        assertEquals("/bla",env.get("root.dir"));
+    }
+
     @Test
     public void testAssembly() throws Exception {
         List<ImageConfiguration> configs = resolveImage(imageConfiguration, props(getTestAssemblyData()));

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyModeTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyModeTest.java
@@ -1,0 +1,24 @@
+package io.fabric8.maven.docker.config.handler.property;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PropertyModeTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidEmpty() {
+        PropertyMode.parse("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidParse() {
+        PropertyMode.parse("propertiespom");
+    }
+    @Test
+    public void testParse() {
+        assertEquals(PropertyMode.Only, PropertyMode.parse(null));
+        assertEquals(PropertyMode.Only, PropertyMode.parse("only"));
+        assertEquals(PropertyMode.Fallback, PropertyMode.parse("fallback"));
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/ValueProviderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/ValueProviderTest.java
@@ -1,0 +1,205 @@
+package io.fabric8.maven.docker.config.handler.property;
+
+import java.util.*;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ValueProviderTest {
+    private ValueProvider provider;
+    private Properties props;
+
+    @Before
+    public void setUp() throws Exception {
+        props = new Properties();
+    }
+
+    private void configure(PropertyMode mode) {
+        provider = new ValueProvider("docker", props, mode);
+    }
+
+    @Test
+    public void testGetString_Only() {
+        configure(PropertyMode.Only);
+        assertEquals(null, provider.getString(ConfigKey.NAME, (String)null));
+        assertEquals(null, provider.getString(ConfigKey.NAME, "ignored"));
+
+        props.put("docker.name", "myname");
+        assertEquals("myname", provider.getString(ConfigKey.NAME, (String)null));
+        assertEquals("myname", provider.getString(ConfigKey.NAME, "ignored"));
+    }
+
+    @Test
+    public void testGetString_Skip() {
+        configure(PropertyMode.Skip);
+        assertEquals(null, provider.getString(ConfigKey.NAME, (String)null));
+        assertEquals("fromconfig", provider.getString(ConfigKey.NAME, "fromconfig"));
+
+        props.put("docker.name", "ignored");
+        assertEquals(null, provider.getString(ConfigKey.NAME, (String)null));
+        assertEquals("fromconfig", provider.getString(ConfigKey.NAME, "fromconfig"));
+    }
+
+    @Test
+    public void testGetString_Fallback() {
+        configure(PropertyMode.Fallback);
+        assertEquals(null, provider.getString(ConfigKey.NAME, (String)null));
+        assertEquals("fromconfig", provider.getString(ConfigKey.NAME, "fromconfig"));
+
+        props.put("docker.name", "fromprop");
+        assertEquals("fromprop", provider.getString(ConfigKey.NAME, (String)null));
+        assertEquals("fromconfig", provider.getString(ConfigKey.NAME, "fromconfig"));
+    }
+
+    @Test
+    public void testGetString_Override() {
+        configure(PropertyMode.Override);
+        assertEquals(null, provider.getString(ConfigKey.NAME, (String)null));
+        assertEquals("fromconfig", provider.getString(ConfigKey.NAME, "fromconfig"));
+
+        props.put("docker.name", "fromprop");
+        assertEquals("fromprop", provider.getString(ConfigKey.NAME, (String)null));
+        assertEquals("fromprop", provider.getString(ConfigKey.NAME, "fromconfig"));
+    }
+
+
+    @Test
+    public void testGetInt() {
+        configure(PropertyMode.Only);
+        assertEquals(null, provider.getInteger(ConfigKey.SHMSIZE, null));
+        assertEquals(null, provider.getInteger(ConfigKey.SHMSIZE, 100));
+
+        props.put("docker.shmsize", "200");
+        assertEquals(200, (int)provider.getInteger(ConfigKey.SHMSIZE, null));
+        assertEquals(200, (int)provider.getInteger(ConfigKey.SHMSIZE, 100));
+    }
+
+
+    @Test
+    public void testGetList() {
+        configure(PropertyMode.Only);
+        assertEquals(null, provider.getList(ConfigKey.PORTS, null));
+        assertEquals(null, provider.getList(ConfigKey.PORTS, Collections.singletonList("8080")));
+
+        props.put("docker.ports.1", "200");
+
+        assertThat(provider.getList(ConfigKey.PORTS, null), Matchers.contains("200"));
+        assertThat(provider.getList(ConfigKey.PORTS, Collections.singletonList("8080")), Matchers.contains("200"));
+
+        props.put("docker.ports.1", "200");
+        props.put("docker.ports.2", "8080");
+        assertThat(provider.getList(ConfigKey.PORTS, null), Matchers.contains("200", "8080"));
+        assertThat(provider.getList(ConfigKey.PORTS, Collections.singletonList("123")), Matchers.contains("200", "8080"));
+
+        configure(PropertyMode.Fallback);
+
+        assertThat(provider.getList(ConfigKey.PORTS, null), Matchers.contains("200", "8080"));
+        assertThat(provider.getList(ConfigKey.PORTS, Collections.singletonList("123")), Matchers.contains("123", "200", "8080"));
+
+        configure(PropertyMode.Override);
+        assertThat(provider.getList(ConfigKey.PORTS, null), Matchers.contains("200", "8080"));
+        assertThat(provider.getList(ConfigKey.PORTS, Collections.singletonList("123")), Matchers.contains("200", "8080", "123"));
+
+        // Test with another property that does not have CombinePolicy Merge
+        props.put("docker.entrypoint.1", "ep1");
+        props.put("docker.entrypoint.2", "ep2");
+        assertThat(provider.getList(ConfigKey.ENTRYPOINT, null), Matchers.contains("ep1", "ep2"));
+        assertThat(provider.getList(ConfigKey.ENTRYPOINT, Collections.singletonList("asd")), Matchers.contains("ep1", "ep2"));
+
+        configure(PropertyMode.Fallback);
+        assertThat(provider.getList(ConfigKey.ENTRYPOINT, null), Matchers.contains("ep1", "ep2"));
+        assertThat(provider.getList(ConfigKey.ENTRYPOINT, Collections.singletonList("asd")), Matchers.contains("asd"));
+
+        // Override combine policy
+        props.put("docker.entrypoint._combine", "merge");
+
+        assertThat(provider.getList(ConfigKey.ENTRYPOINT, Collections.singletonList("asd")), Matchers.contains("asd", "ep1", "ep2"));
+    }
+
+
+
+    @Test
+    public void testGetMap() {
+        configure(PropertyMode.Only);
+        assertEquals(null, provider.getMap(ConfigKey.ENV_RUN, null));
+        assertEquals(null, provider.getMap(ConfigKey.ENV_RUN, getTestMap("key", "value")));
+
+        props.put("docker.envRun.myprop1", "pvalue1");
+        props.put("docker.envRun.myprop2", "pvalue2");
+
+        Map m = provider.getMap(ConfigKey.ENV_RUN, null);
+        assertEquals(2, m.size());
+        assertEquals("pvalue1", m.get("myprop1"));
+        assertEquals("pvalue2", m.get("myprop2"));
+
+        m = provider.getMap(ConfigKey.ENV_RUN, getTestMap("mycfg", "cvalue"));
+        assertEquals(2, m.size());
+        assertEquals("pvalue1", m.get("myprop1"));
+        assertEquals("pvalue2", m.get("myprop2"));
+
+
+        configure(PropertyMode.Override);
+
+        m = provider.getMap(ConfigKey.ENV_RUN, null);
+        assertEquals(2, m.size());
+        assertEquals("pvalue1", m.get("myprop1"));
+        assertEquals("pvalue2", m.get("myprop2"));
+
+        m = provider.getMap(ConfigKey.ENV_RUN, getTestMap("ckey", "cvalue", "myprop1", "ignored"));
+        assertEquals(3, m.size());
+        assertEquals("pvalue1", m.get("myprop1"));
+        assertEquals("pvalue2", m.get("myprop2"));
+        assertEquals("cvalue", m.get("ckey"));
+
+
+        configure(PropertyMode.Fallback);
+        m = provider.getMap(ConfigKey.ENV_RUN, getTestMap("ckey", "cvalue", "myprop1", "overrides"));
+        assertEquals(3, m.size());
+        assertEquals("overrides", m.get("myprop1"));
+        assertEquals("pvalue2", m.get("myprop2"));
+        assertEquals("cvalue", m.get("ckey"));
+
+        // Test with another property that does not have CombinePolicy Merge
+        props.put("docker.buildOptions.boprop1", "popt1");
+        props.put("docker.buildOptions.boprop2", "popt2");
+        configure(PropertyMode.Override);
+        m = provider.getMap(ConfigKey.BUILD_OPTIONS, null);
+        assertEquals(2, m.size());
+        assertEquals("popt1", m.get("boprop1"));
+        assertEquals("popt2", m.get("boprop2"));
+
+        m = provider.getMap(ConfigKey.BUILD_OPTIONS, getTestMap("ckey", "ignored", "myprop1", "ignored"));
+        assertEquals(2, m.size());
+        assertEquals("popt1", m.get("boprop1"));
+        assertEquals("popt2", m.get("boprop2"));
+
+        configure(PropertyMode.Fallback);
+        m = provider.getMap(ConfigKey.BUILD_OPTIONS, getTestMap("ckey", "notignored1", "myprop1", "notignored2"));
+        assertEquals(2, m.size());
+        assertEquals("notignored1", m.get("ckey"));
+        assertEquals("notignored2", m.get("myprop1"));
+
+        // Override combine policy
+        props.put("docker.buildOptions._combine", "merge");
+
+        m = provider.getMap(ConfigKey.BUILD_OPTIONS, getTestMap("ckey", "notignored1", "boprop2", "notignored2"));
+        assertEquals(3, m.size());
+        assertEquals("popt1", m.get("boprop1"));
+        assertEquals("notignored2", m.get("boprop2"));
+        assertEquals("notignored1", m.get("ckey"));
+    }
+
+
+
+    private Map getTestMap(String ... vals) {
+        Map ret = new HashMap();
+        for (int i = 0; i < vals.length; i+=2) {
+            ret.put(vals[i],vals[i+1]);
+        }
+        return ret;
+    }
+
+}

--- a/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
@@ -99,6 +99,7 @@ public class EnvUtilTest {
         Properties props = getTestProperties(
                 "bla.hello","world",
                 "bla.max","morlock",
+                "bla."+EnvUtil.PROPERTY_COMBINE_POLICY_SUFFIX, "ignored-since-it-is-reserved",
                 "blub.not","aMap");
         Map<String,String> result = EnvUtil.extractFromPropertiesAsMap("bla", props);
         assertEquals(2,result.size());
@@ -112,6 +113,7 @@ public class EnvUtilTest {
                 "bla.2","world",
                 "bla.1","hello",
                 "bla.blub","last",
+                "bla."+EnvUtil.PROPERTY_COMBINE_POLICY_SUFFIX, "ignored-since-it-is-reserved",
                 "blub.1","unknown");
         List<String> result = EnvUtil.extractFromPropertiesAsList("bla", props);
         assertEquals(3,result.size());


### PR DESCRIPTION
(originally discussed in #938. Branch based on commit in #941 with run/buildEnv)

This adds supports to use both Properties based configuration and POM based configuration to configure the same image. This is done by adding the `source` configuration to the `<external>` section, which can have one of the following values:
* `properties` - default, same as existing properties based configuration (ie. no merge)
* `pom, properties` - merge pom configs and properties, with values in POM having priority
* `properties, pom` - merge pom configs and properties, with values in properties having priority
* (`pom` - pretty useless, same as not having <external> at all)

Can also be enabled by pure properties (only makes sense for single image), by setting the property `docker.externalPropertyConfiguration.source` to a valid `source` value. This is useful if we want to add properties from site-wide config for example settings.xml, for example adding `runEnv.http_proxy` without touching every POM using the plugin.

Properties are loaded from Maven Project properties merged with System properties (Maven -D flags).

Merging on value level takes place for only a few specific properties by default, for most values it does not make sense to merge (i.e. `runCmd`, `from` or any other single values).
* For Lists, merging happens by appending all values to one list.
* For Maps, merging happens by adding all keys to one map. Source with higher priority overwrites keys with lower priority.

Which values to be merged/replaced are controlled by a new configuration on the `ConfigKey` enum. This can be overridden by setting the `_combine` property suffix.

h2. Examples
```
<properties>
   <docker.network.alias.1>mycontainer</docker.network.alias.1>
</properties>
....
<image>  
  <external>
    <type>properties</type>
    <source>properties,pom</source> <!-- This one is new -->
  </external>
  <name>myimage</name>
  <build> 
       ...
  </build>
   <run>
      ....
   </run>
</image>
```

Set some properties through -D flags (requires that external is activated in POM)
```
mvn docker:run -Ddocker.runEnv.http_proxy=http://my.runtime.specific.proxy.com:1234
```

Set some properties through -D flags, also activating external from -D flag:
```
mvn docker:run -Ddocker.externalPropertyConfiguration.source=properties,pom \
  -Ddocker.runEnv.http_proxy=http://my.runtime.specific.proxy.com:1234
```

Override merge policy for runEnv map (only use the one defined in properties, ignoring any in POM):
```
mvn docker:run -Ddocker.externalPropertyConfiguration.source=properties,pom \
  -Ddocker.runEnv.http_proxy._combine=replace \
  -Ddocker.runEnv.http_proxy=http://my.runtime.specific.proxy.com:1234
```
