### PR TITLE
Unbreak merge of LogConfiguration config 

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
 * **0.24-SNAPSHOT**
   - Fix possible NPE when logging to a file and the parent directory does not exist yet (#911) (#940)
   - Change content type to "application/json" when talking to the Docker daemon (#945)
+  - Add support for merging properties and POM configuration (#948)
 
 * **0.24.0** (2018-02-07)
   - Respect system properties for ECR authentication ([#897](https://github.com/fabric8io/docker-maven-plugin/issues/897))

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -358,7 +358,7 @@ public class StartMojo extends AbstractDockerMojo {
         if (runConfig != null) {
             LogConfiguration logConfig = runConfig.getLogConfiguration();
             if (logConfig != null) {
-                return logConfig.isEnabled();
+                return Boolean.TRUE == logConfig.isEnabled();
             } else {
                 // Default is to show logs if "follow" is true
                 return follow;

--- a/src/main/java/io/fabric8/maven/docker/config/LogConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/LogConfiguration.java
@@ -14,7 +14,7 @@ public class LogConfiguration implements Serializable {
     public static final LogConfiguration DEFAULT = new LogConfiguration(false, null, null, null, null, null);
 
     @Parameter(defaultValue = "true")
-    private boolean enabled = true;
+    private Boolean enabled;
 
     @Parameter
     private String prefix;
@@ -33,7 +33,7 @@ public class LogConfiguration implements Serializable {
 
     public LogConfiguration() {}
 
-    private LogConfiguration(boolean enabled, String prefix, String color, String date, String file, LogDriver driver) {
+    private LogConfiguration(Boolean enabled, String prefix, String color, String date, String file, LogDriver driver) {
         this.enabled = enabled;
         this.prefix = prefix;
         this.date = date;
@@ -54,7 +54,7 @@ public class LogConfiguration implements Serializable {
         return color;
     }
 
-    public boolean isEnabled() {
+    public Boolean isEnabled() {
         return enabled;
     }
 
@@ -95,7 +95,7 @@ public class LogConfiguration implements Serializable {
     // =============================================================================
 
     public static class Builder {
-        private boolean enabled = true;
+        private Boolean enabled = true;
         private String prefix, date, color, file;
         private Map<String, String> driverOpts;
         private String driverName;
@@ -134,6 +134,14 @@ public class LogConfiguration implements Serializable {
             return this;
         }
 
+        /**
+         * Returns true if all options (except enabled) are null, used to decide value of enabled.
+         *
+         * @return
+         */
+        public boolean isBlank() {
+            return prefix == null && date == null && color == null && file == null && driverName == null && driverOpts == null;
+        }
 
         public LogConfiguration build() {
             return new LogConfiguration(enabled, prefix, color, date, file,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -238,10 +238,14 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .prefix(valueProvider.getString(LOG_PREFIX, config == null ? null : config.getPrefix()))
             .logDriverName(valueProvider.getString(LOG_DRIVER_NAME, config == null || config.getDriver() == null ? null : config.getDriver().getName()))
             .logDriverOpts(valueProvider.getMap(LOG_DRIVER_OPTS, config == null || config.getDriver() == null ? null : config.getDriver().getOpts()));
-        Boolean enabled = valueProvider.getBoolean(LOG_ENABLED, config == null ? null : config.isEnabled());
-        if (enabled != null) {
-            builder.enabled(enabled);
-        }
+
+        Boolean configEnabled = config != null ? config.isEnabled() : null;
+        Boolean enabled = valueProvider.getBoolean(LOG_ENABLED, configEnabled);
+
+        if(enabled == null)
+            enabled = configEnabled == Boolean.TRUE || !builder.isBlank();
+
+        builder.enabled(enabled);
         return builder.build();
     }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -54,9 +54,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         String name = valueProvider.getString(NAME, fromConfig.getName());
         String alias = valueProvider.getString(ALIAS, fromConfig.getAlias());
 
-        if (name == null)
+        if (name == null) {
             throw new IllegalArgumentException(String.format("Mandatory property [%s] is not defined", NAME));
-
+        }
+        
         return Collections.singletonList(
                 new ImageConfiguration.Builder()
                         .name(name)
@@ -118,9 +119,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
 
     private RunImageConfiguration extractRunConfiguration(ImageConfiguration fromConfig, ValueProvider valueProvider) {
         RunImageConfiguration config = fromConfig.getRunConfiguration();
-        if(config.isDefault())
+        if (config.isDefault()) {
             config = null;
-
+        }
+        
         return new RunImageConfiguration.Builder()
                 .capAdd(valueProvider.getList(CAP_ADD, config == null ? null : config.getCapAdd()))
                 .capDrop(valueProvider.getList(CAP_DROP, config == null ? null : config.getCapDrop()))
@@ -197,8 +199,9 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                     .mode(valueProvider.getString(HEALTHCHECK_MODE, config == null || config.getMode() == null ? null : config.getMode().name()))
                     .cmd(extractArguments(valueProvider, HEALTHCHECK_CMD, config == null ? null : config.getCmd()))
                     .build();
-        }else
+        } else {
             return config;
+        }
     }
 
     // Extract only the values of the port mapping
@@ -218,8 +221,9 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
 
     private String extractArguments(ValueProvider valueProvider, ConfigKey configKey, Arguments alternative) {
         String rawAlternative = null;
-        if(alternative != null)
+        if (alternative != null) {
             rawAlternative = alternative.getShell();
+        }
 
         return valueProvider.getString(configKey, rawAlternative);
     }
@@ -242,9 +246,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         Boolean configEnabled = config != null ? config.isEnabled() : null;
         Boolean enabled = valueProvider.getBoolean(LOG_ENABLED, configEnabled);
 
-        if(enabled == null)
+        if (enabled == null) {
             enabled = configEnabled == Boolean.TRUE || !builder.isBlank();
-
+        }
+        
         builder.enabled(enabled);
         return builder.build();
     }
@@ -291,7 +296,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
 
     private List<UlimitConfig> extractUlimits(List<UlimitConfig> config, ValueProvider valueProvider) {
         List<String> other = null;
-        if(config != null) {
+        if (config != null) {
             other = new ArrayList<>();
             // Convert back to string for potential merge
             for (UlimitConfig ulimitConfig : config) {


### PR DESCRIPTION
Follow-up on #948, bugfix. LogConfiguration was always created with enabled=true, even if no log properties where set.

Desired functionality: if any config or property in LogConfiguration is set, enabled shall be true.

Also added short note to changelog.