### PR TITLE
Network aliases management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .settings
 .*.md.html
 temp
+/.metadata/

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ target/
 .settings
 .*.md.html
 temp
-/.metadata/

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -190,12 +190,9 @@ class DockerComposeServiceWrapper {
             	} else if(aliases instanceof LinkedHashMap) {
             		LinkedHashMap<String, ArrayList<String>> map = (LinkedHashMap<String, ArrayList<String>>)aliases;
             		if(map.containsKey("aliases")) {
-            			map.get("aliases").forEach(new Consumer<String>() {
-							@Override
-							public void accept(String t) {
-								ret.addAlias(t);
-							}
-						});
+            			for(String alias : map.get("aliases")) {
+            				ret.addAlias(alias);
+            			}
             		} else {
             			throwIllegalArgumentException("'networks:' Aliases must be given as a linked has map of strings. 'aliases' key not founded");
             		}

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -1,9 +1,20 @@
 package io.fabric8.maven.docker.config.handler.compose;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import io.fabric8.maven.docker.config.*;
+import io.fabric8.maven.docker.config.Arguments;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.config.LogConfiguration;
+import io.fabric8.maven.docker.config.NetworkConfig;
+import io.fabric8.maven.docker.config.RestartPolicy;
+import io.fabric8.maven.docker.config.RunVolumeConfiguration;
+import io.fabric8.maven.docker.config.UlimitConfig;
 import io.fabric8.maven.docker.util.VolumeBindingUtil;
 
 
@@ -186,18 +197,18 @@ class DockerComposeServiceWrapper {
                     for (String alias : (List<String>) aliases) {
                         ret.addAlias(alias);
                     }
-                } else if (aliases instanceof LinkedHashMap) {
-                    LinkedHashMap<String, ArrayList<String>> map = (LinkedHashMap<String, ArrayList<String>>) aliases;
+                } else if (aliases instanceof Map) {
+                	Map<String, List<String>> map = (Map<String, List<String>>) aliases;
                     if (map.containsKey("aliases")) {
                         for (String alias : map.get("aliases")) {
                             ret.addAlias(alias);
                         }
                     } else {
                         throwIllegalArgumentException(
-                                "'networks:' Aliases must be given as a linked has map of strings. 'aliases' key not founded");
+                                "'networks:' Aliases must be given as a map of strings. 'aliases' key not founded");
                     }
                 } else {
-                    throwIllegalArgumentException("'networks:' Aliases must be given as a list of string ");
+                    throwIllegalArgumentException("'networks:' No aliases entry found in network config map");
                 }
             }
             return ret;

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -7,7 +7,6 @@ import java.util.function.Consumer;
 import io.fabric8.maven.docker.config.*;
 import io.fabric8.maven.docker.util.VolumeBindingUtil;
 
-
 class DockerComposeServiceWrapper {
 
     private final Map<String, Object> configuration;
@@ -17,15 +16,14 @@ class DockerComposeServiceWrapper {
     private final File baseDir;
 
     DockerComposeServiceWrapper(String serviceName, File composeFile, Map<String, Object> serviceDefinition,
-                                ImageConfiguration enclosingImageConfig, File baseDir) {
+            ImageConfiguration enclosingImageConfig, File baseDir) {
         this.name = serviceName;
         this.composeFile = composeFile;
         this.configuration = serviceDefinition;
         this.enclosingImageConfig = enclosingImageConfig;
 
         if (!baseDir.isAbsolute()) {
-            throw new IllegalArgumentException(
-                    "Expected the base directory '" + baseDir + "' to be an absolute path.");
+            throw new IllegalArgumentException("Expected the base directory '" + baseDir + "' to be an absolute path.");
         }
         this.baseDir = baseDir;
     }
@@ -55,7 +53,7 @@ class DockerComposeServiceWrapper {
         if (build instanceof String) {
             return (String) build;
         }
-        if (! (build instanceof Map)) {
+        if (!(build instanceof Map)) {
             throwIllegalArgumentException("build:' must be either a String or a Map");
         }
         Map<String, String> buildConfig = (Map<String, String>) build;
@@ -121,7 +119,8 @@ class DockerComposeServiceWrapper {
     }
 
     Map<String, String> getEnvironment() {
-        // TODO: load the env files from compose as given with env_file and add them all to the map
+        // TODO: load the env files from compose as given with env_file and add them all
+        // to the map
         return asMap("environment");
     }
 
@@ -153,10 +152,8 @@ class DockerComposeServiceWrapper {
             throwIllegalArgumentException("'logging' has to be a map and not " + logConfig.getClass());
         }
         Map<String, Object> config = (Map<String, Object>) logConfig;
-        return new LogConfiguration.Builder()
-            .logDriverName((String) config.get("driver"))
-            .logDriverOpts((Map<String, String>) config.get("options"))
-            .build();
+        return new LogConfiguration.Builder().logDriverName((String) config.get("driver"))
+                .logDriverOpts((Map<String, String>) config.get("options")).build();
     }
 
     NetworkConfig getNetworkConfig() {
@@ -175,7 +172,7 @@ class DockerComposeServiceWrapper {
             }
             return new NetworkConfig(NetworkConfig.Mode.custom, toJoin.get(0));
         } else if (networks instanceof Map) {
-            Map<String,Object> toJoin = (Map<String, Object>) networks;
+            Map<String, Object> toJoin = (Map<String, Object>) networks;
             if (toJoin.size() > 1) {
                 throwIllegalArgumentException("'networks:' Only one custom network to join is supported currently");
             }
@@ -183,22 +180,23 @@ class DockerComposeServiceWrapper {
             final NetworkConfig ret = new NetworkConfig(NetworkConfig.Mode.custom, custom);
             Object aliases = toJoin.get(custom);
             if (aliases != null) {
-            	if(aliases instanceof List) {
+                if (aliases instanceof List) {
                     for (String alias : (List<String>) aliases) {
                         ret.addAlias(alias);
                     }
-            	} else if(aliases instanceof LinkedHashMap) {
-            		LinkedHashMap<String, ArrayList<String>> map = (LinkedHashMap<String, ArrayList<String>>)aliases;
-            		if(map.containsKey("aliases")) {
-            			for(String alias : map.get("aliases")) {
-            				ret.addAlias(alias);
-            			}
-            		} else {
-            			throwIllegalArgumentException("'networks:' Aliases must be given as a linked has map of strings. 'aliases' key not founded");
-            		}
-            	} else {
-            		throwIllegalArgumentException("'networks:' Aliases must be given as a list of string ");
-            	}                
+                } else if (aliases instanceof LinkedHashMap) {
+                    LinkedHashMap<String, ArrayList<String>> map = (LinkedHashMap<String, ArrayList<String>>) aliases;
+                    if (map.containsKey("aliases")) {
+                        for (String alias : map.get("aliases")) {
+                            ret.addAlias(alias);
+                        }
+                    } else {
+                        throwIllegalArgumentException(
+                                "'networks:' Aliases must be given as a linked has map of strings. 'aliases' key not founded");
+                    }
+                } else {
+                    throwIllegalArgumentException("'networks:' Aliases must be given as a list of string ");
+                }
             }
             return ret;
         } else {
@@ -216,12 +214,12 @@ class DockerComposeServiceWrapper {
             String port = fromYml.get(i);
             if (port.contains(":")) {
                 ports.add(port);
-            }
-            else {
+            } else {
                 /*
-                 * docker-compose allows just the port number which triggers a random port and the plugin does not, so construct a property
-                 * name to mimic the required behavior. names will always based on position, and not the number of times we create the
-                 * string.
+                 * docker-compose allows just the port number which triggers a random port and
+                 * the plugin does not, so construct a property name to mimic the required
+                 * behavior. names will always based on position, and not the number of times we
+                 * create the string.
                  */
                 ports.add(String.format("%s_port_%s:%s", getAlias(), i + 1, port));
             }
@@ -249,7 +247,8 @@ class DockerComposeServiceWrapper {
             } else if (val instanceof Integer) {
                 ret.add(new UlimitConfig(ulimit, (Integer) val, null));
             } else {
-                throwIllegalArgumentException("'ulimits:' invalid limit value " + val + " (class : " + val.getClass() + ")");
+                throwIllegalArgumentException(
+                        "'ulimits:' invalid limit value " + val + " (class : " + val.getClass() + ")");
             }
         }
         return ret;
@@ -308,8 +307,7 @@ class DockerComposeServiceWrapper {
         if (restart.contains(":")) {
             String[] parts = restart.split("\\:", 2);
             builder.name(parts[0]).retry(Integer.valueOf(parts[1]));
-        }
-        else {
+        } else {
             builder.name(restart);
         }
 
@@ -405,7 +403,8 @@ class DockerComposeServiceWrapper {
         } else if (command instanceof List) {
             return new Arguments((List<String>) command);
         } else {
-            throwIllegalArgumentException(String.format("'%s' must be either String or List but not %s", label, command.getClass()));
+            throwIllegalArgumentException(
+                    String.format("'%s' must be either String or List but not %s", label, command.getClass()));
             return null;
         }
     }

--- a/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
@@ -39,33 +39,43 @@ import static org.junit.Assert.fail;
  */
 public class DockerComposeConfigHandlerTest {
 
-	@Injectable
-	ImageConfiguration unresolved;
+    @Injectable
+    ImageConfiguration unresolved;
 
-	@Mocked
-	MavenProject project;
+    @Mocked
+    MavenProject project;
 
-	@Mocked
-	MavenSession session;
+    @Mocked
+    MavenSession session;
 
-	@Mocked
-	MavenReaderFilter readerFilter;
+    @Mocked
+    MavenReaderFilter readerFilter;
 
-	private DockerComposeConfigHandler handler;
+    private DockerComposeConfigHandler handler;
 
-	@Before
-	public void setUp() throws Exception {
-		handler = new DockerComposeConfigHandler();
-		handler.readerFilter = readerFilter;
-	}
+    @Before
+    public void setUp() throws Exception {
+        handler = new DockerComposeConfigHandler();
+        handler.readerFilter = readerFilter;
+    }
 
-	@Test
-	public void simple() throws IOException, MavenFilteringException {
-		setupComposeExpectations("docker-compose.yml");
-		List<ImageConfiguration> configs = handler.resolve(unresolved, project, session);
-		assertEquals(1, configs.size());
-		validateRunConfiguration(configs.get(0).getRunConfiguration());
-	}
+
+    @Test
+    public void simple() throws IOException, MavenFilteringException {
+        setupComposeExpectations("docker-compose.yml");
+        List<ImageConfiguration> configs = handler.resolve(unresolved, project, session);
+        assertEquals(1, configs.size());
+        validateRunConfiguration(configs.get(0).getRunConfiguration());
+    }
+
+    @Test
+    public void positiveVersionTest() throws IOException, MavenFilteringException {
+        for (String composeFile : new String[] { "version/compose-version-2.yml", "version/compose-version-2x.yml"} ) {
+            setupComposeExpectations(composeFile);
+            assertNotNull(handler.resolve(unresolved, project, session));
+        }
+
+    }
 
 	@Test
 	public void networkAliases() throws IOException, MavenFilteringException {
@@ -89,175 +99,151 @@ public class DockerComposeConfigHandlerTest {
 		assertEquals("network1", netSvc.getName());
 		assertEquals(1, netSvc.getAliases().size());
 		assertEquals("alias1", netSvc.getAliases().get(0));
-}
-
-	@Test
-	public void positiveVersionTest() throws IOException, MavenFilteringException {
-		for (String composeFile : new String[] { "version/compose-version-2.yml", "version/compose-version-2x.yml" }) {
-			setupComposeExpectations(composeFile);
-			assertNotNull(handler.resolve(unresolved, project, session));
-		}
-
 	}
+	
+    @Test
+    public void negativeVersionTest() throws IOException, MavenFilteringException {
+        for (String composeFile : new String[] { "version/compose-wrong-version.yml", "version/compose-no-version.yml"} ) {
+            try {
+                setupComposeExpectations(composeFile);
+                handler.resolve(unresolved, project, session);
+                fail();
+            } catch (ExternalConfigHandlerException exp) {
+                assertTrue(exp.getMessage().contains(("2.x")));
+            }
+        }
 
-	@Test
-	public void negativeVersionTest() throws IOException, MavenFilteringException {
-		for (String composeFile : new String[] { "version/compose-wrong-version.yml",
-				"version/compose-no-version.yml" }) {
-			try {
-				setupComposeExpectations(composeFile);
-				handler.resolve(unresolved, project, session);
-				fail();
-			} catch (ExternalConfigHandlerException exp) {
-				assertTrue(exp.getMessage().contains(("2.x")));
-			}
-		}
+    }
 
-	}
+    private void setupComposeExpectations(final String file) throws IOException, MavenFilteringException {
+        new Expectations() {{
+            final File input = getAsFile("/compose/" + file);
 
-	private void setupComposeExpectations(final String file) throws IOException, MavenFilteringException {
-		new Expectations() {
-			{
-				final File input = getAsFile("/compose/" + file);
+            unresolved.getExternalConfig();
+            result = new HashMap<String,String>() {{
+                put("composeFile", input.getAbsolutePath());
+                // provide a base directory that actually exists, so that relative paths referenced by the
+                // docker-compose.yaml file can be resolved
+                // (note: this is different than the directory returned by 'input.getParent()')
+                URL baseResource = this.getClass().getResource("/");
+                String baseDir = baseResource.getFile();
+                assertNotNull("Classpath resource '/' does not have a File: '" + baseResource, baseDir);
+                assertTrue("Classpath resource '/' does not resolve to a File: '" + new File(baseDir) + "' does not exist.", new File(baseDir).exists());
+                put("basedir", baseDir);
+            }};
 
-				unresolved.getExternalConfig();
-				result = new HashMap<String, String>() {
-					{
-						put("composeFile", input.getAbsolutePath());
-						// provide a base directory that actually exists, so that relative paths
-						// referenced by the
-						// docker-compose.yaml file can be resolved
-						// (note: this is different than the directory returned by 'input.getParent()')
-						URL baseResource = this.getClass().getResource("/");
-						String baseDir = baseResource.getFile();
-						assertNotNull("Classpath resource '/' does not have a File: '" + baseResource, baseDir);
-						assertTrue("Classpath resource '/' does not resolve to a File: '" + new File(baseDir)
-								+ "' does not exist.", new File(baseDir).exists());
-						put("basedir", baseDir);
-					}
-				};
+            readerFilter.filter((MavenReaderFilterRequest) any);
+            result = new FileReader(input);
+        }};
+    }
 
-				readerFilter.filter((MavenReaderFilterRequest) any);
-				result = new FileReader(input);
-			}
-		};
-	}
+    private File getAsFile(String resource) throws IOException {
+        File tempFile = File.createTempFile("compose",".yml");
+        InputStream is = getClass().getResourceAsStream(resource);
+        FileUtils.copyInputStreamToFile(is,tempFile);
+        return tempFile;
+    }
 
-	private File getAsFile(String resource) throws IOException {
-		File tempFile = File.createTempFile("compose", ".yml");
-		InputStream is = getClass().getResourceAsStream(resource);
-		FileUtils.copyInputStreamToFile(is, tempFile);
-		return tempFile;
-	}
 
-	void validateRunConfiguration(RunImageConfiguration runConfig) {
+     void validateRunConfiguration(RunImageConfiguration runConfig) {
 
-		validateVolumeConfig(runConfig.getVolumeConfiguration());
+        validateVolumeConfig(runConfig.getVolumeConfiguration());
 
-		assertEquals(a("CAP"), runConfig.getCapAdd());
-		assertEquals(a("CAP"), runConfig.getCapDrop());
-		assertEquals("command.sh", runConfig.getCmd().getShell());
-		assertEquals(a("8.8.8.8"), runConfig.getDns());
-		assertEquals(a("example.com"), runConfig.getDnsSearch());
-		assertEquals("domain.com", runConfig.getDomainname());
-		assertEquals("entrypoint.sh", runConfig.getEntrypoint().getShell());
-		assertEquals(a("localhost:127.0.0.1"), runConfig.getExtraHosts());
-		assertEquals("subdomain", runConfig.getHostname());
-		assertEquals(a("redis", "link1"), runConfig.getLinks());
-		assertEquals((Long) 1L, runConfig.getMemory());
-		assertEquals((Long) 1L, runConfig.getMemorySwap());
-		assertEquals(RunImageConfiguration.NamingStrategy.none, runConfig.getNamingStrategy());
-		assertEquals(null, runConfig.getEnvPropertyFile());
+        assertEquals(a("CAP"), runConfig.getCapAdd());
+        assertEquals(a("CAP"), runConfig.getCapDrop());
+        assertEquals("command.sh", runConfig.getCmd().getShell());
+        assertEquals(a("8.8.8.8"), runConfig.getDns());
+        assertEquals(a("example.com"), runConfig.getDnsSearch());
+        assertEquals("domain.com", runConfig.getDomainname());
+        assertEquals("entrypoint.sh", runConfig.getEntrypoint().getShell());
+        assertEquals(a("localhost:127.0.0.1"), runConfig.getExtraHosts());
+        assertEquals("subdomain", runConfig.getHostname());
+        assertEquals(a("redis","link1"), runConfig.getLinks());
+        assertEquals((Long) 1L, runConfig.getMemory());
+        assertEquals((Long) 1L, runConfig.getMemorySwap());
+        assertEquals(RunImageConfiguration.NamingStrategy.none, runConfig.getNamingStrategy());
+        assertEquals(null,runConfig.getEnvPropertyFile());
 
-		assertEquals(null, runConfig.getPortPropertyFile());
-		assertEquals(a("8081:8080"), runConfig.getPorts());
-		assertEquals(true, runConfig.getPrivileged());
-		assertEquals("tomcat", runConfig.getUser());
-		assertEquals(a("from"), runConfig.getVolumeConfiguration().getFrom());
-		assertEquals("foo", runConfig.getWorkingDir());
+        assertEquals(null, runConfig.getPortPropertyFile());
+        assertEquals(a("8081:8080"), runConfig.getPorts());
+        assertEquals(true, runConfig.getPrivileged());
+        assertEquals("tomcat", runConfig.getUser());
+        assertEquals(a("from"), runConfig.getVolumeConfiguration().getFrom());
+        assertEquals("foo", runConfig.getWorkingDir());
 
-		validateEnv(runConfig.getEnv());
+        validateEnv(runConfig.getEnv());
 
-		// not sure it's worth it to implement 'equals/hashcode' for these
-		RestartPolicy policy = runConfig.getRestartPolicy();
-		assertEquals("on-failure", policy.getName());
-		assertEquals(1, policy.getRetry());
-	}
+        // not sure it's worth it to implement 'equals/hashcode' for these
+        RestartPolicy policy = runConfig.getRestartPolicy();
+        assertEquals("on-failure", policy.getName());
+        assertEquals(1, policy.getRetry());
+    }
 
-	/**
-	 * Validates the {@link RunVolumeConfiguration} by asserting that:
-	 * <ul>
-	 * <li>absolute host paths remain absolute</li>
-	 * <li>access controls are preserved</li>
-	 * <li>relative host paths are resolved to absolute paths correctly</li>
-	 * </ul>
-	 * 
-	 * @param toValidate
-	 *            the {@code RunVolumeConfiguration} being validated
-	 */
-	void validateVolumeConfig(RunVolumeConfiguration toValidate) {
-		final int expectedBindCnt = 4;
-		final List<String> binds = toValidate.getBind();
-		assertEquals("Expected " + expectedBindCnt + " bind statements", expectedBindCnt, binds.size());
+    /**
+     * Validates the {@link RunVolumeConfiguration} by asserting that:
+     * <ul>
+     *     <li>absolute host paths remain absolute</li>
+     *     <li>access controls are preserved</li>
+     *     <li>relative host paths are resolved to absolute paths correctly</li>
+     * </ul>
+     * @param toValidate the {@code RunVolumeConfiguration} being validated
+     */
+    void validateVolumeConfig(RunVolumeConfiguration toValidate) {
+        final int expectedBindCnt = 4;
+        final List<String> binds = toValidate.getBind();
+        assertEquals("Expected " + expectedBindCnt + " bind statements", expectedBindCnt, binds.size());
 
-		assertEquals(a("/foo", "/tmp:/tmp:rw", "namedvolume:/volume:ro"), binds.subList(0, expectedBindCnt - 1));
+        assertEquals(a("/foo", "/tmp:/tmp:rw", "namedvolume:/volume:ro"), binds.subList(0, expectedBindCnt - 1));
 
-		// The docker-compose.yml used for testing contains a volume binding string that
-		// uses relative paths in the
-		// host portion. Insure that the relative portion has been resolved properly.
-		String relativeBindString = binds.get(expectedBindCnt - 1);
-		assertHostBindingExists(relativeBindString);
-	}
+        // The docker-compose.yml used for testing contains a volume binding string that uses relative paths in the
+        // host portion.  Insure that the relative portion has been resolved properly.
+        String relativeBindString = binds.get(expectedBindCnt - 1);
+        assertHostBindingExists(relativeBindString);
+    }
 
-	/**
-	 * Parses the supplied binding string for the host portion, and insures the host
-	 * portion actually exists on the filesystem. Note this method is designed to
-	 * accommodate both Windows-style and *nix-style absolute paths.
-	 * <p>
-	 * The {@code docker-compose.yml} used for testing contains volume binding
-	 * strings which are <em>relative</em>. When the {@link RunVolumeConfiguration}
-	 * is built, relative paths in the host portion of the binding string are
-	 * resolved to absolute paths. This method expects a binding string that has
-	 * already had its relative paths <em>resolved</em> to absolute paths. It parses
-	 * the host portion of the binding string, and asserts that the path exists on
-	 * the system.
-	 * </p>
-	 *
-	 *
-	 * @param bindString
-	 *            a volume binding string that contains a host portion that is
-	 *            expected to exist on the local system
-	 */
-	private void assertHostBindingExists(String bindString) {
-		// System.err.println(">>>> " + bindString);
+    /**
+     * Parses the supplied binding string for the host portion, and insures the host portion actually exists on the
+     * filesystem.  Note this method is designed to accommodate both Windows-style and *nix-style absolute paths.
+     * <p>
+     * The {@code docker-compose.yml} used for testing contains volume binding strings which are <em>relative</em>.
+     * When the {@link RunVolumeConfiguration} is built, relative paths in the host portion of the binding string are
+     * resolved to absolute paths.  This method expects a binding string that has already had its relative paths
+     * <em>resolved</em> to absolute paths.  It parses the host portion of the binding string, and asserts that the path
+     * exists on the system.
+     * </p>
+     *
+     *
+     * @param bindString a volume binding string that contains a host portion that is expected to exist on the local
+     *                   system
+     */
+    private void assertHostBindingExists(String bindString) {
+//        System.err.println(">>>> " + bindString);
 
-		// Extract the host-portion of the volume binding string, accounting for windows
-		// platform paths and unix style
-		// paths. For example:
-		// C:\Users\foo\Documents\workspaces\docker-maven-plugin\target\test-classes\compose\version:/tmp/version
-		// and
-		// /Users/foo/workspaces/docker-maven-plugin/target/test-classes/compose/version:/tmp/version
+        // Extract the host-portion of the volume binding string, accounting for windows platform paths and unix style
+        // paths.  For example:
+        // C:\Users\foo\Documents\workspaces\docker-maven-plugin\target\test-classes\compose\version:/tmp/version
+        // and
+        // /Users/foo/workspaces/docker-maven-plugin/target/test-classes/compose/version:/tmp/version
 
-		File file = null;
-		if (bindString.indexOf(":") > 1) {
-			// a unix-style path
-			file = new File(bindString.substring(0, bindString.indexOf(":")));
-		} else {
-			// a windows-style path with a drive letter
-			file = new File(bindString.substring(0, bindString.indexOf(":", 2)));
-		}
-		assertTrue("The file '" + file + "' parsed from the volume binding string '" + bindString + "' does not exist!",
-				file.exists());
-	}
+        File file = null;
+        if (bindString.indexOf(":") > 1) {
+            // a unix-style path
+            file = new File(bindString.substring(0, bindString.indexOf(":")));
+        } else {
+            // a windows-style path with a drive letter
+            file = new File(bindString.substring(0, bindString.indexOf(":", 2)));
+        }
+        assertTrue("The file '" + file + "' parsed from the volume binding string '" + bindString + "' does not exist!", file.exists());
+    }
 
-	protected void validateEnv(Map<String, String> env) {
-		assertEquals(2, env.size());
-		assertEquals("name", env.get("NAME"));
-		assertEquals("true", env.get("BOOL"));
-	}
+    protected void validateEnv(Map<String, String> env) {
+        assertEquals(2, env.size());
+        assertEquals("name", env.get("NAME"));
+        assertEquals("true", env.get("BOOL"));
+    }
 
-	protected List<String> a(String... args) {
-		return Arrays.asList(args);
-	}
+    protected List<String> a(String ... args) {
+        return Arrays.asList(args);
+    }
 
 }

--- a/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
@@ -101,30 +101,6 @@ public class DockerComposeConfigHandlerTest {
         }
 
     }
-
-	@Test
-	public void networkAliases() throws IOException, MavenFilteringException {
-		setupComposeExpectations("docker-compose-network-aliases.yml");
-		List<ImageConfiguration> configs = handler.resolve(unresolved, project, session);
-		
-		// Service 1 has 1 network (network1) with 2 aliases (alias1, alias2)
-		NetworkConfig netSvc = configs.get(0).getRunConfiguration().getNetworkingConfig();
-		assertEquals("network1", netSvc.getName());
-		assertEquals(2, netSvc.getAliases().size());
-		assertEquals("alias1", netSvc.getAliases().get(0));
-		assertEquals("alias2", netSvc.getAliases().get(1));
-
-		// Service 2 has 1 network (network1) with no aliases
-		netSvc = configs.get(1).getRunConfiguration().getNetworkingConfig();
-		assertEquals("network1", netSvc.getName());
-		assertEquals(0, netSvc.getAliases().size());
-
-		// Service 3 has 1 network (network1) with 1 aliase (alias1)
-		netSvc = configs.get(2).getRunConfiguration().getNetworkingConfig();
-		assertEquals("network1", netSvc.getName());
-		assertEquals(1, netSvc.getAliases().size());
-		assertEquals("alias1", netSvc.getAliases().get(0));
-	}
 	
     @Test
     public void negativeVersionTest() throws IOException, MavenFilteringException {

--- a/src/test/resources/compose/docker-compose-network-aliases.yml
+++ b/src/test/resources/compose/docker-compose-network-aliases.yml
@@ -1,0 +1,20 @@
+version: '2.2'
+services:
+  service1:
+    image: image
+    networks:
+      network1:
+        aliases:
+          - alias1
+          - alias2
+  service2:
+    image: image
+    networks:
+      - network1
+  service3:
+    image: image
+    networks:
+      network1:
+        aliases:
+          - alias1
+          


### PR DESCRIPTION
Hi all,
I had some problems to start an external docker-compose.yml because of network aliases configuration mismatch. 
The DockerComposeServiceWrapper does not manage correctly the network name nor the aliases.
There is a unit test, the changes and a docker-compose file to check the behaviour.

Regards Gianluca.

```
version: '2.2'
services:
  service1:
    image: image
    networks:
      network1:
        aliases:
          - alias1
          - alias2
  service2:
    image: image
    networks:
      - network1
  service3:
    image: image
    networks:
      network1:
        aliases:
          - alias1

```          