### PR TITLE
Add option for regenerating certificates after starting Docker Machine

### DIFF
--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -174,6 +174,9 @@ This plugin supports also Docker machine (which must be installed locally, of co
 | *autoCreate*
 | if set to `true` then a Docker machine will automatically created. Default is `false`.
 
+| *regenerateCertsAfterStart*
+| if set to `true` then certificates will be regenerated after starting the Docker Machine.  This is useful if using the AWS EC2 driver, which will assign machines new IP addresses after each start.  Default is `false`.
+
 | *createOptions*
 | Map with options for Docker machine when auto-creating a machine. See the docker machine documentation for possible options.
 |===

--- a/src/main/java/io/fabric8/maven/docker/access/DockerMachine.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerMachine.java
@@ -68,6 +68,9 @@ public class DockerMachine implements DockerConnectionDetector.DockerHostProvide
                     break;
                 case Stopped:
                     new StartCommand().execute();
+                    if (Boolean.TRUE == machine.getRegenerateCertsAfterStart()) {
+                        new RegenerateCertsCommand().execute();
+                    }
                     break;
             }
         }
@@ -197,6 +200,32 @@ public class DockerMachine implements DockerConnectionDetector.DockerHostProvide
         @Override
         protected void end() {
             log.info("Started docker machine \"%s\" in %d seconds",machine.getName(), (System.currentTimeMillis() - start) / 1000);
+        }
+    }
+
+    // docker-machine regenerate-certs <name>
+    private class RegenerateCertsCommand extends ExternalCommand {
+
+        private long start;
+
+        RegenerateCertsCommand() {
+            super(DockerMachine.this.log);
+        }
+
+        @Override
+        protected String[] getArgs() {
+            return new String[]{"docker-machine", "regenerate-certs", "-f", machine.getName()};
+        }
+
+        @Override
+        protected void start() {
+            log.info("Regenerating certificates for \"%s\"", machine.getName());
+            start = System.currentTimeMillis();
+        }
+
+        @Override
+        protected void end() {
+            log.info("Regenerated certificates for \"%s\" in %d seconds",machine.getName(), (System.currentTimeMillis() - start) / 1000);
         }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/DockerMachineConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/DockerMachineConfiguration.java
@@ -9,6 +9,7 @@ public class DockerMachineConfiguration implements Serializable {
 
     public static final String DOCKER_MACHINE_NAME_PROP = "docker.machine.name";
     public static final String DOCKER_MACHINE_AUTO_CREATE_PROP = "docker.machine.autoCreate";
+    public static final String DOCKER_MACHINE_REGENERATE_CERTS_AFTER_START_PROP = "docker.machine.regenerateCertsAfterStart";
 
     /**
      * Name of the docker-machine
@@ -23,6 +24,12 @@ public class DockerMachineConfiguration implements Serializable {
     private Boolean autoCreate = Boolean.FALSE;
 
     /**
+     * Should the docker-machine's certificates be regenerated after starting?
+     */
+    @Parameter
+    private Boolean regenerateCertsAfterStart = Boolean.FALSE;
+
+    /**
      * When creating a docker-machine, the map of createOptions for the driver.
      * Do not include the '--' portion of the option name.  For options without values, leave the value text empty.
      * e.g. --virtualbox-cpu-count 1 --virtualbox-no-share would be written as:<code>
@@ -35,9 +42,10 @@ public class DockerMachineConfiguration implements Serializable {
 
     public DockerMachineConfiguration() {}
 
-    public DockerMachineConfiguration(String name, String autoCreate) {
+    public DockerMachineConfiguration(String name, String autoCreate, String regenerateCertsAfterStart) {
         this.name = name;
         this.autoCreate = autoCreate != null ? Boolean.parseBoolean(autoCreate) : Boolean.FALSE;
+        this.regenerateCertsAfterStart = regenerateCertsAfterStart != null ? Boolean.parseBoolean(regenerateCertsAfterStart) : Boolean.FALSE;
     }
 
     public String getName() {
@@ -48,12 +56,16 @@ public class DockerMachineConfiguration implements Serializable {
         return autoCreate;
     }
 
+    public Boolean getRegenerateCertsAfterStart() {
+        return regenerateCertsAfterStart;
+    }
+
     public Map<String, String> getCreateOptions() {
         return createOptions;
     }
 
     @Override
     public String toString() {
-        return "MachineConfiguration [name=" + name + ", autoCreate=" + autoCreate + ", createOptions=" + createOptions + "]";
+        return "MachineConfiguration [name=" + name + ", autoCreate=" + autoCreate + ",regenerateCertsAfterStart=" + regenerateCertsAfterStart + ", createOptions=" + createOptions + "]";
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/service/DockerAccessFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/service/DockerAccessFactory.java
@@ -83,7 +83,8 @@ public class DockerAccessFactory {
             if (projectProps.containsKey(DockerMachineConfiguration.DOCKER_MACHINE_NAME_PROP)) {
                 config = new DockerMachineConfiguration(
                     projectProps.getProperty(DockerMachineConfiguration.DOCKER_MACHINE_NAME_PROP),
-                    projectProps.getProperty(DockerMachineConfiguration.DOCKER_MACHINE_AUTO_CREATE_PROP));
+                    projectProps.getProperty(DockerMachineConfiguration.DOCKER_MACHINE_AUTO_CREATE_PROP),
+                    projectProps.getProperty(DockerMachineConfiguration.DOCKER_MACHINE_REGENERATE_CERTS_AFTER_START_PROP));
             }
         }
 

--- a/src/test/java/integration/DockerAccessIT.java
+++ b/src/test/java/integration/DockerAccessIT.java
@@ -58,7 +58,7 @@ public class DockerAccessIT {
     }
 
     private DockerConnectionDetector createDockerConnectionDetector(Logger logger) {
-        DockerMachineConfiguration machine = new DockerMachineConfiguration("default","false");
+        DockerMachineConfiguration machine = new DockerMachineConfiguration("default","false","false");
         return new DockerConnectionDetector(
             Collections.<DockerConnectionDetector.DockerHostProvider>singletonList(new DockerMachine(logger, machine)));
     }

--- a/src/test/java/integration/DockerMachineIT.java
+++ b/src/test/java/integration/DockerMachineIT.java
@@ -17,7 +17,7 @@ public class DockerMachineIT {
 
     @Test
     public void testLaunchDockerMachine() throws Exception {
-        DockerMachineConfiguration mc = new DockerMachineConfiguration("default","true");
+        DockerMachineConfiguration mc = new DockerMachineConfiguration("default","true","true");
         DockerMachine de = new DockerMachine(new AnsiLogger(new SystemStreamLog(), true, true), mc);
         Assert.assertTrue(de.getConnectionParameter(null) != null);
     }


### PR DESCRIPTION
If using Docker Machine with the AWS EC2 driver, the remote host will have a new IP address every time it is started up again.  This causes the Docker Maven plug-in to fail with an error about certificates being invalid when starting up the machine automatically.  Add an option to automatically regenerate the certificates for the new IP address after startup.  Setting this option to true will allow Docker Machines running in AWS EC2 to be automatically started up into a usable state by the Docker Maven plug-in. (Without this option, such automatically started machines will fail the Maven Docker plug-in invocation complaining about certificates being invalid as the existing certificates are associated with the old IP address)

The changes have been tested with the option both on and off, and are working as expected. Also the documentation has been updated to mention the new option and when it is useful.