### PR TITLE
Fix #1060: Smarter API version handling

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -12,6 +12,7 @@
 
   - Fix NPE regression related to volumes (again) (#1091)
   - Fix NPE when stopping containers with autoCreateCustomNetworks (#1097)
+  - Smarter API version handling (#1060)
   - Fix regression when calling the credential helper for authentication, leading to an exception because of the usage of an already shutdown executor service (#1098)
   - Add support for CPU configurations with compose (#1102)
 

--- a/src/test/java/integration/DockerAccessIT.java
+++ b/src/test/java/integration/DockerAccessIT.java
@@ -17,7 +17,6 @@ import io.fabric8.maven.docker.access.hc.DockerAccessWithHcClient;
 import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.config.DockerMachineConfiguration;
 import io.fabric8.maven.docker.model.Container.PortBinding;
-import io.fabric8.maven.docker.service.DockerAccessFactory;
 import io.fabric8.maven.docker.util.AnsiLogger;
 import io.fabric8.maven.docker.util.Logger;
 
@@ -110,7 +109,7 @@ public class DockerAccessIT {
     private DockerAccessWithHcClient createClient(String baseUrl, Logger logger) {
         try {
             String certPath = createDockerConnectionDetector(logger).detectConnectionParameter(null,null).getCertPath();
-            return new DockerAccessWithHcClient("v" + DockerAccessFactory.API_VERSION, baseUrl, certPath, 20, logger);
+            return new DockerAccessWithHcClient(baseUrl, certPath, 20, logger);
         } catch (@SuppressWarnings("unused") IOException e) {
             // not using ssl, so not going to happen
             logger.error(e.getMessage());

--- a/src/test/java/integration/DockerAccessWinIT.java
+++ b/src/test/java/integration/DockerAccessWinIT.java
@@ -16,7 +16,6 @@ import io.fabric8.maven.docker.access.PortMapping;
 import io.fabric8.maven.docker.access.hc.DockerAccessWithHcClient;
 import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.model.Container.PortBinding;
-import io.fabric8.maven.docker.service.DockerAccessFactory;
 import io.fabric8.maven.docker.util.AnsiLogger;
 import io.fabric8.maven.docker.util.Logger;
 
@@ -98,7 +97,7 @@ public class DockerAccessWinIT {
     private DockerAccessWithHcClient createClient(String baseUrl, Logger logger) {
         try {
             String certPath = createDockerConnectionDetector(logger).detectConnectionParameter(null, null).getCertPath();
-            return new DockerAccessWithHcClient("v" + DockerAccessFactory.API_VERSION, baseUrl, certPath, 1, logger);
+            return new DockerAccessWithHcClient(baseUrl, certPath, 1, logger);
         } catch (@SuppressWarnings("unused") IOException e) {
             // not using ssl, so not going to happen
             logger.error(e.getMessage());

--- a/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
@@ -45,7 +45,7 @@ public class DockerAccessWithHcClientTest {
 
     @Before
     public void setup() throws IOException {
-        client = new DockerAccessWithHcClient("v1.20", "tcp://1.2.3.4:2375", null, 1, mockLogger) {
+        client = new DockerAccessWithHcClient("tcp://1.2.3.4:2375", null, 1, mockLogger) {
             @Override
             ApacheHttpClientDelegate createHttpClient(ClientBuilder builder) throws IOException {
                 return mockDelegate;


### PR DESCRIPTION
#1060 Send a test request to the Daemon, and check whether it succeeds. In the return response
there's a header Api-Version: which holds the actual Docker daemon version. If this test
request because of a too low version, we can just pick up that version and use it as
minimal version for us.