### PR TITLE
Issue #1195 Remove Windows file name validations.

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -580,10 +580,6 @@ public class BuildImageConfiguration implements Serializable {
         }
 
         if (dockerFile != null) {
-            if (EnvUtil.isWindows() && !EnvUtil.isValidWindowsFileName(dockerFile)) {
-                throw new IllegalArgumentException(String.format("Invalid Windows file name %s for <dockerFile>", dockerFile));
-            }
-
             File dFile = new File(dockerFile);
             if (dockerFileDir == null && contextDir == null) {
                 return dFile;

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -433,34 +433,4 @@ public class EnvUtil {
     public static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().contains("windows");
     }
-
-    /**
-     * Validate that the provided filename is a valid Windows filename.
-     *
-     * The validation of the Windows filename is copied from stackoverflow: https://stackoverflow.com/a/6804755
-     *
-     * @param filename the filename
-     * @return filename is a valid Windows filename
-     */
-    public static boolean isValidWindowsFileName(String filename) {
-
-        Pattern pattern = Pattern.compile(
-            "# Match a valid Windows filename (unspecified file system).          \n" +
-            "^                                # Anchor to start of string.        \n" +
-            "(?!                              # Assert filename is not: CON, PRN, \n" +
-            "  (?:                            # AUX, NUL, COM1, COM2, COM3, COM4, \n" +
-            "    CON|PRN|AUX|NUL|             # COM5, COM6, COM7, COM8, COM9,     \n" +
-            "    COM[1-9]|LPT[1-9]            # LPT1, LPT2, LPT3, LPT4, LPT5,     \n" +
-            "  )                              # LPT6, LPT7, LPT8, and LPT9...     \n" +
-            "  (?:\\.[^.]*)?                  # followed by optional extension    \n" +
-            "  $                              # and end of string                 \n" +
-            ")                                # End negative lookahead assertion. \n" +
-            "[^<>:\"/\\\\|?*\\x00-\\x1F]*     # Zero or more valid filename chars.\n" +
-            "[^<>:\"/\\\\|?*\\x00-\\x1F .]    # Last char is not a space or dot.  \n" +
-            "$                                # Anchor to end of string.            ",
-            Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE | Pattern.COMMENTS);
-        Matcher matcher = pattern.matcher(filename);
-        return matcher.matches();
-    }
-
 }

--- a/src/test/java/io/fabric8/maven/docker/config/BuildImageConfigurationTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/BuildImageConfigurationTest.java
@@ -86,7 +86,7 @@ public class BuildImageConfigurationTest {
         BuildImageConfiguration config =
             new BuildImageConfiguration.Builder().
                 dockerFileDir("/tmp/").
-                dockerFile("/Dockerfile").build();
+                dockerFile(new File("Dockerfile").getAbsolutePath()).build();
         config.initAndValidate(logger);
     }
 

--- a/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/EnvUtilTest.java
@@ -175,14 +175,6 @@ public class EnvUtilTest {
 
     }
 
-    @Test
-    public void isValidWindowsFileName() {
-
-    	assertFalse(EnvUtil.isValidWindowsFileName("/Dockerfile"));
-    	assertTrue(EnvUtil.isValidWindowsFileName("Dockerfile"));
-    	assertFalse(EnvUtil.isValidWindowsFileName("Dockerfile/"));
-    }
-
     private Properties getTestProperties(String ... vals) {
         Properties ret = new Properties();
         for (int i = 0; i < vals.length; i+=2) {


### PR DESCRIPTION
The Windows file name validations were inconsistent with other platform
behaviour and impede the creation of cross-platform POMs.

Signed-off-by: William Rose <william.rose@nuance.com>