### PR TITLE
Bump jnr-unixsocket to 0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.12</version>
+      <version>0.18</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The newer release of jnr-unixsocket pulls in a newer version on jnr-ffi which supports ARM64 platforms.

Signed-off-by: Mohammed Naser <mnaser@vexxhost.com>