### PR TITLE
docs: Correct default image naming

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,7 @@
 
 * 0.28.1
   - Reintroduce minimal API-VERSION parameter in order to support docker versions below apiVersion 1.25
+  - docs: Correct default image naming
 
 * **0.28.0** (2018-12-13)
   - Update to JMockit 1.43

--- a/src/main/asciidoc/inc/image/_naming.adoc
+++ b/src/main/asciidoc/inc/image/_naming.adoc
@@ -30,7 +30,7 @@ Similar to image name placeholders, for starting and stopping containers and alt
 
 These placeholders can be used in the top-level configuration value `containerNamePattern` which is used globally for every container that is created.
 This global pattern can be overwritten individually by each image's <<config-image-run, *run*>> configuration.
-If neither is given, then by default the pattern `%n-%a` is used.
+If neither is given, then by default the pattern `%n-%i` is used.
 
 When specifying the container name pattern the following placeholders can be used:
 


### PR DESCRIPTION
The same document claims the default pattern is `%n-%i` and `%n-%a` in different places.

It seems to me it's `%n-%i`