### PR TITLE
Issue #1205 Increase GZIP compression speed for docker:save.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,7 @@
 
 * **0.29-SNAPSHOT**
   - Restore ANSI color to Maven logging if disabled during plugin execution and enable color for Windows with Maven 3.5.0 or later. Color logging is enabled by default, but disabled if the Maven CLI disables color (e.g. in batch mode) ([#1108](https://github.com/fabric8io/docker-maven-plugin/issues/1108))
+  - Fix NPE if docker:save is called with -Dfile=file-name-only.tar ([#1203](https://github.com/fabric8io/docker-maven-plugin/issues/1203))
 
 * **0.29.0** (2019-04-08)
   - Avoid failing docker:save when no images with build configuration are present ([#1185](https://github.com/fabric8io/docker-maven-plugin/issues/1185))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
 * **0.29-SNAPSHOT**
   - Restore ANSI color to Maven logging if disabled during plugin execution and enable color for Windows with Maven 3.5.0 or later. Color logging is enabled by default, but disabled if the Maven CLI disables color (e.g. in batch mode) ([#1108](https://github.com/fabric8io/docker-maven-plugin/issues/1108))
   - Fix NPE if docker:save is called with -Dfile=file-name-only.tar ([#1203](https://github.com/fabric8io/docker-maven-plugin/issues/1203))
+  - Improve GZIP compression performance for docker:save ([#1205](https://github.com/fabric8io/docker-maven-plugin/issues/1205))
 
 * **0.29.0** (2019-04-08)
   - Avoid failing docker:save when no images with build configuration are present ([#1185](https://github.com/fabric8io/docker-maven-plugin/issues/1185))

--- a/src/main/java/io/fabric8/maven/docker/SaveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/SaveMojo.java
@@ -106,7 +106,7 @@ public class SaveMojo extends AbstractDockerMojo {
     }
 
     private void ensureSaveDir(String fileName) throws MojoExecutionException {
-        File saveDir = new File(fileName).getParentFile();
+        File saveDir = new File(fileName).getAbsoluteFile().getParentFile();
         if (!saveDir.exists()) {
             if (!saveDir.mkdirs()) {
                 throw new MojoExecutionException("Can not create directory " + saveDir + " for storing save file");

--- a/src/main/java/io/fabric8/maven/docker/SaveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/SaveMojo.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Properties;
 
 import io.fabric8.maven.docker.config.ArchiveCompression;
+import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.ImageName;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
@@ -54,7 +55,9 @@ public class SaveMojo extends AbstractDockerMojo {
 			throw new MojoExecutionException("No image " + imageName + " exists");
 		}
 
+		long time = System.currentTimeMillis();
 		serviceHub.getDockerAccess().saveImage(imageName, fileName, ArchiveCompression.fromFileName(fileName));
+		log.info("%s: Saved image to %s in %s", imageName, fileName, EnvUtil.formatDurationTill(time));
 	}
 
 	private boolean skipSaveFor(List<ImageConfiguration> images) {

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -465,7 +465,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
             public Object handleResponse(HttpResponse response) throws IOException {
                 try (InputStream stream = response.getEntity().getContent();
                      OutputStream out = compression.wrapOutputStream(new FileOutputStream(filename))) {
-                    IOUtils.copy(stream, out);
+                    IOUtils.copy(stream, out, 65536);
                 }
                 return null;
             }

--- a/src/main/java/io/fabric8/maven/docker/config/ArchiveCompression.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ArchiveCompression.java
@@ -18,7 +18,7 @@ package io.fabric8.maven.docker.config;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.zip.GZIPOutputStream;
+import java.util.zip.Deflater;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.codehaus.plexus.archiver.tar.TarArchiver;
@@ -81,4 +81,11 @@ public enum ArchiveCompression {
         return ArchiveCompression.none;
     }
 
+    private static class GZIPOutputStream extends java.util.zip.GZIPOutputStream {
+        private GZIPOutputStream(OutputStream out) throws IOException {
+            super(out, 65536);
+            // According to https://bugs.openjdk.java.net/browse/JDK-8142920, 3 is a better default
+            def.setLevel(3);
+        }
+    }
 }


### PR DESCRIPTION
Change the default compression level to 3 in line with [JDK-8142920](https://bugs.openjdk.java.net/browse/JDK-8142920) and increase buffer sizes for copy and compression.

Signed-off-by: William Rose <william.rose@nuance.com>