### PR TITLE
Enhance Fix #541: Allow @sha256 digest for tags in FROM

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -5,6 +5,7 @@
   - docs: Correct default image naming
   - close api version http connection ([#1152](https://github.com/fabric8io/docker-maven-plugin/issues/1152))
   - Update to jnr-unixsocket 0.22
+  - Enhance @sha256 digest for tags in FROM (image_name:image_tag@sha256<digest>) ([#541](https://github.com/fabric8io/docker-maven-plugin/issues/541))
 
 * **0.28.0** (2018-12-13)
   - Update to JMockit 1.43

--- a/src/test/java/io/fabric8/maven/docker/util/ImageNameTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/ImageNameTest.java
@@ -129,6 +129,22 @@ public class ImageNameTest {
                 new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName(null));
         assertEquals("docker.jolokia.org",
                 new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+        assertEquals("docker.jolokia.org",
+                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine").getRegistry());
+        assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:alpine",
+                new ImageName("org/jolokia/jolokia_demo:alpine").getFullName("docker.jolokia.org"));
+        assertEquals("docker.jolokia.org",
+                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine").getRegistry());
+        assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine",
+                new ImageName("org/jolokia/jolokia_demo:1.2.3.4-alpine").getFullName("docker.jolokia.org"));
+        assertEquals("docker.jolokia.org",
+                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+        assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da",
+                new ImageName("org/jolokia/jolokia_demo:alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName("docker.jolokia.org"));
+        assertEquals("docker.jolokia.org",
+                new ImageName("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getRegistry());
+        assertEquals("docker.jolokia.org/org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da",
+                new ImageName("org/jolokia/jolokia_demo:1.2.3.4-alpine@sha256:2781907cc3ae9bb732076f14392128d4b84ff3ebb66379d268e563b10fbfb9da").getFullName("docker.jolokia.org"));
     }
 
 


### PR DESCRIPTION
ImageName.java and respective test class adjusted to be able to handle
image names with tag AND sha256 digest like:
image_name:image_tag@sha256<digest>

Signed-off-by: Marcus Konrad <M.M.Konrad@web.de>