### PR TITLE
Added 'autoRemove' option

### DIFF
--- a/src/main/asciidoc/inc/start/_configuration.adoc
+++ b/src/main/asciidoc/inc/start/_configuration.adoc
@@ -107,6 +107,9 @@ a| *This option is deprecated, please use a `containerNamePattern` instead* Nami
 | *readOnly*
 | If `true` mount the container's root filesystem as read only
 
+| *autoRemove*
+| If `true` automatically remove the container when it exits. This has no effect if <<start-restart, Restart Policy>> has been set.
+
 | <<start-restart, *restartPolicy*>>
 | Restart Policy
 

--- a/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
@@ -199,6 +199,10 @@ public class ContainerHostConfig {
         return add("ReadonlyRootfs", readOnly);
     }
 
+    public ContainerHostConfig autoRemove(Boolean autoRemove) {
+        return add("AutoRemove", autoRemove);
+    }
+
     /**
      * Get JSON which is used for <em>starting</em> a container
      *

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -184,6 +184,10 @@ public class RunImageConfiguration implements Serializable {
     @Parameter
     private Boolean readOnly;
 
+    // Automatically remove the container when it exists
+    @Parameter
+    private Boolean autoRemove;
+
     public RunImageConfiguration() { }
 
     public String initAndValidate() {
@@ -391,6 +395,10 @@ public class RunImageConfiguration implements Serializable {
 
     public Boolean getReadOnly() {
         return readOnly;
+    }
+
+    public Boolean getAutoRemove() {
+        return autoRemove;
     }
 
     /**
@@ -644,6 +652,10 @@ public class RunImageConfiguration implements Serializable {
             return this;
         }
 
+        public Builder autoRemove(Boolean autoRemove) {
+            config.autoRemove = autoRemove;
+            return this;
+        }
 
         public RunImageConfiguration build() {
             return config;

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -35,6 +35,7 @@ public enum ConfigKey {
     ASSEMBLY_USER("assembly.user"),
     ASSEMBLY_MODE("assembly.mode"),
     ASSEMBLY_TARLONGFILEMODE("assembly.tarLongFileMode"),
+    AUTO_REMOVE,
     BIND,
     BUILD_OPTIONS,
     CAP_ADD,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -208,6 +208,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .cpus(valueProvider.getLong(CPUS, config == null ? null : config.getCpus()))
                 .cpuSet(valueProvider.getString(CPUSET, config == null ? null : config.getCpuSet()))
                 .readOnly(valueProvider.getBoolean(READ_ONLY, config == null ? null : config.getReadOnly()))
+                .autoRemove(valueProvider.getBoolean(AUTO_REMOVE, config == null ? null : config.getAutoRemove()))
                 .build();
     }
 

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -358,7 +358,8 @@ public class RunService {
                 .cpuShares(runConfig.getCpuShares())
                 .cpus(runConfig.getCpus())
                 .cpuSet(runConfig.getCpuSet())
-                .readonlyRootfs(runConfig.getReadOnly());
+                .readonlyRootfs(runConfig.getReadOnly())
+                .autoRemove(runConfig.getAutoRemove());
 
         addVolumeConfig(config, runConfig, baseDir);
         addNetworkingConfig(config, runConfig);

--- a/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
@@ -102,9 +102,24 @@ public class ContainerHostConfigTest {
             Pair.of(Boolean.FALSE, "{ReadonlyRootfs: false}")
         };
         for (int i = 0; i < data.length; i++) {
-        	Pair<Boolean, String> d = data[i];
+            Pair<Boolean, String> d = data[i];
             ContainerHostConfig hc = new ContainerHostConfig();
             JsonObject result = hc.readonlyRootfs(d.getLeft()).toJsonObject();
+            JsonObject expected = JsonFactory.newJsonObject(d.getRight());
+            assertEquals(expected, result);
+        }
+    }
+    
+    @Test
+    public void testAutoRemove() throws Exception {
+        Pair [] data = {
+            Pair.of(Boolean.TRUE, "{AutoRemove: true}"),
+            Pair.of(Boolean.FALSE, "{AutoRemove: false}")
+        };
+        for (int i = 0; i < data.length; i++) {
+            Pair<Boolean, String> d = data[i];
+            ContainerHostConfig hc = new ContainerHostConfig();
+            JsonObject result = hc.autoRemove(d.getLeft()).toJsonObject();
             JsonObject expected = JsonFactory.newJsonObject(d.getRight());
             assertEquals(expected, result);
         }

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -929,6 +929,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals(1, runConfig.getTmpfs().size());
         assertEquals("Never", runConfig.getImagePullPolicy());
         assertEquals(true, runConfig.getReadOnly());
+        assertEquals(true, runConfig.getAutoRemove());
 
         validateEnv(runConfig.getEnv());
 
@@ -1048,6 +1049,7 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
             k(ConfigKey.IMAGE_PULL_POLICY_BUILD), "Always",
             k(ConfigKey.IMAGE_PULL_POLICY_RUN), "Never",
             k(ConfigKey.READ_ONLY), "true",
+            k(ConfigKey.AUTO_REMOVE), "true",
         };
     }
 

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -358,6 +358,7 @@ public class RunServiceTest {
                         .net("custom_network")
                         .network(networkConfiguration())
                         .readOnly(false)
+                        .autoRemove(false)
                         .build();
     }
 

--- a/src/test/resources/docker/containerCreateConfigAll.json
+++ b/src/test/resources/docker/containerCreateConfigAll.json
@@ -68,6 +68,7 @@
     "NanoCpus": 1000000000,
     "CpusetCpus":"0,1",
     "ReadonlyRootfs":false,    
+    "AutoRemove":false,    
     "Binds":[
       "/host_tmp:/container_tmp"
     ],

--- a/src/test/resources/docker/containerHostConfigAll.json
+++ b/src/test/resources/docker/containerHostConfigAll.json
@@ -48,6 +48,7 @@
   "NanoCpus":1000000000,
   "CpusetCpus":"0,1",
   "ReadonlyRootfs":false,    
+  "AutoRemove":false,    
   "Binds":[
     "/host_tmp:/container_tmp"
   ],


### PR DESCRIPTION
Added 'autoRemove' option to run configuration to automatically remove a container when it exits (like docker run --rm).
This is needed to make sure that a container will be removed after exit even if the maven process is killed before it could stop the container.