### PR TITLE
Added 'readOnly' option to run configuration to mount container's roo…

### DIFF
--- a/src/main/asciidoc/inc/start/_configuration.adoc
+++ b/src/main/asciidoc/inc/start/_configuration.adoc
@@ -104,6 +104,9 @@ a| *This option is deprecated, please use a `containerNamePattern` instead* Nami
 | *privileged*
 | If `true` give container full access to host
 
+| *readOnly*
+| If `true` mount the container's root filesystem as read only
+
 | <<start-restart, *restartPolicy*>>
 | Restart Policy
 

--- a/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
@@ -194,6 +194,10 @@ public class ContainerHostConfig {
         }
         return this;
     }
+    
+    public ContainerHostConfig readonlyRootfs(Boolean readOnly) {
+        return add("ReadonlyRootfs", readOnly);
+    }
 
     /**
      * Get JSON which is used for <em>starting</em> a container

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -173,12 +173,16 @@ public class RunImageConfiguration implements Serializable {
 
     @Parameter
     private Boolean skip;
-
+    
     /**
      * Policy for pulling the image to start
      */
     @Parameter
     private String imagePullPolicy;
+
+    // Mount the container's root filesystem as read only
+    @Parameter
+    private Boolean readOnly;
 
     public RunImageConfiguration() { }
 
@@ -383,6 +387,10 @@ public class RunImageConfiguration implements Serializable {
 
     public String getContainerNamePattern() {
         return containerNamePattern;
+    }
+
+    public Boolean getReadOnly() {
+        return readOnly;
     }
 
     /**
@@ -628,6 +636,11 @@ public class RunImageConfiguration implements Serializable {
             if (imagePullPolicy != null) {
                 config.imagePullPolicy = imagePullPolicy;
             }
+            return this;
+        }
+
+        public Builder readOnly(Boolean readOnly) {
+            config.readOnly = readOnly;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -94,6 +94,7 @@ public enum ConfigKey {
     PORT_PROPERTY_FILE,
     PORTS(ValueCombinePolicy.Merge),
     PRIVILEGED,
+    READ_ONLY,
     REGISTRY,
     RESTART_POLICY_NAME("restartPolicy.name"),
     RESTART_POLICY_RETRY("restartPolicy.retry"),

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -207,6 +207,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .cpuShares(valueProvider.getLong(CPUSHARES, config == null ? null : config.getCpuShares()))
                 .cpus(valueProvider.getLong(CPUS, config == null ? null : config.getCpus()))
                 .cpuSet(valueProvider.getString(CPUSET, config == null ? null : config.getCpuSet()))
+                .readOnly(valueProvider.getBoolean(READ_ONLY, config == null ? null : config.getReadOnly()))
                 .build();
     }
 

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -357,7 +357,8 @@ public class RunService {
                 .ulimits(runConfig.getUlimits())
                 .cpuShares(runConfig.getCpuShares())
                 .cpus(runConfig.getCpus())
-                .cpuSet(runConfig.getCpuSet());
+                .cpuSet(runConfig.getCpuSet())
+                .readonlyRootfs(runConfig.getReadOnly());
 
         addVolumeConfig(config, runConfig, baseDir);
         addNetworkingConfig(config, runConfig);

--- a/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
@@ -3,6 +3,7 @@ package io.fabric8.maven.docker.access;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.json.JSONException;
 import org.junit.Test;
 
@@ -90,6 +91,21 @@ public class ContainerHostConfigTest {
             ContainerHostConfig hc = new ContainerHostConfig();
             JsonObject result = hc.tmpfs(Arrays.asList(data[i])).toJsonObject();
             JsonObject expected = JsonFactory.newJsonObject(data[i + 1]);
+            assertEquals(expected, result);
+        }
+    }
+    
+    @Test
+    public void testReadonlyRootfs() throws Exception {
+        Pair [] data = {
+            Pair.of(Boolean.TRUE, "{ReadonlyRootfs: true}"),
+            Pair.of(Boolean.FALSE, "{ReadonlyRootfs: false}")
+        };
+        for (int i = 0; i < data.length; i++) {
+        	Pair<Boolean, String> d = data[i];
+            ContainerHostConfig hc = new ContainerHostConfig();
+            JsonObject result = hc.readonlyRootfs(d.getLeft()).toJsonObject();
+            JsonObject expected = JsonFactory.newJsonObject(d.getRight());
             assertEquals(expected, result);
         }
     }

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -928,7 +928,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals("/var/lib/mysql:10m", runConfig.getTmpfs().get(0));
         assertEquals(1, runConfig.getTmpfs().size());
         assertEquals("Never", runConfig.getImagePullPolicy());
-
+        assertEquals(true, runConfig.getReadOnly());
 
         validateEnv(runConfig.getEnv());
 
@@ -1046,7 +1046,8 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
             k(ConfigKey.WORKING_DIR), "foo",
             k(ConfigKey.TMPFS) + ".1", "/var/lib/mysql:10m",
             k(ConfigKey.IMAGE_PULL_POLICY_BUILD), "Always",
-            k(ConfigKey.IMAGE_PULL_POLICY_RUN), "Never"
+            k(ConfigKey.IMAGE_PULL_POLICY_RUN), "Never",
+            k(ConfigKey.READ_ONLY), "true",
         };
     }
 

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -357,6 +357,7 @@ public class RunServiceTest {
                         .restartPolicy(restartPolicy())
                         .net("custom_network")
                         .network(networkConfiguration())
+                        .readOnly(false)
                         .build();
     }
 

--- a/src/test/resources/docker/containerCreateConfigAll.json
+++ b/src/test/resources/docker/containerCreateConfigAll.json
@@ -67,6 +67,7 @@
     "CpuShares":1,
     "NanoCpus": 1000000000,
     "CpusetCpus":"0,1",
+    "ReadonlyRootfs":false,    
     "Binds":[
       "/host_tmp:/container_tmp"
     ],

--- a/src/test/resources/docker/containerHostConfigAll.json
+++ b/src/test/resources/docker/containerHostConfigAll.json
@@ -47,6 +47,7 @@
   "CpuShares":1,
   "NanoCpus":1000000000,
   "CpusetCpus":"0,1",
+  "ReadonlyRootfs":false,    
   "Binds":[
     "/host_tmp:/container_tmp"
   ],


### PR DESCRIPTION
'docker run' provided the option --read-only to mount a container's root file system as read only.
The docker-maven-plugin didn't provide such an option, so I have added it to be able to run
integration tests with that option.