### PR TITLE
Update jnr-unixsocket 0.21->0.22.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
   - Reintroduce minimal API-VERSION parameter in order to support docker versions below apiVersion 1.25
   - docs: Correct default image naming
   - close api version http connection ([#1152](https://github.com/fabric8io/docker-maven-plugin/issues/1152))
+  - Update to jnr-unixsocket 0.22
 
 * **0.28.0** (2018-12-13)
   - Update to JMockit 1.43

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.21</version>
+      <version>0.22</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Resolves issues similar to #1119.