### PR TITLE
 Changing the place where the "USER" command is put in the generated Dockerfile

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
@@ -105,6 +105,7 @@ public class DockerFileBuilder {
         addPorts(b);
 
         addCopy(b);
+        addUser(b);
         addWorkdir(b);
         addRun(b);
         addVolumes(b);
@@ -114,7 +115,6 @@ public class DockerFileBuilder {
         addCmd(b);
         addEntryPoint(b);
 
-        addUser(b);
 
         return b.toString();
     }

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
@@ -194,7 +194,7 @@ public class DockerFileBuilderTest {
     public void testUser() {
         String dockerFile = new DockerFileBuilder().assemblyUser("jboss:jboss:jboss").user("bob")
                                                    .add("a","a/nested").add("b","b/deeper/nested").content();
-        String EXPECTED_REGEXP = "USER bob$";
+        String EXPECTED_REGEXP = "USER bob";
         Pattern pattern = Pattern.compile(EXPECTED_REGEXP);
         assertTrue(pattern.matcher(dockerFile).find());
     }


### PR DESCRIPTION
Right now, the "USER" command is always put last if you generate the Dockerfile from the pom. It isn't very useful this way because normally you want to run some commands after USER.