### PR TITLE
Fix encoding for X-Registry-Auth

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
@@ -80,10 +80,23 @@ public class AuthConfig {
         putNonNull(ret, "email", email);
         putNonNull(ret, "auth", auth);
         try {
-            return Base64.encodeBase64String(ret.toString().getBytes("UTF-8"));
+            return encodeBase64ChunkedURLSafeString(ret.toString().getBytes("UTF-8"));
         } catch (UnsupportedEncodingException e) {
-            return Base64.encodeBase64String(ret.toString().getBytes());
+            return encodeBase64ChunkedURLSafeString(ret.toString().getBytes());
         }
+    }
+
+    /**
+     * Encodes the given binaryData in a format that is compatible with the Docker Engine API.
+     * That is, base64 encoded, padded, and URL safe.
+     *
+     * @param binaryData data to encode
+     * @return encoded data
+     */
+    private String encodeBase64ChunkedURLSafeString(final byte[] binaryData) {
+        return Base64.encodeBase64String(binaryData)
+                .replace('+', '-')
+                .replace('_', '/');
     }
 
     private void putNonNull(JSONObject ret, String key, String value) {

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigTest.java
@@ -43,8 +43,8 @@ public class AuthConfigTest {
         // Since Base64.decodeBase64 handles URL-safe encoding, must explicitly check
         // the correct characters are used
         assertEquals(
-                config.toHeaderValue(),
-                "eyJwYXNzd29yZCI6IiM-c2VjcmV0ISIsImVtYWlsIjoicm9sYW5kQGpvbG9raWEub3JnIiwidXNlcm5hbWUiOiJyb2xhbmQifQ=="
+                "eyJwYXNzd29yZCI6IiM-c2VjcmV0ISIsImVtYWlsIjoicm9sYW5kQGpvbG9raWEub3JnIiwidXNlcm5hbWUiOiJyb2xhbmQifQ==",
+                config.toHeaderValue()
         );
 
         String header = new String(Base64.decodeBase64(config.toHeaderValue()));

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigTest.java
@@ -21,7 +21,7 @@ public class AuthConfigTest {
     public void simpleConstructor() {
         Map<String,String> map = new HashMap<String,String>();
         map.put("username","roland");
-        map.put("password","secret");
+        map.put("password","#>secret!");
         map.put("email","roland@jolokia.org");
         AuthConfig config = new AuthConfig(map);
         check(config);
@@ -29,21 +29,29 @@ public class AuthConfigTest {
 
     @Test
     public void mapConstructor() {
-        AuthConfig config = new AuthConfig("roland","secret","roland@jolokia.org",null);
+        AuthConfig config = new AuthConfig("roland","#>secret!","roland@jolokia.org",null);
         check(config);
     }
 
     @Test
     public void dockerLoginConstructor() {
-        AuthConfig config = new AuthConfig(Base64.encodeBase64String("roland:secret".getBytes()),"roland@jolokia.org");
+        AuthConfig config = new AuthConfig(Base64.encodeBase64String("roland:#>secret!".getBytes()),"roland@jolokia.org");
         check(config);
     }
 
     private void check(AuthConfig config) {
+        // Since Base64.decodeBase64 handles URL-safe encoding, must explicitly check
+        // the correct characters are used
+        assertEquals(
+                config.toHeaderValue(),
+                "eyJwYXNzd29yZCI6IiM-c2VjcmV0ISIsImVtYWlsIjoicm9sYW5kQGpvbG9raWEub3JnIiwidXNlcm5hbWUiOiJyb2xhbmQifQ=="
+        );
+
         String header = new String(Base64.decodeBase64(config.toHeaderValue()));
+
         JSONObject data = new JSONObject(header);
         assertEquals("roland",data.getString("username"));
-        assertEquals("secret",data.getString("password"));
+        assertEquals("#>secret!",data.getString("password"));
         assertEquals("roland@jolokia.org",data.getString("email"));
         assertFalse(data.has("auth"));
     }


### PR DESCRIPTION
I was getting mysterious failures when pushing images -- turned out I had some characters in the password causing `+` to be part of the resulting base64 string.

It appears that this isn't documented very well, but Docker Engine requires URL-safe base64 encoding.

Related issue: https://github.com/moby/moby/issues/19214
Related code: https://github.com/moby/moby/blob/4bf8714fac11e95e835cf78eb15ba5a518c67c4b/api/server/router/image/image_routes.go#L140-L146

With this fix, my arcane password is now working.