### PR TITLE
Add startPeriod to healthCheck

### DIFF
--- a/samples/healthcheck/pom.xml
+++ b/samples/healthcheck/pom.xml
@@ -102,7 +102,21 @@
               </build>
             </image>
             <image>
-              <alias>unhealthybox5</alias>
+              <alias>healthybox5</alias>
+              <name>busybox5</name>
+              <build>
+                <from>busybox</from>
+                <healthCheck>
+                  <interval>5m</interval>
+                  <timeout>3s</timeout>
+                  <startPeriod>30m</startPeriod>
+                  <retries>3</retries>
+                  <cmd>curl -f http://localhost/ || exit 1</cmd>
+                </healthCheck>
+              </build>
+            </image>
+            <image>
+              <alias>unhealthybox6</alias>
               <name>busybox5</name>
               <build>
                 <from>busybox</from>

--- a/src/main/asciidoc/inc/build/_healthcheck.adoc
+++ b/src/main/asciidoc/inc/build/_healthcheck.adoc
@@ -21,6 +21,9 @@ The healtcheck configuration can have the following options
 | *retries*
 | How many retries should be performed before the container is to be considered unhealthy.
 
+| *startPeriod*
+| Initialization time for containers that need time to bootstrap. Probe failure during that period will not be counted towards the maximum number of retries. However, if a health check succeeds during the start period, the container is considered started and all consecutive failures will be counted towards the maximum number of retries. Given in seconds, but another time unit can be appended.
+
 | *timeout*
 | Timeout after which healthckeck should be stopped and considered to have failed. Given in seconds, but another time unit can be appended.
 |===
@@ -35,6 +38,8 @@ The following example queries an URL every 10s as an healthcheck:
   <interval>5m</interval>
   <!-- Fail if no response after 3 seconds -->
   <timeout>3s</timeout>
+  <!-- Allow 30 minutes for the container to start before being flagged as unhealthy -->
+  <startPeriod>30m</startPeriod>
   <!-- Fail 3 times until the container is considerd unhealthy -->
   <retries>3</retries>
   <!-- Command to execute in shell form -->

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -145,6 +145,9 @@ when a `docker.from` or a `docker.fromExt` is set.
 | *docker.healthcheck.retries*
 | Number of retries for how often to retry a healthcheck until it is considered to have failed
 
+| *docker.healthcheck.startPeriod*
+| Initialization time for containers that need time to bootstrap. Probe failure during that period will not be counted towards the maximum number of retries. However, if a health check succeeds during the start period, the container is considered started and all consecutive failures will be counted towards the maximum number of retries. (in seconds or with a given time unit)
+
 | *docker.healthcheck.timeout*
 | Timeout after which a healthcheck command is considered to be failed (in seconds or with a given time unit)
 

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
@@ -133,6 +133,7 @@ public class DockerFileBuilder {
             case cmd:
                 buildOption(healthString, DockerFileOption.HEALTHCHECK_INTERVAL, healthCheck.getInterval());
                 buildOption(healthString, DockerFileOption.HEALTHCHECK_TIMEOUT, healthCheck.getTimeout());
+                buildOption(healthString, DockerFileOption.HEALTHCHECK_START_PERIOD, healthCheck.getStartPeriod());
                 buildOption(healthString, DockerFileOption.HEALTHCHECK_RETRIES, healthCheck.getRetries());
                 buildArguments(healthString, DockerFileKeyword.CMD, false, healthCheck.getCmd());
                 break;

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileOption.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileOption.java
@@ -7,6 +7,7 @@ public enum DockerFileOption
 {
     HEALTHCHECK_INTERVAL("interval"),
     HEALTHCHECK_TIMEOUT("timeout"),
+    HEALTHCHECK_START_PERIOD("start-period"),
     HEALTHCHECK_RETRIES("retries");
 
     private String key;

--- a/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
@@ -13,6 +13,8 @@ public class HealthCheckConfiguration implements Serializable {
 
     private String timeout;
 
+    private String startPeriod;
+
     private Integer retries;
 
     private Arguments cmd;
@@ -25,6 +27,10 @@ public class HealthCheckConfiguration implements Serializable {
 
     public String getTimeout() {
         return prepareTimeValue(timeout);
+    }
+
+    public String getStartPeriod() {
+        return prepareTimeValue(startPeriod);
     }
 
     private String prepareTimeValue(String timeout) {
@@ -54,7 +60,7 @@ public class HealthCheckConfiguration implements Serializable {
 
         switch(mode) {
         case none:
-            if (interval != null || timeout != null || retries != null || cmd != null) {
+            if (interval != null || timeout != null || startPeriod != null || retries != null || cmd != null) {
                 throw new IllegalArgumentException("HealthCheck: no parameters are allowed when the health check mode is set to 'none'");
             }
             break;
@@ -82,6 +88,11 @@ public class HealthCheckConfiguration implements Serializable {
 
         public Builder timeout(String timeout) {
             config.timeout = timeout;
+            return this;
+        }
+
+        public Builder startPeriod(String startPeriod) {
+            config.startPeriod = startPeriod;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -64,6 +64,7 @@ public enum ConfigKey {
     HEALTHCHECK_MODE("healthcheck.mode"),
     HEALTHCHECK_INTERVAL("healthcheck.interval"),
     HEALTHCHECK_TIMEOUT("healthcheck.timeout"),
+    HEALTHCHECK_START_PERIOD("healthcheck.startPeriod"),
     HEALTHCHECK_RETRIES("healthcheck.retries"),
     HEALTHCHECK_CMD("healthcheck.cmd"),
     HOSTNAME,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -195,6 +195,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             return new HealthCheckConfiguration.Builder()
                     .interval(valueProvider.getString(HEALTHCHECK_INTERVAL, config == null ? null : config.getInterval()))
                     .timeout(valueProvider.getString(HEALTHCHECK_TIMEOUT, config == null ? null : config.getTimeout()))
+                    .startPeriod(valueProvider.getString(HEALTHCHECK_START_PERIOD, config == null ? null : config.getStartPeriod()))
                     .retries(valueProvider.getInteger(HEALTHCHECK_RETRIES, config == null ? null : config.getRetries()))
                     .mode(valueProvider.getString(HEALTHCHECK_MODE, config == null || config.getMode() == null ? null : config.getMode().name()))
                     .cmd(extractArguments(valueProvider, HEALTHCHECK_CMD, config == null ? null : config.getCmd()))

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
@@ -182,9 +182,9 @@ public class DockerFileBuilderTest {
 
     @Test
     public void testHealthCheckCmdParams() {
-        HealthCheckConfiguration hc = new HealthCheckConfiguration.Builder().cmd("echo hello").interval("5s").timeout("3s").retries(4).build();
+        HealthCheckConfiguration hc = new HealthCheckConfiguration.Builder().cmd("echo hello").interval("5s").timeout("3s").startPeriod("30s").retries(4).build();
         String dockerfileContent = new DockerFileBuilder().healthCheck(hc).content();
-        assertThat(dockerfileToMap(dockerfileContent), hasEntry("HEALTHCHECK", "--interval=5s --timeout=3s --retries=4 CMD echo hello"));
+        assertThat(dockerfileToMap(dockerfileContent), hasEntry("HEALTHCHECK", "--interval=5s --timeout=3s --start-period=30s --retries=4 CMD echo hello"));
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/config/HealthCheckConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/HealthCheckConfigTest.java
@@ -48,17 +48,30 @@ public class HealthCheckConfigTest {
     @Test
     public void testGoodHealthCheck5() {
         new HealthCheckConfiguration.Builder()
-                .mode(HealthCheckMode.cmd)
                 .cmd("exit 0")
                 .retries(1)
                 .interval("2s")
                 .timeout("3s")
+                .startPeriod("30s")
                 .build()
                 .validate();
     }
 
     @Test
     public void testGoodHealthCheck6() {
+        new HealthCheckConfiguration.Builder()
+                .mode(HealthCheckMode.cmd)
+                .cmd("exit 0")
+                .retries(1)
+                .interval("2s")
+                .timeout("3s")
+                .startPeriod("4s")
+                .build()
+                .validate();
+    }
+
+    @Test
+    public void testGoodHealthCheck7() {
         new HealthCheckConfiguration.Builder()
                 .mode(HealthCheckMode.none)
                 .build()
@@ -96,7 +109,7 @@ public class HealthCheckConfigTest {
     public void testBadHealthCheck4() {
         new HealthCheckConfiguration.Builder()
                 .mode(HealthCheckMode.none)
-                .cmd("echo a")
+                .startPeriod("30s")
                 .build()
                 .validate();
     }
@@ -104,12 +117,21 @@ public class HealthCheckConfigTest {
     @Test(expected = IllegalArgumentException.class)
     public void testBadHealthCheck5() {
         new HealthCheckConfiguration.Builder()
+                .mode(HealthCheckMode.none)
+                .cmd("echo a")
                 .build()
                 .validate();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testBadHealthCheck6() {
+        new HealthCheckConfiguration.Builder()
+                .build()
+                .validate();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadHealthCheck7() {
         new HealthCheckConfiguration.Builder()
                 .mode(HealthCheckMode.cmd)
                 .build()


### PR DESCRIPTION
Addresses issue #961.  A startPeriod may now be specified in the health
check in the POM.  This works in the same way as adding a start-period
option to a Dockerfile.