### PR TITLE
Issue #1203 NPE if docker:save called with filename only.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,7 @@
 
 * **0.29-SNAPSHOT**
   - Restore ANSI color to Maven logging if disabled during plugin execution and enable color for Windows with Maven 3.5.0 or later. Color logging is enabled by default, but disabled if the Maven CLI disables color (e.g. in batch mode) ([#1108](https://github.com/fabric8io/docker-maven-plugin/issues/1108))
+  - Fix NPE if docker:save is called with -Dfile=file-name-only.tar ([#1203](https://github.com/fabric8io/docker-maven-plugin/issues/1203))
 
 * **0.29.0** (2019-04-08)
   - Avoid failing docker:save when no images with build configuration are present ([#1185](https://github.com/fabric8io/docker-maven-plugin/issues/1185))

--- a/src/main/java/io/fabric8/maven/docker/SaveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/SaveMojo.java
@@ -106,7 +106,7 @@ public class SaveMojo extends AbstractDockerMojo {
     }
 
     private void ensureSaveDir(String fileName) throws MojoExecutionException {
-        File saveDir = new File(fileName).getParentFile();
+        File saveDir = new File(fileName).getAbsoluteFile().getParentFile();
         if (!saveDir.exists()) {
             if (!saveDir.mkdirs()) {
                 throw new MojoExecutionException("Can not create directory " + saveDir + " for storing save file");


### PR DESCRIPTION
Fixes NPE that happens if you run mvn docker:save -Dfile=no-directory-name.tar

Signed-off-by: William Rose <william.rose@nuance.com>