### PR TITLE
Fixes #960 Property placeholders are not interpolated when they are only thing in XML

### DIFF
--- a/src/main/asciidoc/inc/_implicit-properties.adoc
+++ b/src/main/asciidoc/inc/_implicit-properties.adoc
@@ -1,0 +1,7 @@
+= Implicit properties
+
+There are some implicit configurations in docker maven plugin that are not so straightforward. These are simply workarouds to get docker-maven-plugin's flow right; just to overcome limitations of Maven and other things. Some of these are mentioned below:
+
+* If the only value of the `env` parameter is a docker-maven-plugin internal property which has been set implicitly you have to prefix the property with a single `+` like in `+${docker.container.test.ip}`. This is necessary due to some Maven limitations which simply interpolates a lone, non defined property, to an empty string which can't then be replaced by this plugin after the initial interpolation phase.
+
+* When providing port mapping in a format like `host.ip:host.port:80`, you need to prefix property with a single `+`. In this form, the host ip of the container will be placed into a Maven property name host.ip. If docker reports that value to be 0.0.0.0, the value of docker.host.address will be substituted instead. In the event you want to use this form and have the container bind to a specific hostname/ip address, you can declare a Maven property of the same name (host.ip in this example) containing the value to use. host:port works in the same way as described above.

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -44,4 +44,6 @@ include::inc/_registry.adoc[]
 
 include::inc/_authentication.adoc[]
 
+include::inc/_implicit-properties.adoc[]
+
 include::inc/_links.adoc[]

--- a/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
@@ -57,6 +57,12 @@ public class ContainerCreateConfig {
                 String value = entry.getValue();
                 if (value == null) {
                     value = "";
+                } else if(value.matches("^\\+\\$\\{.*\\}$")) {
+                    /*
+                     * This case is to handle the Maven interpolation issue which used
+                     * to occur when using ${..} only without any suffix.
+                     */
+                    value = value.substring(1, value.length());
                 }
                 envProps.put(entry.getKey(), StrSubstitutor.replace(value, mavenProps));
             }

--- a/src/test/java/io/fabric8/maven/docker/access/ContainerCreateConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ContainerCreateConfigTest.java
@@ -41,11 +41,14 @@ public class ContainerCreateConfigTest {
         cc.environment(copyPropsToFile(), envMap, Collections.<String, String>emptyMap());
         JSONArray env = getEnvArray(cc);
         assertNotNull(env);
-        assertEquals(3, env.length());
+        assertEquals(6, env.length());
         List<String> envAsString = convertToList(env);
         assertTrue(envAsString.contains("JAVA_OPTS=-Xmx512m"));
         assertTrue(envAsString.contains("TEST_SERVICE=SECURITY"));
         assertTrue(envAsString.contains("EXTERNAL_ENV=TRUE"));
+        assertTrue(envAsString.contains("TEST_HTTP_ADDR=${docker.container.consul.ip}"));
+        assertTrue(envAsString.contains("TEST_CONSUL_IP=+${docker.container.consul.ip}:8080"));
+        assertTrue(envAsString.contains("TEST_CONSUL_IP_WITHOUT_DELIM=${docker.container.consul.ip}:8225"));
     }
 
     @Test
@@ -53,7 +56,7 @@ public class ContainerCreateConfigTest {
         ContainerCreateConfig cc = new ContainerCreateConfig("testImage");
         cc.environment(null, getEnvMap(),Collections.<String, String>emptyMap());
         JSONArray env = getEnvArray(cc);
-        assertEquals(2, env.length());
+        assertEquals(5, env.length());
     }
 
     @Test
@@ -122,6 +125,9 @@ public class ContainerCreateConfigTest {
         Map<String,String> envMap = new HashMap<>();
         envMap.put("JAVA_OPTS", "-Xmx512m");
         envMap.put("TEST_SERVICE", "LOGGING");
+        envMap.put("TEST_HTTP_ADDR", "+${docker.container.consul.ip}");
+        envMap.put("TEST_CONSUL_IP", "+${docker.container.consul.ip}:8080");
+        envMap.put("TEST_CONSUL_IP_WITHOUT_DELIM", "${docker.container.consul.ip}:8225");
         return envMap;
     }
 


### PR DESCRIPTION
Fixes #960 

Somehow these ${...} parameters are not being picked up by maven
properly when used solely without any suffix string literal, the maven
parameter string comes off as NULL. So adding a workaround for this.
We'll use +${...} as a parameter which would be handled by dmp afterwards