### PR TITLE
Issue #1033 : don't try to decrypt a JSON key password (used by GCR auh)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -228,8 +228,9 @@ public class AuthConfigFactory {
             if (!props.containsKey(passwordKey)) {
                 throw new MojoExecutionException("No " + passwordKey + " provided for username " + props.getProperty(userKey));
             }
+            String password = props.getProperty(passwordKey);
             return new AuthConfig(props.getProperty(userKey),
-                                  decrypt(props.getProperty(passwordKey)),
+                                  EnvUtil.isJsonObject(password) ? password : decrypt(password),
                                   props.getProperty(lookupMode.asSysProperty(AUTH_EMAIL)),
                                   props.getProperty(lookupMode.asSysProperty(AUTH_AUTHTOKEN)));
         } else {

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -14,6 +14,8 @@ import com.google.common.collect.Lists;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.io.FileUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -462,6 +464,15 @@ public class EnvUtil {
         Matcher matcher = pattern.matcher(filename);
         boolean isMatch = matcher.matches();
         return isMatch;
+    }
+
+    public static boolean isJsonObject(String test) {
+        try {
+            new JSONObject(test);
+        } catch (JSONException ex) {
+            return false;
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
Bypass Plexus `DefaultSecDispatcher#isEncryptedString` that matches a JSON string as a Maven encrypted password:

```
ENCRYPTED_STRING_PATTERN = Pattern.compile( ".*?[^\\\\]?\\{(.*?[^\\\\])\\}.*" );
```

Fist time with JMockit expectations: so simple!