### PR TITLE
Reintroduce minimal api-version parameter for Api-Versions < 1.25

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+* 0.28.1
+  - Reintroduce minimal API-VERSION parameter in order to support docker versions below apiVersion 1.25
+
 * **0.28.0** (2018-12-13)
   - Update to JMockit 1.43
   - Compiles with Java 11

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -92,6 +92,9 @@ public class DockerAccessWithHcClient implements DockerAccess {
     // Base URL which is given through when using NamedPipe communication but is not really used
     private static final String NPIPE_URL = "npipe://127.0.0.1:1/";
 
+    // Minimal API version, independent of any feature used
+    public static final String API_VERSION = "1.18";
+
     // Logging
     private final Logger log;
 
@@ -721,6 +724,6 @@ public class DockerAccessWithHcClient implements DockerAccess {
         get.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
         CloseableHttpResponse response = delegate.getHttpClient().execute(get);
 
-        return response.getFirstHeader("Api-Version") != null ? response.getFirstHeader("Api-Version").getValue() : null;
+        return response.getFirstHeader("Api-Version") != null ? response.getFirstHeader("Api-Version").getValue() : API_VERSION;
     }
 }


### PR DESCRIPTION
Since Api-Version header was introduced in 1.25, we should send a minimal api-version
rather than just sending null. See this comment:
   https://github.com/fabric8io/docker-maven-plugin/issues/1060#issuecomment-453348656