### PR TITLE
Issue #1108 Restore color log output after plugin executes.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.29-SNAPSHOT**
+  - Restore ANSI color to Maven logging if disabled during plugin execution and enable color for Windows with Maven 3.5.0 or later. Color logging is enabled by default, but disabled if the Maven CLI disables color (e.g. in batch mode) ([#1108](https://github.com/fabric8io/docker-maven-plugin/issues/1108))
 
 * **0.29.0** (2019-04-08)
   - Avoid failing docker:save when no images with build configuration are present ([#1185](https://github.com/fabric8io/docker-maven-plugin/issues/1185))

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import com.google.common.base.*;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.io.FileUtils;
@@ -432,5 +433,12 @@ public class EnvUtil {
 
     public static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().contains("windows");
+    }
+
+    public static boolean isMaven350OrLater(MavenSession mavenSession) {
+        // Maven enforcer and help:evaluate goals both use mavenSession.getSystemProperties(),
+        // and it turns out that System.getProperty("maven.version") does not return the value.
+        String mavenVersion = mavenSession.getSystemProperties().getProperty("maven.version", "3");
+        return greaterOrEqualsVersion(mavenVersion, "3.5.0");
     }
 }

--- a/src/test/java/io/fabric8/maven/docker/util/AnsiLoggerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AnsiLoggerTest.java
@@ -16,43 +16,222 @@ package io.fabric8.maven.docker.util;
  * limitations under the License.
  */
 
-import org.apache.maven.plugin.logging.SystemStreamLog;
-import org.fusesource.jansi.Ansi;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.apache.maven.monitor.logging.DefaultLog;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.AnsiConsole;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * @author roland
  * @since 07/10/16
  */
 public class AnsiLoggerTest {
+    @BeforeClass
+    public static void installAnsi() {
+        AnsiConsole.systemInstall();
+    }
+
+    @Before
+    public void forceAnsiPassthrough() {
+        // Because the AnsiConsole keeps a per-VM counter of calls to systemInstall, it is
+        // difficult to force it to pass through escapes to stdout during test.
+        // Additionally, running the test in a suite (e.g. with mvn test) means other
+        // code may have already initialized or manipulated the AnsiConsole.
+        // Hence we just reset the stdout/stderr references to those captured by AnsiConsole
+        // during its static initialization and restore them after tests.
+        System.setOut(AnsiConsole.system_out);
+        System.setErr(AnsiConsole.system_err);
+    }
+
+    @AfterClass
+    public static void restoreAnsiPassthrough() {
+        AnsiConsole.systemUninstall();
+        System.setOut(AnsiConsole.out);
+        System.setErr(AnsiConsole.err);
+    }
 
     @Test
-    public void emphasize() {
+    public void emphasizeDebug() {
+        TestLog testLog = new TestLog() {
+            @Override
+            public boolean isDebugEnabled() {
+                return true;
+            }
+        };
+
+        AnsiLogger logger = new AnsiLogger(testLog, true, false, false, "T>");
+        logger.debug("Debug messages do not interpret [[*]]%s[[*]]", "emphasis");
+        assertEquals("T>Debug messages do not interpret [[*]]emphasis[[*]]",
+                testLog.getMessage());
+    }
+
+    @Test
+    public void emphasizeInfoWithDebugEnabled() {
+        TestLog testLog = new TestLog() {
+            @Override
+            public boolean isDebugEnabled() {
+                return true;
+            }
+        };
+
+        AnsiLogger logger = new AnsiLogger(testLog, true, false, false, "T>");
+        logger.info("Info messages do not apply [[*]]%s[[*]] when debug is enabled", "color codes");
+        assertEquals("T>Info messages do not apply color codes when debug is enabled",
+                testLog.getMessage());
+    }
+
+    @Test
+    public void emphasizeInfo() {
         TestLog testLog = new TestLog();
         AnsiLogger logger = new AnsiLogger(testLog, true, false, false, "T>");
-        Ansi ansi = Ansi.ansi();
-        logger.info("Yet another [[*]]Test[[*]] %s","emphasis");
-        assertEquals(ansi.a("T>")
-                         .fg(AnsiLogger.COLOR_INFO)
-                         .a("Yet another ")
+        Ansi ansi = new Ansi();
+        logger.info("Info messages [[*]]show[[*]] %s","emphasis");
+        assertEquals(ansi.fg(AnsiLogger.COLOR_INFO)
+                         .a("T>")
+                         .a("Info messages ")
                          .fgBright(AnsiLogger.COLOR_EMPHASIS)
-                         .a("Test")
+                         .a("show")
                          .fg(AnsiLogger.COLOR_INFO)
                          .a(" emphasis")
                          .reset().toString(),
                      testLog.getMessage());
     }
 
+    @Test
+    public void emphasizeInfoSpecificColor() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, true, false, false, "T>");
+        Ansi ansi = new Ansi();
+        logger.info("Specific [[C]]color[[C]] %s","is possible");
+        assertEquals(ansi.fg(AnsiLogger.COLOR_INFO)
+                        .a("T>")
+                        .a("Specific ")
+                        .fg(Ansi.Color.CYAN)
+                        .a("color")
+                        .fg(AnsiLogger.COLOR_INFO)
+                        .a(" is possible")
+                        .reset().toString(),
+                testLog.getMessage());
+    }
 
-    private class TestLog extends SystemStreamLog {
+    @Test
+    public void emphasizeInfoIgnoringEmpties() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, true, false, false, "T>");
+        Ansi ansi = new Ansi();
+        // Note that the closing part of the emphasis does not need to match the opening.
+        // E.g. [[b]]Blue[[*]] works just like [[b]]Blue[[b]]
+        logger.info("[[b]][[*]]Skip[[*]][[*]]ping [[m]]empty strings[[/]] %s[[*]][[c]][[c]][[*]]","is possible");
+        assertEquals(ansi.fg(AnsiLogger.COLOR_INFO)
+                        .a("T>")
+                        .a("Skipping ")
+                        .fgBright(Ansi.Color.MAGENTA)
+                        .a("empty strings")
+                        .fg(AnsiLogger.COLOR_INFO)
+                        .a(" is possible")
+                        .reset().toString(),
+                testLog.getMessage());
+    }
+
+    @Test
+    public void emphasizeInfoSpecificBrightColor() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, true, false, false, "T>");
+        Ansi ansi = new Ansi();
+        logger.info("Lowercase enables [[c]]bright version[[c]] of %d colors",Ansi.Color.values().length - 1);
+        assertEquals(ansi.fg(AnsiLogger.COLOR_INFO)
+                        .a("T>")
+                        .a("Lowercase enables ")
+                        .fgBright(Ansi.Color.CYAN)
+                        .a("bright version")
+                        .fg(AnsiLogger.COLOR_INFO)
+                        .a(" of 8 colors")
+                        .reset().toString(),
+                testLog.getMessage());
+    }
+
+    @Test
+    public void emphasizeInfoWithoutColor() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, false, false, false, "T>");
+        logger.info("Disabling color causes logger to [[*]]interpret and remove[[*]] %s","emphasis");
+        assertEquals("T>Disabling color causes logger to interpret and remove emphasis",
+                     testLog.getMessage());
+    }
+
+    @Test
+    public void emphasizeWarning() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, true, false, false, "T>");
+        Ansi ansi = new Ansi();
+        logger.warn("%s messages support [[*]]emphasis[[*]] too","Warning");
+        assertEquals(ansi.fg(AnsiLogger.COLOR_WARNING)
+                         .a("T>")
+                         .a("Warning messages support ")
+                         .fgBright(AnsiLogger.COLOR_EMPHASIS)
+                         .a("emphasis")
+                         .fg(AnsiLogger.COLOR_WARNING)
+                         .a(" too")
+                         .reset().toString(),
+                     testLog.getMessage());
+    }
+
+    @Test
+    public void emphasizeError() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, true, false, false, "T>");
+        Ansi ansi = new Ansi();
+        logger.error("Error [[*]]messages[[*]] could emphasise [[*]]%s[[*]]","many things");
+        assertEquals(ansi.fg(AnsiLogger.COLOR_ERROR)
+                         .a("T>")
+                         .a("Error ")
+                         .fgBright(AnsiLogger.COLOR_EMPHASIS)
+                         .a("messages")
+                         .fg(AnsiLogger.COLOR_ERROR)
+                         .a(" could emphasise ")
+                         .fgBright(AnsiLogger.COLOR_EMPHASIS)
+                         .a("many things")
+                         .reset()
+                         .toString(),
+                     testLog.getMessage());
+    }
+
+
+    private class TestLog extends DefaultLog {
         private String message;
+
+        public TestLog() {
+            super(new ConsoleLogger());
+        }
+
+        @Override
+        public void debug(CharSequence content) {
+            this.message = content.toString();
+            super.debug(content);
+        }
 
         @Override
         public void info(CharSequence content) {
             this.message = content.toString();
             super.info(content);
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+            this.message = content.toString();
+            super.warn(content);
+        }
+
+        @Override
+        public void error(CharSequence content) {
+            this.message = content.toString();
+            super.error(content);
         }
 
         void reset() {


### PR DESCRIPTION
Fix for #1108.

If the plugin is set to disable color output, or detects pre-3.5.0 Maven
on Windows, ANSI color logging is disabled. Previously this would then
disable color logging for all subsequent plugins, but now the setting is
restored. Additionally it has been enabled for Windows with Maven 3.5.0+.

Signed-off-by: William Rose <william.rose@nuance.com>