### PR TITLE
Implemented authentication via EC2 instance role for ECR

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,6 +9,7 @@
   - Update to jnr-unixsocket 0.22
   - Support docker SHELL setting for runCmds (#1157)
   - Added 'autoRemove' option for running containers (#1179)
+  - Added support for AWS EC2 instance roles when pushing to AWS ECR (#1186)
 
 * **0.28.0** (2018-12-13)
   - Update to JMockit 1.43

--- a/src/main/asciidoc/inc/_authentication.adoc
+++ b/src/main/asciidoc/inc/_authentication.adoc
@@ -184,3 +184,9 @@ You can use any IAM access key with the necessary permissions in any of the loca
 Use the IAM *Access key ID* as the username and the *Secret access key* as the password.
 In case you're using temporary security credentials provided by the AWS Security Token Service (AWS STS), you have to provide the *security token* as well.
 To do so, either specify the `docker.authToken` system property or provide an `<auth>` element alongside username & password in the `authConfig`.
+
+In case you are running on an EC2 instance that has an appropriate IAM role assigned
+(e.g. a role that grants the AWS built-in policy _AmazonEC2ContainerRegistryPowerUser_)
+authentication information doesn't need to be provided at all. Instead the instance
+meta-data service is queried for temporary access credentials supplied by the
+assigned role.

--- a/src/main/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuth.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuth.java
@@ -1,8 +1,12 @@
 package io.fabric8.maven.docker.access.ecr;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
@@ -13,13 +17,9 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.maven.plugin.MojoExecutionException;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 import io.fabric8.maven.docker.access.AuthConfig;
 import io.fabric8.maven.docker.util.Logger;
@@ -40,6 +40,16 @@ public class EcrExtendedAuth {
     private final String accountId;
     private final String region;
 
+    /**
+     * Is given the registry an ecr registry?
+     * 
+     * @param registry the registry name
+     * @return true, if the registry matches the ecr pattern
+     */
+    public static boolean isAwsRegistry(String registry) {
+        return (registry != null) && AWS_REGISTRY.matcher(registry).matches();
+    }
+    
     /**
      * Initialize an extended authentication for ecr registry.
      *


### PR DESCRIPTION
This PR adds support for EC2 instance roles as described in issue #1177.
I didn't add any tests since they would only work when run on a correctly configured EC2 instance.