### PR TITLE
Use docker.skip.tag property on push and remove

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,7 +3,8 @@
 * **0.24-SNAPSHOT**
   - Fix possible NPE when logging to a file and the parent directory does not exist yet (#911) (#940)
   - Change content type to "application/json" when talking to the Docker daemon (#945)
-
+  - Use docker.skip.tag property on push and remove (#954) ([#869](https://github.com/fabric8io/docker-maven-plugin/issues/869))
+  
 * **0.24.0** (2018-02-07)
   - Respect system properties for ECR authentication ([#897](https://github.com/fabric8io/docker-maven-plugin/issues/897))
   - Simplified auto pull handling and moved to `imagePullPolicy` instead.

--- a/src/main/asciidoc/inc/_docker-remove.adoc
+++ b/src/main/asciidoc/inc/_docker-remove.adoc
@@ -5,7 +5,6 @@
 This goal can be used to clean up images and containers. By default all images with a build configuration are removed.
 You can tune this by setting the property `removeMode` (property: `docker.removeMode`) to one of the following values:
 
-[[config-image-build]]
 .removeMode Values
 [cols="1,5"]
 |===
@@ -34,3 +33,13 @@ Considering three images 'db','tomcat' and 'data' where 'data' is the only image
 * `mvn -Ddocker.removeMode=all {plugin}:remove` will remove all three images
 * `mvn -Ddocker.filter=data,tomcat {plugin}:remove` will remove 'data'
 * `mvn -Ddocker.filter=data,tomcat -Ddocker.removeMode=all {plugin}:remove` will remove 'data' and 'tomcat'
+
+.Remove options
+[cols="1,5,1"]
+|===
+| Element | Description | Property
+
+| *skipTag*
+| If set to `true` this plugin won't remove any tags
+| `docker.skip.tag`
+|===

--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -126,7 +126,9 @@ By default a progress meter is printed out on the console, which is omitted when
 | `docker.skip.run`
 
 | *skipTag*
-| If set to `true` this plugin won't add any tags to images that have been built with `{plugin}:build`
+| If set to `true` this plugin won't add any tags to images that have been built with `{plugin}:build`. +
+If set to `true` this plugin won't push any tags with `{plugin}:push`. +
+If set to `true` this plugin won't remove any tags with `{plugin}:remove`. +
 | `docker.skip.tag`
 
 | *skipMachine*

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -96,6 +96,9 @@ A provided `<from>` takes precedence over the name given here. This tag is usefu
 | *skip*
 | if set to true disables building of the image. This config option is best used together with a maven property
 
+| *skipTag*
+| If set to `true` this plugin won't add any tags to images. Property: `docker.skip.tag`
+
 | *tags*
 | List of additional `tag` elements with which an image is to be tagged after the build. Whitespace is trimmed from each element and empty elements are ignored.
 

--- a/src/main/asciidoc/inc/push/_configuration.adoc
+++ b/src/main/asciidoc/inc/push/_configuration.adoc
@@ -9,6 +9,10 @@
 | If set to `true` the plugin won't push any images that have been built.
 | `docker.skip.push`
 
+| *skipTag*
+| If set to `true` this plugin won't push any tags
+| `docker.skip.tag`
+
 | *pushRegistry*
 | The registry to use when pushing the image. See <<registry,Registry Handling>> for
 more details.

--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -10,7 +10,6 @@ import io.fabric8.maven.docker.service.BuildService;
 import io.fabric8.maven.docker.service.ImagePullManager;
 import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.EnvUtil;
-import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -25,11 +24,14 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "build", defaultPhase = LifecyclePhase.INSTALL)
 public class BuildMojo extends AbstractBuildSupportMojo {
 
-    @Parameter(property = "docker.skip.tag", defaultValue = "false")
-    private boolean skipTag;
-
     @Parameter(property = "docker.skip.build", defaultValue = "false")
     protected boolean skipBuild;
+    
+    /** 
+     * Skip building tags
+     */
+    @Parameter(property = "docker.skip.tag", defaultValue = "false")
+    protected boolean skipTag;
 
     @Override
     protected void executeInternal(ServiceHub hub) throws DockerAccessException, MojoExecutionException {

--- a/src/main/java/io/fabric8/maven/docker/PushMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/PushMojo.java
@@ -22,7 +22,13 @@ public class PushMojo extends AbstractDockerMojo {
 
     @Parameter(property = "docker.skip.push", defaultValue = "false")
     private boolean skipPush;
-
+    
+    /** 
+     * Skip building tags
+     */
+    @Parameter(property = "docker.skip.tag", defaultValue = "false")
+    private boolean skipTag;
+    
     @Parameter(property = "docker.push.retries", defaultValue = "0")
     private int retries;
 
@@ -35,6 +41,6 @@ public class PushMojo extends AbstractDockerMojo {
             return;
         }
 
-        hub.getRegistryService().pushImages(getResolvedImages(), retries, getRegistryConfig(pushRegistry));
+        hub.getRegistryService().pushImages(getResolvedImages(), retries, getRegistryConfig(pushRegistry), skipTag);
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/RemoveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/RemoveMojo.java
@@ -19,12 +19,12 @@ import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.QueryService;
 import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.util.ImageName;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -52,7 +52,13 @@ public class RemoveMojo extends AbstractDockerMojo {
 
     @Parameter(property = "docker.removeMode")
     private String removeMode;
-
+    
+    /** 
+     * Skip building tags
+     */
+    @Parameter(property = "docker.skip.tag", defaultValue = "false")
+    private boolean skipTag;
+    
     @Override
     protected void executeInternal(ServiceHub hub) throws DockerAccessException {
         for (ImageConfiguration image : getResolvedImages()) {
@@ -61,9 +67,11 @@ public class RemoveMojo extends AbstractDockerMojo {
             if (imageShouldBeRemoved(image)) {
                 removeImage(hub, name);
 
-                // Remove any tagged images
-                for (String tag: getImageBuildTags(image)){
-                    removeImage(hub, name + ":" + tag);
+                if(!skipTag) {
+                    // Remove any tagged images
+                    for (String tag: getImageBuildTags(image)){
+                        removeImage(hub, new ImageName(name, tag).getFullName());
+                    }
                 }
             }
         }

--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -37,11 +37,12 @@ public class RegistryService {
      * @param imageConfigs images to push (but only if they have a build configuration)
      * @param retries how often to retry
      * @param registryConfig a global registry configuration
+     * @param skipTag flag to skip pushing tagged images
      * @throws DockerAccessException
      * @throws MojoExecutionException
      */
     public void pushImages(Collection<ImageConfiguration> imageConfigs,
-                           int retries, RegistryConfig registryConfig) throws DockerAccessException, MojoExecutionException {
+                           int retries, RegistryConfig registryConfig, boolean skipTag) throws DockerAccessException, MojoExecutionException {
         for (ImageConfiguration imageConfig : imageConfigs) {
             BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
             String name = imageConfig.getName();
@@ -58,9 +59,11 @@ public class RegistryService {
                 docker.pushImage(name, authConfig, configuredRegistry, retries);
                 log.info("Pushed %s in %s", name, EnvUtil.formatDurationTill(start));
 
-                for (String tag : imageConfig.getBuildConfiguration().getTags()) {
-                    if (tag != null) {
-                        docker.pushImage(new ImageName(name, tag).getFullName(), authConfig, configuredRegistry, retries);
+                if (!skipTag) {
+                    for (String tag : imageConfig.getBuildConfiguration().getTags()) {
+                        if (tag != null) {
+                            docker.pushImage(new ImageName(name, tag).getFullName(), authConfig, configuredRegistry, retries);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When pushing and removing images, the docker.skip.tag property is not
used and can cause errors because the plugin will try to push and/or
remove image tags that don't exist because they were skipped during the
build process.

https://github.com/fabric8io/docker-maven-plugin/issues/869

Fix bug in removing tagged images

Code to remove tagged images was not creating the image name correctly

Signed-off-by: Mark Whelan <mbwhelan@gmail.com>