### PR TITLE
Unbreak setting of entrypoint in exec form when property mode is enabled

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -413,9 +413,9 @@ public class BuildImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder cmd(String cmd) {
+        public Builder cmd(Arguments cmd) {
             if (cmd != null) {
-                config.cmd = new Arguments(cmd);
+                config.cmd = cmd;
             }
             return this;
         }
@@ -444,9 +444,9 @@ public class BuildImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder entryPoint(String entryPoint) {
+        public Builder entryPoint(Arguments entryPoint) {
             if (entryPoint != null) {
-                config.entryPoint = new Arguments(entryPoint);
+                config.entryPoint = entryPoint;
             }
             return this;
         }

--- a/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
@@ -96,9 +96,9 @@ public class HealthCheckConfiguration implements Serializable {
             return this;
         }
 
-        public Builder cmd(String command) {
+        public Builder cmd(Arguments command) {
             if (command != null) {
-                config.cmd = new Arguments(command);
+                config.cmd = command;
             }
             return this;
         }

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -400,13 +400,6 @@ public class RunImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder entrypoint(String entrypoint) {
-            if (entrypoint != null) {
-                config.entrypoint = new Arguments(entrypoint);
-            }
-            return this;
-        }
-
         public Builder entrypoint(Arguments args) {
             config.entrypoint = args;
             return this;

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -20,9 +20,12 @@ import java.util.*;
 import io.fabric8.maven.docker.config.*;
 import io.fabric8.maven.docker.config.handler.ExternalConfigHandler;
 import io.fabric8.maven.docker.util.EnvUtil;
+import com.google.common.base.Function;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.CollectionUtils;
+
+import javax.annotation.Nullable;
 
 import static io.fabric8.maven.docker.config.handler.property.ConfigKey.*;
 
@@ -220,13 +223,13 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return ret;
     }
 
-    private String extractArguments(ValueProvider valueProvider, ConfigKey configKey, Arguments alternative) {
-        String rawAlternative = null;
-        if (alternative != null) {
-            rawAlternative = alternative.getShell();
-        }
-
-        return valueProvider.getString(configKey, rawAlternative);
+    private Arguments extractArguments(ValueProvider valueProvider, ConfigKey configKey, Arguments alternative) {
+        return valueProvider.getObject(configKey, alternative, new Function<String, Arguments>() {
+            @Override
+            public Arguments apply(@Nullable String raw) {
+                return raw != null ? new Arguments(raw) : null;
+            }
+        });
     }
 
     private RestartPolicy extractRestartPolicy(RestartPolicy config, ValueProvider valueProvider) {

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ValueProvider.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ValueProvider.java
@@ -101,6 +101,16 @@ public class ValueProvider {
         return mapValueExtractor.getFromPreferredSource(prefix, key, fromConfig);
     }
 
+    public <T> T getObject(ConfigKey key, T fromConfig, final com.google.common.base.Function<String, T> converter) {
+        ValueExtractor<T> arbitraryExtractor = new ValueExtractor<T>() {
+            @Override
+            protected T withPrefix(String prefix, ConfigKey key, Properties properties) {
+                return converter.apply(properties.getProperty(key.asPropertyKey(prefix)));
+            }
+        };
+
+        return arbitraryExtractor.getFromPreferredSource(prefix, key, fromConfig);
+    }
 
     /**
      * Helper base class for picking values out of the the Properties class and/or config value.

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
@@ -4,11 +4,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import io.fabric8.maven.docker.config.*;
 import com.google.common.collect.ImmutableMap;
-import io.fabric8.maven.docker.config.Arguments;
-import io.fabric8.maven.docker.config.HealthCheckConfiguration;
-import io.fabric8.maven.docker.config.HealthCheckMode;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -182,7 +179,7 @@ public class DockerFileBuilderTest {
 
     @Test
     public void testHealthCheckCmdParams() {
-        HealthCheckConfiguration hc = new HealthCheckConfiguration.Builder().cmd("echo hello").interval("5s").timeout("3s").startPeriod("30s").retries(4).build();
+        HealthCheckConfiguration hc = new HealthCheckConfiguration.Builder().cmd(new Arguments("echo hello")).interval("5s").timeout("3s").startPeriod("30s").retries(4).build();
         String dockerfileContent = new DockerFileBuilder().healthCheck(hc).content();
         assertThat(dockerfileToMap(dockerfileContent), hasEntry("HEALTHCHECK", "--interval=5s --timeout=3s --start-period=30s --retries=4 CMD echo hello"));
     }

--- a/src/test/java/io/fabric8/maven/docker/config/HealthCheckConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/HealthCheckConfigTest.java
@@ -10,7 +10,7 @@ public class HealthCheckConfigTest {
     @Test
     public void testGoodHealthCheck1() {
         new HealthCheckConfiguration.Builder()
-                .cmd("exit 0")
+                .cmd(new Arguments("exit 0"))
                 .build()
                 .validate();
     }
@@ -18,7 +18,7 @@ public class HealthCheckConfigTest {
     @Test
     public void testGoodHealthCheck2() {
         new HealthCheckConfiguration.Builder()
-                .cmd("exit 0")
+                .cmd(new Arguments("exit 0"))
                 .retries(1)
                 .build()
                 .validate();
@@ -27,7 +27,7 @@ public class HealthCheckConfigTest {
     @Test
     public void testGoodHealthCheck3() {
         new HealthCheckConfiguration.Builder()
-                .cmd("exit 0")
+                .cmd(new Arguments("exit 0"))
                 .retries(1)
                 .interval("2s")
                 .build()
@@ -37,7 +37,7 @@ public class HealthCheckConfigTest {
     @Test
     public void testGoodHealthCheck4() {
         new HealthCheckConfiguration.Builder()
-                .cmd("exit 0")
+                .cmd(new Arguments("exit 0"))
                 .retries(1)
                 .interval("2s")
                 .timeout("3s")
@@ -48,7 +48,8 @@ public class HealthCheckConfigTest {
     @Test
     public void testGoodHealthCheck5() {
         new HealthCheckConfiguration.Builder()
-                .cmd("exit 0")
+                .mode(HealthCheckMode.cmd)
+                .cmd(new Arguments("exit 0"))
                 .retries(1)
                 .interval("2s")
                 .timeout("3s")
@@ -61,7 +62,7 @@ public class HealthCheckConfigTest {
     public void testGoodHealthCheck6() {
         new HealthCheckConfiguration.Builder()
                 .mode(HealthCheckMode.cmd)
-                .cmd("exit 0")
+                .cmd(new Arguments("exit 0"))
                 .retries(1)
                 .interval("2s")
                 .timeout("3s")
@@ -110,6 +111,7 @@ public class HealthCheckConfigTest {
         new HealthCheckConfiguration.Builder()
                 .mode(HealthCheckMode.none)
                 .startPeriod("30s")
+                .cmd(new Arguments("echo a"))
                 .build()
                 .validate();
     }
@@ -118,7 +120,7 @@ public class HealthCheckConfigTest {
     public void testBadHealthCheck5() {
         new HealthCheckConfiguration.Builder()
                 .mode(HealthCheckMode.none)
-                .cmd("echo a")
+                .cmd(new Arguments("echo a"))
                 .build()
                 .validate();
     }

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -218,6 +218,43 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
     }
 
     @Test
+    public void testEntrypoint() {
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.from", "base",
+                        "docker.name","demo",
+                        "docker.entrypoint", "/entrypoint.sh --from-property")
+        );
+
+        assertEquals(1, configs.size());
+
+        BuildImageConfiguration buildConfig = configs.get(0).getBuildConfiguration();
+        assertArrayEquals(new String[]{"/entrypoint.sh", "--from-property"}, buildConfig.getEntryPoint().asStrings().toArray());
+    }
+
+    @Test
+    public void testEntrypointExecFromConfig() {
+        imageConfiguration = new ImageConfiguration.Builder()
+                .externalConfig(externalConfigMode(PropertyMode.Fallback))
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .entryPoint(new Arguments(Arrays.asList("/entrypoint.sh", "--from-property")))
+                        .build()
+                )
+                .build();
+
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration,props(
+                        "docker.from", "base",
+                        "docker.name","demo")
+        );
+
+        assertEquals(1, configs.size());
+
+        BuildImageConfiguration buildConfig = configs.get(0).getBuildConfiguration();
+        assertArrayEquals(new String[]{"/entrypoint.sh", "--from-property"}, buildConfig.getEntryPoint().asStrings().toArray());
+    }
+
+    @Test
     public void testDefaultLogEnabledConfiguration() {
         imageConfiguration = new ImageConfiguration.Builder()
                 .externalConfig(externalConfigMode(PropertyMode.Override))

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -263,7 +263,7 @@ public class RunServiceTest {
                         .memorySwap(1L)
                         .env(env())
                         .cmd("date")
-                        .entrypoint("entrypoint")
+                        .entrypoint(new Arguments("entrypoint"))
                         .extraHosts(extraHosts())
                         .ulimits(ulimits())
                         .workingDir("/foo")


### PR DESCRIPTION
Any `<entrypoint><exec><arg>...</arg>` would disappear when any property mode was enabled (but corresponding property not defined as property), due to bad string conversion.

Fix is to get rid of all string conversions dealing with Arguments (which was mostly from test).

Bug in #948