### PR TITLE
Enhance Fix #541: Allow @sha256 digest for tags in FROM

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/ImageName.java
+++ b/src/main/java/io/fabric8/maven/docker/util/ImageName.java
@@ -182,7 +182,6 @@ public class ImageName {
      * @return full name with original registry (if set) or optional registry (if not <code>null</code>).
      */
     public String getFullName(String optionalRegistry) {
-
         String fullName = getNameWithoutTag(optionalRegistry);
         if (tag != null) {
             fullName = fullName +  ":" + tag;
@@ -231,18 +230,18 @@ public class ImageName {
         String image = user != null ? repository.substring(user.length() + 1) : repository;
 
         Object[] checks = new Object[] {
-                "registry", DOMAIN_REGEXP, registry,
-                "image", IMAGE_NAME_REGEXP, image,
-                "user", NAME_COMP_REGEXP, user,
-                "tag", TAG_REGEXP, tag,
-                "digest", DIGEST_REGEXP, digest
+            "registry", DOMAIN_REGEXP, registry,
+            "image", IMAGE_NAME_REGEXP, image,
+            "user", NAME_COMP_REGEXP, user,
+            "tag", TAG_REGEXP, tag,
+            "digest", DIGEST_REGEXP, digest
         };
 
         for (int i = 0; i < checks.length; i +=3) {
             String value = (String) checks[i + 2];
             Pattern checkPattern = (Pattern) checks[i + 1];
             if (value != null &&
-                    !checkPattern.matcher(value).matches()) {
+                !checkPattern.matcher(value).matches()) {
                 errors.add(String.format("%s part '%s' doesn't match allowed pattern '%s'",
                         checks[i], value, checkPattern.pattern()));
             }

--- a/src/main/java/io/fabric8/maven/docker/util/ImageName.java
+++ b/src/main/java/io/fabric8/maven/docker/util/ImageName.java
@@ -64,25 +64,35 @@ public class ImageName {
             throw new NullPointerException("Image name must not be null");
         }
 
+        // set digest to null as default
+        digest = null;
+        // check if digest is part of fullName, if so -> extract it
         if(fullName.contains("@sha256")) { // Of it contains digest
             String[] digestParts = fullName.split("@");
             digest = digestParts[1];
-            parseComponentsBeforeTag(digestParts[0]);
-        } else {
-            digest = null;
-            Pattern tagPattern = Pattern.compile("^(.+?)(?::([^:/]+))?$");
-            Matcher matcher = tagPattern.matcher(fullName);
-            if (!matcher.matches()) {
-                throw new IllegalArgumentException(fullName + " is not a proper image name ([registry/][repo][:port]");
-            }
-            tag = givenTag != null ? givenTag : matcher.group(2);
-            String rest = matcher.group(1);
+            fullName = digestParts[0];
+        }
 
-            parseComponentsBeforeTag(rest);
+        // check for tag
+        Pattern tagPattern = Pattern.compile("^(.+?)(?::([^:/]+))?$");
+        Matcher matcher = tagPattern.matcher(fullName);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(fullName + " is not a proper image name ([registry/][repo][:port]");
+        }
+        // extract tag if it exists
+        tag = givenTag != null ? givenTag : matcher.group(2);
+        String rest = matcher.group(1);
 
-            if (tag == null) {
-                tag = "latest";
-            }
+        // extract registry, repository, user
+        parseComponentsBeforeTag(rest);
+
+        /*
+         * set tag to latest if tag AND digest are null
+         * if digest is not null but tag is -> leave it!
+         *  -> in case of "image_name@sha256" it is not required to get resolved to "latest"
+         */
+        if (tag == null && digest == null) {
+            tag = "latest";
         }
 
         doValidate();
@@ -172,10 +182,15 @@ public class ImageName {
      * @return full name with original registry (if set) or optional registry (if not <code>null</code>).
      */
     public String getFullName(String optionalRegistry) {
-        if(digest != null) {
-            return getNameWithoutTag(optionalRegistry) + "@" + digest;
+
+        String fullName = getNameWithoutTag(optionalRegistry);
+        if (tag != null) {
+            fullName = fullName +  ":" + tag;
         }
-        return getNameWithoutTag(optionalRegistry) + ":" + tag;
+        if(digest != null) {
+            fullName = fullName + "@" + digest;
+        }
+        return fullName;
     }
 
     /**
@@ -214,20 +229,22 @@ public class ImageName {
         List<String> errors = new ArrayList<>();
         // Strip off user from repository name
         String image = user != null ? repository.substring(user.length() + 1) : repository;
+
         Object[] checks = new Object[] {
-            "registry", DOMAIN_REGEXP, registry,
-            "image", IMAGE_NAME_REGEXP, image,
-            "user", NAME_COMP_REGEXP, user,
-            "tag", TAG_REGEXP, tag,
-            "digest", DIGEST_REGEXP, digest
+                "registry", DOMAIN_REGEXP, registry,
+                "image", IMAGE_NAME_REGEXP, image,
+                "user", NAME_COMP_REGEXP, user,
+                "tag", TAG_REGEXP, tag,
+                "digest", DIGEST_REGEXP, digest
         };
+
         for (int i = 0; i < checks.length; i +=3) {
             String value = (String) checks[i + 2];
             Pattern checkPattern = (Pattern) checks[i + 1];
             if (value != null &&
-                !checkPattern.matcher(value).matches()) {
+                    !checkPattern.matcher(value).matches()) {
                 errors.add(String.format("%s part '%s' doesn't match allowed pattern '%s'",
-                                         checks[i], value, checkPattern.pattern()));
+                        checks[i], value, checkPattern.pattern()));
             }
         }
         if (errors.size() > 0) {

--- a/src/test/java/io/fabric8/maven/docker/util/ImageNameTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/ImageNameTest.java
@@ -13,7 +13,7 @@ public class ImageNameTest {
         Object[] data = {
                 "jolokia/jolokia_demo",
                 r().repository("jolokia/jolokia_demo")
-                   .fullName("jolokia/jolokia_demo").fullNameWithTag("jolokia/jolokia_demo:latest").simpleName("jolokia_demo").tag("latest"),
+                        .fullName("jolokia/jolokia_demo").fullNameWithTag("jolokia/jolokia_demo:latest").simpleName("jolokia_demo").tag("latest"),
 
                 "jolokia/jolokia_demo:0.9.6",
                 r().repository("jolokia/jolokia_demo").tag("0.9.6")
@@ -102,15 +102,15 @@ public class ImageNameTest {
     @Test
     public void testRegistryNaming() throws Exception {
         assertEquals("docker.jolokia.org/jolokia/jolokia_demo:0.18",
-                     new ImageName("jolokia/jolokia_demo:0.18").getFullName("docker.jolokia.org"));
+                new ImageName("jolokia/jolokia_demo:0.18").getFullName("docker.jolokia.org"));
         assertEquals("docker.jolokia.org/jolokia/jolokia_demo:latest",
-                     new ImageName("jolokia/jolokia_demo").getFullName("docker.jolokia.org"));
+                new ImageName("jolokia/jolokia_demo").getFullName("docker.jolokia.org"));
         assertEquals("jolokia/jolokia_demo:latest",
-                     new ImageName("jolokia/jolokia_demo").getFullName(null));
+                new ImageName("jolokia/jolokia_demo").getFullName(null));
         assertEquals("docker.jolokia.org/jolokia/jolokia_demo:latest",
-                     new ImageName("docker.jolokia.org/jolokia/jolokia_demo").getFullName("another.registry.org"));
+                new ImageName("docker.jolokia.org/jolokia/jolokia_demo").getFullName("another.registry.org"));
         assertEquals("docker.jolokia.org/jolokia/jolokia_demo:latest",
-                     new ImageName("docker.jolokia.org/jolokia/jolokia_demo").getFullName(null));
+                new ImageName("docker.jolokia.org/jolokia/jolokia_demo").getFullName(null));
     }
 
     @Test
@@ -129,6 +129,22 @@ public class ImageNameTest {
                 new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName(null));
         assertEquals("docker.jolokia.org",
                 new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+        assertEquals("docker.jolokia.org",
+                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine").getRegistry());
+        assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:alpine",
+                new ImageName("org/jolokia/jolokia_demo:alpine").getFullName("docker.jolokia.org"));
+        assertEquals("docker.jolokia.org",
+                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine").getRegistry());
+        assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine",
+                new ImageName("org/jolokia/jolokia_demo:1.2.3.4-alpine").getFullName("docker.jolokia.org"));
+        assertEquals("docker.jolokia.org",
+                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+        assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da",
+                new ImageName("org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName("docker.jolokia.org"));
+        assertEquals("docker.jolokia.org",
+                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+        assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da",
+                new ImageName("org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName("docker.jolokia.org"));
     }
 
 
@@ -144,10 +160,10 @@ public class ImageNameTest {
             longTag.append("a");
         }
         String[] illegal = {
-            "fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar",
-            "repo:fo$z$", "repo:Foo@3cc", "repo:Foo$3", "repo:Foo*3", "repo:Fo^3", "repo:Foo!3",
-            "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..","repo:" + longTag.toString(),
-            "-busybox:test", "-test/busybox:test", "-index:5000/busybox:test"
+                "fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar",
+                "repo:fo$z$", "repo:Foo@3cc", "repo:Foo$3", "repo:Foo*3", "repo:Fo^3", "repo:Foo!3",
+                "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..","repo:" + longTag.toString(),
+                "-busybox:test", "-test/busybox:test", "-index:5000/busybox:test"
 
         };
 
@@ -159,7 +175,7 @@ public class ImageNameTest {
         }
 
         String[] legal = {
-            "fooo/bar", "fooaa/test", "foooo:t", "HOSTNAME.DOMAIN.COM:443/foo/bar"
+                "fooo/bar", "fooaa/test", "foooo:t", "HOSTNAME.DOMAIN.COM:443/foo/bar"
         };
 
         for (String l : legal) {

--- a/src/test/java/io/fabric8/maven/docker/util/ImageNameTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/ImageNameTest.java
@@ -102,49 +102,49 @@ public class ImageNameTest {
     @Test
     public void testRegistryNaming() throws Exception {
         assertEquals("docker.jolokia.org/jolokia/jolokia_demo:0.18",
-                new ImageName("jolokia/jolokia_demo:0.18").getFullName("docker.jolokia.org"));
+            new ImageName("jolokia/jolokia_demo:0.18").getFullName("docker.jolokia.org"));
         assertEquals("docker.jolokia.org/jolokia/jolokia_demo:latest",
-                new ImageName("jolokia/jolokia_demo").getFullName("docker.jolokia.org"));
+            new ImageName("jolokia/jolokia_demo").getFullName("docker.jolokia.org"));
         assertEquals("jolokia/jolokia_demo:latest",
-                new ImageName("jolokia/jolokia_demo").getFullName(null));
+            new ImageName("jolokia/jolokia_demo").getFullName(null));
         assertEquals("docker.jolokia.org/jolokia/jolokia_demo:latest",
-                new ImageName("docker.jolokia.org/jolokia/jolokia_demo").getFullName("another.registry.org"));
+            new ImageName("docker.jolokia.org/jolokia/jolokia_demo").getFullName("another.registry.org"));
         assertEquals("docker.jolokia.org/jolokia/jolokia_demo:latest",
-                new ImageName("docker.jolokia.org/jolokia/jolokia_demo").getFullName(null));
+            new ImageName("docker.jolokia.org/jolokia/jolokia_demo").getFullName(null));
     }
 
     @Test
     public void testRegistryNamingExtended() throws Exception {
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:0.18",
-                new ImageName("org/jolokia/jolokia_demo:0.18").getFullName("docker.jolokia.org"));
+            new ImageName("org/jolokia/jolokia_demo:0.18").getFullName("docker.jolokia.org"));
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:latest",
-                new ImageName("org/jolokia/jolokia_demo").getFullName("docker.jolokia.org"));
+            new ImageName("org/jolokia/jolokia_demo").getFullName("docker.jolokia.org"));
         assertEquals("org/jolokia/jolokia_demo:latest",
-                new ImageName("org/jolokia/jolokia_demo").getFullName(null));
+            new ImageName("org/jolokia/jolokia_demo").getFullName(null));
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:latest",
-                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo").getFullName("another.registry.org"));
+            new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo").getFullName("another.registry.org"));
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:latest",
-                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo").getFullName(null));
+            new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo").getFullName(null));
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da",
-                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName(null));
+            new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName(null));
         assertEquals("docker.jolokia.org",
-                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+            new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
         assertEquals("docker.jolokia.org",
-                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine").getRegistry());
+            new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine").getRegistry());
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:alpine",
-                new ImageName("org/jolokia/jolokia_demo:alpine").getFullName("docker.jolokia.org"));
+            new ImageName("org/jolokia/jolokia_demo:alpine").getFullName("docker.jolokia.org"));
         assertEquals("docker.jolokia.org",
-                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine").getRegistry());
+            new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine").getRegistry());
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine",
-                new ImageName("org/jolokia/jolokia_demo:1.2.3.4-alpine").getFullName("docker.jolokia.org"));
+            new ImageName("org/jolokia/jolokia_demo:1.2.3.4-alpine").getFullName("docker.jolokia.org"));
         assertEquals("docker.jolokia.org",
-                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+            new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da",
-                new ImageName("org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName("docker.jolokia.org"));
+            new ImageName("org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName("docker.jolokia.org"));
         assertEquals("docker.jolokia.org",
-                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+            new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
         assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da",
-                new ImageName("org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName("docker.jolokia.org"));
+            new ImageName("org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName("docker.jolokia.org"));
     }
 
 
@@ -160,11 +160,10 @@ public class ImageNameTest {
             longTag.append("a");
         }
         String[] illegal = {
-                "fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar",
-                "repo:fo$z$", "repo:Foo@3cc", "repo:Foo$3", "repo:Foo*3", "repo:Fo^3", "repo:Foo!3",
-                "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..","repo:" + longTag.toString(),
-                "-busybox:test", "-test/busybox:test", "-index:5000/busybox:test"
-
+            "fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar",
+            "repo:fo$z$", "repo:Foo@3cc", "repo:Foo$3", "repo:Foo*3", "repo:Fo^3", "repo:Foo!3",
+            "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..","repo:" + longTag.toString(),
+            "-busybox:test", "-test/busybox:test", "-index:5000/busybox:test"
         };
 
         for (String i : illegal) {
@@ -175,7 +174,7 @@ public class ImageNameTest {
         }
 
         String[] legal = {
-                "fooo/bar", "fooaa/test", "foooo:t", "HOSTNAME.DOMAIN.COM:443/foo/bar"
+            "fooo/bar", "fooaa/test", "foooo:t", "HOSTNAME.DOMAIN.COM:443/foo/bar"
         };
 
         for (String l : legal) {


### PR DESCRIPTION
ImageName.java and respective test class adjusted to be able to handle
image names with tag AND sha256 digest like:
image_name:image_tag@sha256<digest>

Signed-off-by: Marcus Konrad <M.M.Konrad@web.de>