### PR TITLE
Fixes #957 Simplify configuration

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -14,6 +14,8 @@
   - Introduced a `removeMode` for selecting the images to remove
   - Introduced a `breakOnError` for the `postStart` and `preStop` hooks in the 
     wait configuration ([#914](https://github.com/fabric8io/docker-maven-plugin/issues/914))
+  - Simplified Configuration: When only a single image is build with Dockerfile, no need to provide too much parameters
+    in configuration; build ImageConfiguration dynamically with given defaults.
     
 Please note that `autoPullMode` is deprecated now and the behaviour of the `autoPullMode == always` has been changed slightly so that now, it really always pulls the image from the registry. Also `removeAll` for `docker:remove` is deprecated in favor of `removeMode` (and the default mode has changed slightly). Please refer to the documentation for more information.
 

--- a/samples/simple-configuration/pom.xml
+++ b/samples/simple-configuration/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>simple-configuration-sample</groupId>
+    <artifactId>simple-configuration</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.24-SNAPSHOT</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/samples/simple-configuration/src/main/docker/Dockerfile
+++ b/samples/simple-configuration/src/main/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM busybox:latest

--- a/src/main/asciidoc/inc/_image-configuration.adoc
+++ b/src/main/asciidoc/inc/_image-configuration.adoc
@@ -12,3 +12,9 @@ include::image/_configuration.adoc[]
 Either a `<build>` or `<run>` section must be present. These are explained in details in the corresponding goal sections.
 
 include::image/_example.adoc[]
+
+When only a single image is build with Dockerfile, no need to provide too much parameters in configuration. ImageConfiguration can be dynamically built with the given defaults.
+
+include::image/_simple_configuration_example.adoc[]
+
+It requires a single Dockerfile to be in the base directory or `/src/main/docker`.The image name would default to `${project.groupId}/${project.artifactId}:${project.version}`, but this can be configured with a `docker.autoConfiguration.imageName` flag

--- a/src/main/asciidoc/inc/image/_simple_configuration_example.adoc
+++ b/src/main/asciidoc/inc/image/_simple_configuration_example.adoc
@@ -1,0 +1,9 @@
+
+.Simple configuration Example
+[source,xml]
+----
+<plugin>
+  <groupId>io.fabric8</groupId>
+  <artifactId>docker-maven-plugin</artifactId>
+</plugin>
+----

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -102,6 +102,9 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     @Parameter(property = "docker.removeVolumes", defaultValue = "false")
     protected boolean removeVolumes;
 
+    @Parameter(property = "docker.autoConfiguration.imageName", defaultValue = "")
+    protected String imageName;
+
     @Parameter(property = "docker.apiVersion")
     private String apiVersion;
 

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import io.fabric8.maven.docker.util.*;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
 /**
  * @author roland
@@ -151,6 +152,16 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
             minimalApiVersion = EnvUtil.extractLargerVersion(minimalApiVersion, run.initAndValidate());
         }
         return minimalApiVersion;
+    }
+
+    public static ImageConfiguration getDefaultImageConfiguration(String defaultImageName, String projectBaseDir) {
+        ImageConfiguration imageConfiguration = new ImageConfiguration.Builder()
+                .name(defaultImageName)
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .dockerFileDir(DockerFileUtil.getDockerFileDirectory(projectBaseDir))
+                        .build())
+                .build();
+        return imageConfiguration;
     }
 
     // =========================================================================

--- a/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
@@ -119,6 +119,27 @@ public class DockerFileUtil {
                 .withExpressionMarkers(delimiters[0], delimiters[1]);
     }
 
+    /**
+     * Fetch the location of docker file in case of simple configuration
+     *
+     * @param projectBaseDirPath Absolute path to project's base directory.
+     * @return directory containing the Dockerfile
+     */
+    public static String getDockerFileDirectory(String projectBaseDirPath) {
+        if(checkFileExists(projectBaseDirPath + "/Dockerfile")) {
+            return projectBaseDirPath;
+        } else if(checkFileExists(projectBaseDirPath + "/src/main/docker/Dockerfile")){
+            return projectBaseDirPath + "/src/main/docker";
+        } else {
+            throw new IllegalStateException("Unable to locate Dockerfile");
+        }
+    }
+
+    private static boolean checkFileExists(String filePath) {
+        File aFile = new File(filePath);
+        return aFile.exists() && !aFile.isDirectory();
+    }
+
     private static String[] extractDelimiters(String filter) {
         if (filter == null ||
             filter.equalsIgnoreCase("false") ||


### PR DESCRIPTION
When only a single image is build with Dockerfile, no need to provide
too much parameters in configuration; build ImageConfiguration dynamically
with the given defaults.
#957 