### PR TITLE
Add possiblity to use docker.imagePropertyConfiguration with multipe images

### DIFF
--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -330,19 +330,20 @@ configuration (since version 0.25.0), which can have one of the following values
 [[combining-property-config-externally]]
 .Activating property configuration externally
 It also possible to activate property configuration by setting the property `docker.imagePropertyConfiguration` to a
-valid `property mode`, without adding an `<external>` section.
-This will use any properties with default prefix.
+valid `property mode`, without adding an `<external>` section. The plugin will then use any properties with default `docker.` prefix.
 This can be useful if most of the configuration is specified in XML/POM file, but there
-is need to override certain configuration values without altering the POM file (by i.e. adding this to a parent POM or
+is need to override certain configuration values without altering the POM file (instead add this to a parent POM or
 global settings.xml).
 
-If set globally (i.e. parent POM), but not wanted locally, the property could be overriden to `skip` to disabled it.
-Note that settings.xml properties take precedence over any properties defined in pom.xml.
+If set in parent POM, but not wanted in specific project, the property could be overriden locally with the value `skip`
+to disabled property configuration for that particular project.
+If set in settings.xml however, by Maven design, that value will always take precedence over any properties defined in
+pom.xml.
 
-For configurations with multiple images, using this property will produce an error. All images would use the docker prefix,
-they would all be given the same configuration, and that is probably not intended.
+For configurations with multiple images, using this property will produce an error. All images would then
+use the same `docker.` property prefix, resulting in multiple identical configurations.
 This error can be avoided by adding an explicit <external> configuration element with an alternative <prefix> to all
-images (or at least all but one).
+images (or at least all but one). Since they then have different prefixes, it would be OK.
 
 .Merging POM and property values
 For some fields it may be desired to merge values from both POM and properties. For example, in a certain run environment

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -348,6 +348,8 @@ it does allow you to use the same prefix (even `docker`) on all images. This is 
 a few properties. This only makes sense when `property mode` is _override_ or _fallback_ and image-specific configuration
 are defined in the POM configuration.
 
+For examples, see <<externally-property-config-example, here>>
+
 .Merging POM and property values
 For some fields it may be desired to merge values from both POM and properties. For example, in a certain run environment
 we might want to inject a `http_proxy` environment variable, but we do not want to add this to the POM file.
@@ -405,6 +407,8 @@ For example, to not merge ports, set `docker.ports._combine=replace`, and to ena
 </build>
 ----
 
+
+[[externally-property-config-example]]
 .Example, combining properties and XML/POM configuration
 [source,xml]
 ----
@@ -452,3 +456,101 @@ If instead built with `mvn docker:build -Pdocker.from=console/tomcat:8.0 -Ddocke
 
 If `-Ddocker.labels.status=beta` is added, the image would be given two labels: `status=beta` and `software=tomcat`.
 If `-Ddocker.labels._combine=replace` is added, the image would be given one label only: `status=beta`.
+
+
+.Example, external activation of property configuration, single image
+
+Global ~/.m2/settings.xml file:
+[source,xml]
+----
+<profiles>
+  <profile>
+    <id>http-proxy</id>
+    <properties>
+      <docker.buildArg.http_proxy>http://proxy.example.com:8080</docker.buildArg.http_proxy>
+      <docker.runArg.http_proxy>http://proxy.example.com:8080</docker.runArg.http_proxy>
+      <docker.imagePropertyConfiguration>override</docker.imagePropertyConfiguration>
+    </properties>
+  </profile>
+</profiles>
+----
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>io.fabric8</groupId>
+      <artifactId>docker-maven-plugin</artifactId>
+      <configuration>
+        <images>
+          <image>
+            <name>jolokia/demo</name>
+            <alias>service</alias>
+            <build>
+              <from>consol/tomcat:7.0</from>
+            </build>
+          </image>
+        </images>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+----
+
+When the plugin is executed, on a machine with the given settings.xml, the plugin will see the `docker.imagePropertyConfiguration` configuration and enable
+the property merging feature. When building, it will inject the http_proxy build ARG, and when running, it will inject the http_proxy ENV variable.
+The rest of the configuration will be sourced from the XML, unless the Maven project has any other `docker.*` properties defined.
+
+
+.Example, external activation of property configuration, two images
+Using the same global ~/.m2/settings.xml file as in previous example, but with two image definitions and no extra configuration will cause
+an error, saying that you cannot use property docker.imagePropertyConfiguration on projects with multiple images.
+
+By adding an explicit external configuration directive with the same prefix in both images, this error is disabled.
+
+[source,xml]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>io.fabric8</groupId>
+      <artifactId>docker-maven-plugin</artifactId>
+      <configuration>
+        <images>
+          <image>
+            <external>
+              <type>properties</type>
+              <prefix>docker</prefix>
+              <mode>override</mode>
+            </external>
+
+            <name>jolokia/demo</name>
+            <alias>service</alias>
+            <build>
+              <from>consol/tomcat:7.0</from>
+            </build>
+          </image>
+
+          <image>
+            <external>
+              <type>properties</type>
+              <prefix>docker</prefix>
+              <mode>override</mode>
+            </external>
+
+            <name>jolokia/demo2</name>
+            <alias>service2</alias>
+            <build>
+              <from>consol/tomcat:7.0</from>
+            </build>
+          </image>
+        </images>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+----
+
+The behaviour will now be same as previous example.
+Note that you must explicitly state `<mode>override</mode>`, otherwise it will use the default `only`.

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -152,7 +152,7 @@ when a `docker.from` or a `docker.fromExt` is set.
 | Container hostname
 
 | *docker.imagePropertyConfiguration*
-| Special property to activate property configuration without altering XML file (see <<combining-property-config,Combining property and XML config>>).
+| Special property to activate property configuration without altering XML file (see <<combining-property-config-externally,Activating property configuration externally>>).
 
 | *docker.imagePullPolicy.build*
 | Specific pull policy used when building images. See <<image-pull-policy,imagePullPolicy>> for the possible values.
@@ -327,12 +327,22 @@ configuration (since version 0.25.0), which can have one of the following values
 | Effectively disable properties, same as not specifying the `<external>` section at all.
 |===
 
-For single-image configurations it is also possible to active property
-configuration by setting the property `docker.imagePropertyConfiguration` to a
-valid `property mode`, without adding a `<external>` section.
-This will use properties with default prefix.
-This can be useful if most of configuration is specified in XML/POM file, but there
-is need to override certain configuration values without altering the POM file.
+[[combining-property-config-externally]]
+.Activating property configuration externally
+It also possible to activate property configuration by setting the property `docker.imagePropertyConfiguration` to a
+valid `property mode`, without adding an `<external>` section.
+This will use any properties with default prefix.
+This can be useful if most of the configuration is specified in XML/POM file, but there
+is need to override certain configuration values without altering the POM file (by i.e. adding this to a parent POM or
+global settings.xml).
+
+If set globally (i.e. parent POM), but not wanted locally, the property could be overriden to `skip` to disabled it.
+Note that settings.xml properties take precedence over any properties defined in pom.xml.
+
+For configurations with multiple images, using this property will produce an error. All images would use the docker prefix,
+they would all be given the same configuration, and that is probably not intended.
+This error can be avoided by adding an explicit <external> configuration element with an alternative <prefix> to all
+images (or at least all but one).
 
 .Merging POM and property values
 For some fields it may be desired to merge values from both POM and properties. For example, in a certain run environment

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -340,10 +340,13 @@ to disabled property configuration for that particular project.
 If set in settings.xml however, by Maven design, that value will always take precedence over any properties defined in
 pom.xml.
 
-For configurations with multiple images, using this property will produce an error. All images would then
-use the same `docker.` property prefix, resulting in multiple identical configurations.
-This error can be avoided by adding an explicit <external> configuration element with an alternative <prefix> to all
-images (or at least all but one). Since they then have different prefixes, it would be OK.
+For configurations with multiple images, using this property will by default produce an error. All images would then
+use the same `docker` property prefix, resulting in multiple identical configurations.
+This can be overruled by adding an explicit <external> configuration element with an explicit <prefix> to all
+images (or at least all but one). Normally you'd want to use different prefix for each image, but if explicitly set
+it does allow you to use the same prefix (even `docker`) on all images. This is useful in case you just want to share
+a few properties. This only makes sense when `property mode` is _override_ or _fallback_ and image-specific configuration
+are defined in the POM configuration.
 
 .Merging POM and property values
 For some fields it may be desired to merge values from both POM and properties. For example, in a certain run environment

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -205,6 +205,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         if (!skip) {
             log = new AnsiLogger(getLog(), useColor, verbose, !settings.getInteractiveMode(), getLogPrefix());
             authConfigFactory.setLog(log);
+            imageConfigResolver.setLog(log);
 
             LogOutputSpecFactory logSpecFactory = new LogOutputSpecFactory(useColor, logStdout, logDate);
 

--- a/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
@@ -18,6 +18,8 @@ package io.fabric8.maven.docker.config;
 
 import java.util.*;
 
+import io.fabric8.maven.docker.config.handler.property.PropertyConfigHandler;
+import io.fabric8.maven.docker.config.handler.property.PropertyMode;
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.Logger;
 import org.apache.maven.plugin.MojoFailureException;
@@ -72,14 +74,35 @@ public class ConfigHelper {
             return;
         }
 
-        if(images.size() > 1) {
-            throw new MojoFailureException("Configuration error: Cannot use property "+EXTERNALCONFIG_ACTIVATION_PROPERTY+" on projects with multiple images.");
+        if(images.size() == 1)
+            return;
+
+        // With more than one image, externally activating propertyConfig get's tricky. We can only allow it to affect
+        // one single image. Go through each image and check if they will be controlled by default properties.
+        // If more than one image matches, fail.
+        int imagesWithoutExternalConfig = 0;
+        for (ImageConfiguration image : images) {
+            if(PropertyConfigHandler.canCoexistWithOtherPropertyConfiguredImages(image.getExternalConfig()))
+                continue;
+
+            // else, it will be affected by the external property.
+            imagesWithoutExternalConfig++;
+        }
+
+        if(imagesWithoutExternalConfig > 1) {
+            throw new MojoFailureException("Configuration error: Cannot use property "+EXTERNALCONFIG_ACTIVATION_PROPERTY+" on projects with multiple images without explicit image external configuration.");
         }
     }
 
     public static String getExternalConfigActivationProperty(MavenProject project) {
         Properties properties = EnvUtil.getPropertiesWithSystemOverrides(project);
-        return properties.getProperty(EXTERNALCONFIG_ACTIVATION_PROPERTY);
+        String value = properties.getProperty(EXTERNALCONFIG_ACTIVATION_PROPERTY);
+
+        // This can be used to disable in a more "local" context, if set globally
+        if(PropertyMode.Skip.name().equalsIgnoreCase(value))
+            return null;
+
+        return value;
     }
 
     /**

--- a/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
@@ -74,16 +74,18 @@ public class ConfigHelper {
             return;
         }
 
-        if(images.size() == 1)
+        if(images.size() == 1) {
             return;
+        }
 
         // With more than one image, externally activating propertyConfig get's tricky. We can only allow it to affect
         // one single image. Go through each image and check if they will be controlled by default properties.
         // If more than one image matches, fail.
         int imagesWithoutExternalConfig = 0;
         for (ImageConfiguration image : images) {
-            if(PropertyConfigHandler.canCoexistWithOtherPropertyConfiguredImages(image.getExternalConfig()))
+            if(PropertyConfigHandler.canCoexistWithOtherPropertyConfiguredImages(image.getExternalConfig())) {
                 continue;
+            }
 
             // else, it will be affected by the external property.
             imagesWithoutExternalConfig++;
@@ -99,8 +101,9 @@ public class ConfigHelper {
         String value = properties.getProperty(EXTERNALCONFIG_ACTIVATION_PROPERTY);
 
         // This can be used to disable in a more "local" context, if set globally
-        if(PropertyMode.Skip.name().equalsIgnoreCase(value))
+        if(PropertyMode.Skip.name().equalsIgnoreCase(value)) {
             return null;
+        }
 
         return value;
     }

--- a/src/main/java/io/fabric8/maven/docker/config/UlimitConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/config/UlimitConfig.java
@@ -69,13 +69,14 @@ public class UlimitConfig implements Serializable {
     }
 
     public String serialize() {
-        if(hard != null && soft != null)
+        if(hard != null && soft != null) {
             return name + "="+hard+":"+soft;
-        else if(hard != null)
+        } else if(hard != null) {
             return name + "="+hard;
-        else if(soft != null)
+        } else if(soft != null) {
             return name + "=:"+soft;
-        else
+        } else {
             return null;
+        }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/ImageConfigResolver.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/ImageConfigResolver.java
@@ -21,6 +21,7 @@ import io.fabric8.maven.docker.config.ConfigHelper;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.handler.compose.DockerComposeConfigHandler;
 import io.fabric8.maven.docker.config.handler.property.PropertyConfigHandler;
+import io.fabric8.maven.docker.util.Logger;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
@@ -51,6 +52,8 @@ public class ImageConfigResolver implements Initializable {
     @Requirement(role = DockerComposeConfigHandler.class)
     private ExternalConfigHandler dockerComposeConfigHandler;
 
+    private Logger log;
+
     @Override
     public void initialize() throws InitializationException {
         this.registry = new HashMap<>();
@@ -59,6 +62,10 @@ public class ImageConfigResolver implements Initializable {
                 registry.put(handler.getType(), handler);
             }
         }
+    }
+
+    public void setLog(Logger log) {
+        this.log = log;
     }
 
     /**
@@ -108,6 +115,12 @@ public class ImageConfigResolver implements Initializable {
             externalConfig.put("type", propertyConfigHandler.getType());
             externalConfig.put("mode", mode);
             unresolvedConfig.setExternalConfiguration(externalConfig);
+
+            log.verbose("Global %s=%s property activates property configuration for image", ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY, mode);
+        }
+        else
+        {
+            log.verbose("Ignoring %s=%s property, image has <external> in POM which takes precedence", ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY, mode);
         }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -34,9 +34,12 @@ import static io.fabric8.maven.docker.config.handler.property.ConfigKey.*;
 // @Component(role = ExternalConfigHandler.class)
 public class PropertyConfigHandler implements ExternalConfigHandler {
 
+    public static final String TYPE_NAME = "properties";
+    public static final String DEFAULT_PREFIX = "docker";
+
     @Override
     public String getType() {
-        return "properties";
+        return TYPE_NAME;
     }
 
     @Override
@@ -45,7 +48,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         Map<String, String> externalConfig = fromConfig.getExternalConfig();
         String prefix = getPrefix(externalConfig);
         Properties properties = EnvUtil.getPropertiesWithSystemOverrides(project);
-        PropertyMode propertyMode = PropertyMode.parse(externalConfig.get("mode"));
+        PropertyMode propertyMode = getMode(externalConfig);
         ValueProvider valueProvider = new ValueProvider(prefix, properties, propertyMode);
 
         RunImageConfiguration run = extractRunConfiguration(fromConfig, valueProvider);
@@ -57,7 +60,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         if (name == null) {
             throw new IllegalArgumentException(String.format("Mandatory property [%s] is not defined", NAME));
         }
-        
+
         return Collections.singletonList(
                 new ImageConfiguration.Builder()
                         .name(name)
@@ -322,11 +325,30 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .build();
     }
 
-    private String getPrefix(Map<String, String> externalCconfig) {
-        String prefix = externalCconfig.get("prefix");
+    private static String getPrefix(Map<String, String> externalConfig) {
+        String prefix = externalConfig.get("prefix");
         if (prefix == null) {
-            prefix = "docker";
+            prefix = DEFAULT_PREFIX;
         }
         return prefix;
+    }
+
+    private static PropertyMode getMode(Map<String, String> externalConfig) {
+        return PropertyMode.parse(externalConfig.get("mode"));
+    }
+
+    public static boolean canCoexistWithOtherPropertyConfiguredImages(Map<String, String> externalConfig) {
+        if(externalConfig == null || externalConfig.isEmpty())
+            return false;
+
+        if(!TYPE_NAME.equals(externalConfig.get("type")))
+            // This images loads config from something totally different
+            return true;
+
+        if(!DEFAULT_PREFIX.equals(getPrefix(externalConfig)))
+            // This image uses a non-default prefix
+            return true;
+
+        return false;
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -338,16 +338,21 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
     }
 
     public static boolean canCoexistWithOtherPropertyConfiguredImages(Map<String, String> externalConfig) {
-        if(externalConfig == null || externalConfig.isEmpty())
+        if(externalConfig == null || externalConfig.isEmpty()) {
             return false;
+        }
 
         if(!TYPE_NAME.equals(externalConfig.get("type")))
+        {
             // This images loads config from something totally different
             return true;
+        }
 
         if(!DEFAULT_PREFIX.equals(getPrefix(externalConfig)))
+        {
             // This image uses a non-default prefix
             return true;
+        }
 
         return false;
     }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -348,9 +348,10 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             return true;
         }
 
-        if(!DEFAULT_PREFIX.equals(getPrefix(externalConfig)))
+        if(externalConfig.get("prefix") != null)
         {
-            // This image uses a non-default prefix
+            // This image has a specified prefix. If multiple images have explicitly set docker. as prefix we
+            // assume user know what they are doing and allow it.
             return true;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyMode.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyMode.java
@@ -22,8 +22,9 @@ public enum PropertyMode {
      * @throws IllegalArgumentException if empty or invalid names
      */
     static PropertyMode parse(String name) {
-        if(name == null)
+        if(name == null) {
             return PropertyMode.Only;
+        }
 
         name = name.toLowerCase();
         for (PropertyMode e : PropertyMode.values()) {

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyMode.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyMode.java
@@ -6,7 +6,7 @@ package io.fabric8.maven.docker.config.handler.property;
  *
  * @author Johan Ström
  */
-enum PropertyMode {
+public enum PropertyMode {
     Only,
     Override,
     Fallback,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ValueProvider.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ValueProvider.java
@@ -76,8 +76,9 @@ public class ValueProvider {
 
     public int getInt(ConfigKey key, Integer fromConfig) {
         Integer integer = getInteger(key, fromConfig);
-        if(integer == null)
+        if(integer == null) {
             return 0;
+        }
         return integer;
     }
 
@@ -110,8 +111,9 @@ public class ValueProvider {
      */
     private abstract class ValueExtractor<T> {
         T getFromPreferredSource(String prefix, ConfigKey key, T fromConfig) {
-            if(propertyMode == PropertyMode.Skip)
+            if(propertyMode == PropertyMode.Skip) {
                 return fromConfig;
+            }
 
             List<T> values = new ArrayList<>();
 
@@ -127,16 +129,20 @@ public class ValueProvider {
                 case Only:
                     return fromProperty;
                 case Override:
-                    if(fromProperty != null)
+                    if(fromProperty != null) {
                         values.add(fromProperty);
-                    if(fromConfig != null)
+                    }
+                    if(fromConfig != null) {
                         values.add(fromConfig);
+                    }
                     break;
                 case Fallback:
-                    if(fromConfig != null)
+                    if(fromConfig != null) {
                         values.add(fromConfig);
-                    if(fromProperty != null)
+                    }
+                    if(fromProperty != null) {
                         values.add(fromProperty);
+                    }
                     break;
                 default:
                     throw new AssertionError("Invalid PropertyMode");

--- a/src/test/java/io/fabric8/maven/docker/config/ConfigHelperTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/ConfigHelperTest.java
@@ -16,9 +16,7 @@ package io.fabric8.maven.docker.config;
  * limitations under the License.
  */
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import io.fabric8.maven.docker.util.AnsiLogger;
 import org.apache.maven.plugin.MojoFailureException;
@@ -71,10 +69,40 @@ public class ConfigHelperTest {
             ConfigHelper.validateExternalPropertyActivation(project, images);
             fail();
         }catch(MojoFailureException ex) {
-            assertTrue(ex.getMessage().contains("Configuration error: Cannot use property"));
+            assertEquals("Configuration error: Cannot use property " + ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY + " on projects with multiple images without explicit image external configuration.",
+                    ex.getMessage());
         }
 
+        // When one of the images are configured externally from other source, it is OK with two images.
+        Map<String, String> externalConfig = new HashMap<>();
+        images.get(0).setExternalConfiguration(externalConfig);
+        externalConfig.put("type", "othermagic");
+
+        ConfigHelper.validateExternalPropertyActivation(project, images);
+
+        // Or if prefix is non-default
+        externalConfig.put("type", "properties");
+        externalConfig.put("prefix", "docker2");
+
+        ConfigHelper.validateExternalPropertyActivation(project, images);
+
+        // But with default prefix it fails
+        externalConfig.remove("prefix");
+
+        try {
+            ConfigHelper.validateExternalPropertyActivation(project, images);
+            fail();
+        }catch(MojoFailureException ex) {
+            assertEquals("Configuration error: Cannot use property " + ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY + " on projects with multiple images without explicit image external configuration.",
+                    ex.getMessage());
+        }
+
+        // With no external properly, it works.
         project.getProperties().clear();
+        ConfigHelper.validateExternalPropertyActivation(project, images);
+
+        // And if explicitly set to "skip" it works too.
+        project.getProperties().put(ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY, "skip");
         ConfigHelper.validateExternalPropertyActivation(project, images);
     }
 

--- a/src/test/java/io/fabric8/maven/docker/config/ConfigHelperTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/ConfigHelperTest.java
@@ -69,8 +69,7 @@ public class ConfigHelperTest {
             ConfigHelper.validateExternalPropertyActivation(project, images);
             fail();
         }catch(MojoFailureException ex) {
-            assertEquals("Configuration error: Cannot use property " + ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY + " on projects with multiple images without explicit image external configuration.",
-                    ex.getMessage());
+            assertTrue(ex.getMessage().contains("Cannot use property " + ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY + " on projects with multiple images"));
         }
 
         // When one of the images are configured externally from other source, it is OK with two images.
@@ -93,8 +92,7 @@ public class ConfigHelperTest {
             ConfigHelper.validateExternalPropertyActivation(project, images);
             fail();
         }catch(MojoFailureException ex) {
-            assertEquals("Configuration error: Cannot use property " + ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY + " on projects with multiple images without explicit image external configuration.",
-                    ex.getMessage());
+            assertTrue(ex.getMessage().contains("Cannot use property " + ConfigHelper.EXTERNALCONFIG_ACTIVATION_PROPERTY + " on projects with multiple images"));
         }
 
         // With no external properly, it works.

--- a/src/test/java/io/fabric8/maven/docker/config/ConfigHelperTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/ConfigHelperTest.java
@@ -79,9 +79,9 @@ public class ConfigHelperTest {
 
         ConfigHelper.validateExternalPropertyActivation(project, images);
 
-        // Or if prefix is non-default
+        // Or if prefix is set explicitly
         externalConfig.put("type", "properties");
-        externalConfig.put("prefix", "docker2");
+        externalConfig.put("prefix", "docker");
 
         ConfigHelper.validateExternalPropertyActivation(project, images);
 

--- a/src/test/java/io/fabric8/maven/docker/config/ImageConfigResolverTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/ImageConfigResolverTest.java
@@ -19,6 +19,8 @@ import java.util.*;
 
 import io.fabric8.maven.docker.config.handler.ExternalConfigHandler;
 import io.fabric8.maven.docker.config.handler.ImageConfigResolver;
+import io.fabric8.maven.docker.util.Logger;
+import mockit.Mocked;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
@@ -36,11 +38,15 @@ public class ImageConfigResolverTest {
 
     private ImageConfigResolver resolver;
 
+    @Mocked
+    private Logger log;
+
     @Before
     public void setUp() throws Exception {
         resolver = new ImageConfigResolver();
         ReflectionUtils.setVariableValueInObject(resolver, "propertyConfigHandler", new TestHandler(3));
         resolver.initialize();
+        resolver.setLog(log);
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -690,10 +690,11 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
     private void makeExternalConfigUse(PropertyMode mode) {
         Map<String, String> externalConfig = imageConfiguration.getExternalConfig();
         externalConfig.put("type", "properties");
-        if(mode != null)
+        if(mode != null) {
             externalConfig.put("mode", mode.name());
-        else
+        } else {
             externalConfig.remove("mode");
+        }
     }
 
     private List<ImageConfiguration> resolveImage(ImageConfiguration image, final Properties properties) {


### PR DESCRIPTION
By default it works as previous, but if explicit <external> is added to each image, and i.e. setting a custom prefix, it work.

This is useful when i.e. env has `docker.imagePropertyConfiguration` set globally (i.e. settings.xml), and a Maven project happens to have multiple images.

Also add support for docker.imagePropertyConfiguration=skip, for i.e. overriding parents config and disable it (note that setting this in pom <properties> will not override a value in settings.xml, mostly useful to override parent pom).