### PR TITLE
Unbreak use of build/dockerFile in properties mode

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -72,8 +72,8 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
     private boolean buildConfigured(BuildImageConfiguration config, ValueProvider valueProvider) {
         return valueProvider.getString(FROM, config == null ? null : config.getFrom()) != null ||
                 valueProvider.getMap(FROM_EXT, config == null ? null : config.getFromExt()) != null ||
-                valueProvider.getString(DOCKER_FILE, config == null || config.getDockerFile() == null ? null : config.getDockerFile().getAbsolutePath()) != null ||
-                valueProvider.getString(DOCKER_FILE_DIR, config == null || config.getDockerArchive() == null ? null : config.getDockerArchive().getAbsolutePath()) != null;
+                valueProvider.getString(DOCKER_FILE, config == null || config.getDockerFileRaw() == null ? null : config.getDockerFileRaw()) != null ||
+                valueProvider.getString(DOCKER_FILE_DIR, config == null || config.getDockerArchiveRaw() == null ? null : config.getDockerArchiveRaw()) != null;
     }
 
 

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -385,6 +385,29 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
     }
 
     @Test
+    public void testBuildFromDockerFileMerged() {
+        imageConfiguration = new ImageConfiguration.Builder()
+                .name("myimage")
+                .externalConfig(externalConfigMode(PropertyMode.Override))
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .dockerFile("/some/path")
+                        .build()
+                )
+                .build();
+
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration, props()
+        );
+
+        assertEquals(1, configs.size());
+
+        BuildImageConfiguration buildConfiguration = configs.get(0).getBuildConfiguration();
+        assertNotNull(buildConfiguration);
+        buildConfiguration.initAndValidate(null);
+        assertEquals("/some/path", buildConfiguration.getDockerFile().getAbsolutePath().toString());
+    }
+
+    @Test
     public void testEnvAndLabels() throws Exception {
         List<ImageConfiguration> configs = resolveImage(
                 imageConfiguration,props(


### PR DESCRIPTION
The POM provided configuration was totally ignored since getDockerFile() was null (should use Raw instead)

Bug in #948, only affects those trying to use config + properties. Temporary workaround is to set property `docker.dockerFile` and build goal will start working again.