### PR TITLE
Unbreak implicit enabling of log configuration

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -12,19 +12,15 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 
-import com.google.common.util.concurrent.MoreExecutors;
-import io.fabric8.maven.docker.access.DockerAccessException;
-import io.fabric8.maven.docker.access.ExecException;
-import io.fabric8.maven.docker.access.PortMapping;
+import io.fabric8.maven.docker.access.*;
 import io.fabric8.maven.docker.config.*;
 import io.fabric8.maven.docker.log.LogDispatcher;
 import io.fabric8.maven.docker.model.Container;
 import io.fabric8.maven.docker.service.*;
 import io.fabric8.maven.docker.util.StartOrderResolver;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.*;
 import org.codehaus.plexus.util.StringUtils;
 
 
@@ -370,7 +366,7 @@ public class StartMojo extends AbstractDockerMojo {
         if (runConfig != null) {
             LogConfiguration logConfig = runConfig.getLogConfiguration();
             if (logConfig != null) {
-                return Boolean.TRUE == logConfig.isEnabled();
+                return logConfig.isActivated();
             } else {
                 // Default is to show logs if "follow" is true
                 return follow;

--- a/src/main/java/io/fabric8/maven/docker/config/LogConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/LogConfiguration.java
@@ -11,7 +11,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  */
 public class LogConfiguration implements Serializable {
 
-    public static final LogConfiguration DEFAULT = new LogConfiguration(false, null, null, null, null, null);
+    public static final LogConfiguration DEFAULT = new LogConfiguration(null, null, null, null, null, null);
 
     @Parameter(defaultValue = "true")
     private Boolean enabled;
@@ -58,6 +58,25 @@ public class LogConfiguration implements Serializable {
         return enabled;
     }
 
+    /**
+     * If explicitly enabled, or configured in any way and NOT explicitly disabled, return true.
+     *
+     * @return
+     */
+    public boolean isActivated() {
+        return enabled == Boolean.TRUE ||
+                (enabled != Boolean.FALSE && !isBlank());
+    }
+
+    /**
+     * Returns true if all options (except enabled) are null, used to decide value of enabled.
+     *
+     * @return
+     */
+    private boolean isBlank() {
+        return prefix == null && date == null && color == null && file == null && driver == null;
+    }
+
     public String getFileLocation() {
         return file;
     }
@@ -95,11 +114,11 @@ public class LogConfiguration implements Serializable {
     // =============================================================================
 
     public static class Builder {
-        private Boolean enabled = true;
+        private Boolean enabled;
         private String prefix, date, color, file;
         private Map<String, String> driverOpts;
         private String driverName;
-        public Builder enabled(boolean enabled) {
+        public Builder enabled(Boolean enabled) {
             this.enabled = enabled;
             return this;
         }
@@ -132,15 +151,6 @@ public class LogConfiguration implements Serializable {
         public Builder logDriverOpts(Map<String, String> logOpts) {
             this.driverOpts = logOpts;
             return this;
-        }
-
-        /**
-         * Returns true if all options (except enabled) are null, used to decide value of enabled.
-         *
-         * @return
-         */
-        public boolean isBlank() {
-            return prefix == null && date == null && color == null && file == null && driverName == null && driverOpts == null;
         }
 
         public LogConfiguration build() {

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -75,6 +75,7 @@ public enum ConfigKey {
     LOG_ENABLED("log.enabled"),
     LOG_PREFIX("log.prefix"),
     LOG_DATE("log.date"),
+    LOG_FILE("log.file"),
     LOG_COLOR("log.color"),
     LOG_DRIVER_NAME("log.driver.name"),
     LOG_DRIVER_OPTS("log.driver.opts"),

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -246,11 +246,6 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
 
         Boolean configEnabled = config != null ? config.isEnabled() : null;
         Boolean enabled = valueProvider.getBoolean(LOG_ENABLED, configEnabled);
-
-        if (enabled == null) {
-            enabled = configEnabled == Boolean.TRUE || !builder.isBlank();
-        }
-        
         builder.enabled(enabled);
         return builder.build();
     }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -240,6 +240,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         LogConfiguration.Builder builder = new LogConfiguration.Builder()
             .color(valueProvider.getString(LOG_COLOR, config == null ? null : config.getColor()))
             .date(valueProvider.getString(LOG_DATE, config == null ? null : config.getDate()))
+            .file(valueProvider.getString(LOG_FILE, config == null ? null : config.getFileLocation()))
             .prefix(valueProvider.getString(LOG_PREFIX, config == null ? null : config.getPrefix()))
             .logDriverName(valueProvider.getString(LOG_DRIVER_NAME, config == null || config.getDriver() == null ? null : config.getDriver().getName()))
             .logDriverOpts(valueProvider.getMap(LOG_DRIVER_OPTS, config == null || config.getDriver() == null ? null : config.getDriver().getOpts()));

--- a/src/test/java/io/fabric8/maven/docker/config/LogConfigurationTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/LogConfigurationTest.java
@@ -1,0 +1,80 @@
+package io.fabric8.maven.docker.config;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests LogConfiguration
+ */
+public class LogConfigurationTest {
+    @Test
+    public void testDefaultConfiguration() {
+        LogConfiguration cfg = LogConfiguration.DEFAULT;
+        assertNull(cfg.isEnabled());
+        assertFalse(cfg.isActivated());
+    }
+
+    @Test
+    public void testEmptyBuiltConfiguration() {
+        LogConfiguration cfg = new LogConfiguration.Builder()
+                .build();
+        assertNull(cfg.isEnabled());
+        assertFalse(cfg.isActivated());
+    }
+
+    @Test
+    public void testNonEmptyBuiltConfiguration() {
+        LogConfiguration cfg = new LogConfiguration.Builder()
+                .file("test")
+                .build();
+        assertNull(cfg.isEnabled());
+        assertTrue(cfg.isActivated());
+
+        cfg = new LogConfiguration.Builder()
+                .color("test")
+                .build();
+        assertNull(cfg.isEnabled());
+        assertTrue(cfg.isActivated());
+
+        cfg = new LogConfiguration.Builder()
+                .logDriverName("test")
+                .build();
+        assertNull(cfg.isEnabled());
+        assertTrue(cfg.isActivated());
+
+        cfg = new LogConfiguration.Builder()
+                .date("1234")
+                .build();
+        assertNull(cfg.isEnabled());
+        assertTrue(cfg.isActivated());
+    }
+
+    @Test
+    public void testEnabled() {
+        LogConfiguration cfg = new LogConfiguration.Builder()
+                .enabled(true)
+                .build();
+        assertTrue(cfg.isEnabled());
+        assertTrue(cfg.isActivated());
+
+        cfg = new LogConfiguration.Builder()
+                .enabled(true)
+                .color("red")
+                .build();
+        assertTrue(cfg.isEnabled());
+        assertTrue(cfg.isActivated());
+        assertEquals("red", cfg.getColor());
+    }
+
+    @Test
+    public void testDisabled() {
+        LogConfiguration cfg = new LogConfiguration.Builder()
+                .color("red")
+                .enabled(false)
+                .build();
+        assertFalse(cfg.isEnabled());
+        assertFalse(cfg.isActivated());
+        assertEquals("red", cfg.getColor());
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -235,7 +235,8 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals(1, configs.size());
 
         RunImageConfiguration runConfiguration = configs.get(0).getRunConfiguration();
-        assertFalse(runConfiguration.getLogConfiguration().isEnabled());
+        assertNull(runConfiguration.getLogConfiguration().isEnabled());
+        assertFalse(runConfiguration.getLogConfiguration().isActivated());
 
         // If any log property is set, enabled shall be true by default
         configs = resolveImage(
@@ -246,7 +247,8 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         );
 
         runConfiguration = getRunImageConfiguration(configs);
-        assertTrue(runConfiguration.getLogConfiguration().isEnabled());
+        assertNull(runConfiguration.getLogConfiguration().isEnabled());
+        assertTrue(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("green", runConfiguration.getLogConfiguration().getColor());
 
 
@@ -266,7 +268,8 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         );
 
         runConfiguration = getRunImageConfiguration(configs);
-        assertTrue(runConfiguration.getLogConfiguration().isEnabled());
+        assertNull(runConfiguration.getLogConfiguration().isEnabled());
+        assertTrue(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("red", runConfiguration.getLogConfiguration().getColor());
 
 
@@ -279,7 +282,8 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         );
 
         runConfiguration = getRunImageConfiguration(configs);
-        assertTrue(runConfiguration.getLogConfiguration().isEnabled());
+        assertNull(runConfiguration.getLogConfiguration().isEnabled());
+        assertTrue(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("yellow", runConfiguration.getLogConfiguration().getColor());
 
 
@@ -293,7 +297,8 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         );
 
         runConfiguration = getRunImageConfiguration(configs);
-        assertTrue(runConfiguration.getLogConfiguration().isEnabled());
+        assertNull(runConfiguration.getLogConfiguration().isEnabled());
+        assertTrue(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("red", runConfiguration.getLogConfiguration().getColor());
     }
 
@@ -317,6 +322,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
         RunImageConfiguration runConfiguration = getRunImageConfiguration(configs);
         assertTrue(runConfiguration.getLogConfiguration().isEnabled());
+        assertTrue(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("red", runConfiguration.getLogConfiguration().getColor());
 
         // Explicitly disabled
@@ -331,6 +337,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
         runConfiguration = getRunImageConfiguration(configs);
         assertFalse(runConfiguration.getLogConfiguration().isEnabled());
+        assertFalse(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("yellow", runConfiguration.getLogConfiguration().getColor());
 
 
@@ -351,6 +358,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
         runConfiguration = getRunImageConfiguration(configs);
         assertFalse(runConfiguration.getLogConfiguration().isEnabled());
+        assertFalse(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("red", runConfiguration.getLogConfiguration().getColor());
 
         // Enabled by property, with override
@@ -364,6 +372,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
         runConfiguration = getRunImageConfiguration(configs);
         assertTrue(runConfiguration.getLogConfiguration().isEnabled());
+        assertTrue(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("red", runConfiguration.getLogConfiguration().getColor());
 
         // Disabled with property too
@@ -376,6 +385,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
         runConfiguration = getRunImageConfiguration(configs);
         assertFalse(runConfiguration.getLogConfiguration().isEnabled());
+        assertFalse(runConfiguration.getLogConfiguration().isActivated());
         assertEquals("red", runConfiguration.getLogConfiguration().getColor());
     }
 

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -389,6 +389,51 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals("red", runConfiguration.getLogConfiguration().getColor());
     }
 
+    @Test
+    public void testLogFile() {
+        imageConfiguration = new ImageConfiguration.Builder()
+                .externalConfig(externalConfigMode(PropertyMode.Override))
+                .runConfig(new RunImageConfiguration.Builder()
+                        .log(new LogConfiguration.Builder().file("myfile").build())
+                        .build()
+                )
+                .build();
+
+        List<ImageConfiguration> configs = resolveImage(
+                imageConfiguration, props(
+                        "docker.from", "base",
+                        "docker.name", "demo")
+        );
+
+        assertEquals(1, configs.size());
+
+        RunImageConfiguration runConfiguration = configs.get(0).getRunConfiguration();
+        assertNull(runConfiguration.getLogConfiguration().isEnabled());
+        assertTrue(runConfiguration.getLogConfiguration().isActivated());
+        assertEquals("myfile", runConfiguration.getLogConfiguration().getFileLocation());
+
+        imageConfiguration = new ImageConfiguration.Builder()
+                .externalConfig(externalConfigMode(PropertyMode.Override))
+                .runConfig(new RunImageConfiguration.Builder()
+                        .build()
+                )
+                .build();
+
+        configs = resolveImage(
+                imageConfiguration, props(
+                        "docker.from", "base",
+                        "docker.name", "demo",
+                        "docker.log.file", "myfilefromprop")
+        );
+
+        assertEquals(1, configs.size());
+
+        runConfiguration = configs.get(0).getRunConfiguration();
+        assertNull(runConfiguration.getLogConfiguration().isEnabled());
+        assertTrue(runConfiguration.getLogConfiguration().isActivated());
+        assertEquals("myfilefromprop", runConfiguration.getLogConfiguration().getFileLocation());
+    }
+
     private RunImageConfiguration getRunImageConfiguration(List<ImageConfiguration> configs) {
         assertEquals(1, configs.size());
         return configs.get(0).getRunConfiguration();


### PR DESCRIPTION
My previous `enabled` logic change was flawed, and failed to activate LogConfiguration for pom-only configs.

In addition, there was never any property for `log.file`, causing `<file>` in pom to be dropped entirely (as no merge could happen).

Fixes #1010 