### PR TITLE
Add the ability to attach a saved image archive as a project artifact

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
   - Restore ANSI color to Maven logging if disabled during plugin execution and enable color for Windows with Maven 3.5.0 or later. Color logging is enabled by default, but disabled if the Maven CLI disables color (e.g. in batch mode) ([#1108](https://github.com/fabric8io/docker-maven-plugin/issues/1108))
   - Fix NPE if docker:save is called with -Dfile=file-name-only.tar ([#1203](https://github.com/fabric8io/docker-maven-plugin/issues/1203))
   - Improve GZIP compression performance for docker:save ([#1205](https://github.com/fabric8io/docker-maven-plugin/issues/1205))
+  - Allow docker:save to attach image archive as a project artifact ([#1210](https://github.com/fabric8io/docker-maven-plugin/pull/1210))
 
 * **0.29.0** (2019-04-08)
   - Avoid failing docker:save when no images with build configuration are present ([#1185](https://github.com/fabric8io/docker-maven-plugin/issues/1185))

--- a/src/main/asciidoc/inc/_docker-save.adoc
+++ b/src/main/asciidoc/inc/_docker-save.adoc
@@ -10,6 +10,31 @@ If the option `saveFile` is not set, the file name is calculated automatically:
 
 Please note that the exported image contains all image layers and can be quite large (also, it takes a bit to export the image).
 
+.Controlling image compression
+The file name extension is used to select a compression method for the output.
+[cols="3,2,1"]
+|===
+| Extensions | Compression | Type
+
+| .tar or unrecognized
+| No compression
+| .tar
+
+| .tar.gz, .tgz
+| GZIP compression
+| .tar.gz
+
+| .tar.bz, .tar.bz2, .tar.bzip2
+| BZIP2 compression
+| .tar.bz
+
+|===
+
+.Attaching the saved image as an artifact
+If `saveClassifier` is set, the saved archive will be attached to the project using the provided classifier and the type determined from the file name. The placeholder `%a` will be replaced with the image alias.
+
+Note that using overriding the default to use `docker` or `docker-%a` may lead to a conflict if a source archive is also attached with <<{plugin}:source>>.
+
 .Save options
 [cols="1,5,1"]
 |===
@@ -27,12 +52,8 @@ Please note that the exported image contains all image layers and can be quite l
 | The filename to save.
 | `docker.save.file` or `docker.file` or `file`
 
-| *saveAttach*
-| Whether to attach the saved archive to the project (`false` by default).
-| `docker.save.attach`
-
 | *saveClassifier*
-| Sets the artifact classifier when attaching the saved archive to the project. If `saveAlias` is set, defaults to `archive-<saveAlias>`, otherwise defaults to `archive`. Note that using overriding the default to use `docker` or `docker-<saveAlias>` may lead to a conflict if a source archive is also attached with <<{plugin}:source>>.
+| If set, attach the the saved archive to the project with the provided classifier. A placeholder of `%a` will be replaced with the image alias.
 | `docker.save.classifier`
 
 | *skipSave*

--- a/src/main/asciidoc/inc/_docker-save.adoc
+++ b/src/main/asciidoc/inc/_docker-save.adoc
@@ -27,6 +27,14 @@ Please note that the exported image contains all image layers and can be quite l
 | The filename to save.
 | `docker.save.file` or `docker.file` or `file`
 
+| *saveAttach*
+| Whether to attach the saved archive to the project (`false` by default).
+| `docker.save.attach`
+
+| *saveClassifier*
+| Sets the artifact classifier when attaching the saved archive to the project. If `saveAlias` is set, defaults to `archive-<saveAlias>`, otherwise defaults to `archive`. Note that using overriding the default to use `docker` or `docker-<saveAlias>` may lead to a conflict if a source archive is also attached with <<{plugin}:source>>.
+| `docker.save.classifier`
+
 | *skipSave*
 | A boolean flag whether to skip execution of the goal.
 | `docker.skip.save`

--- a/src/test/java/io/fabric8/maven/docker/SaveMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/SaveMojoTest.java
@@ -1,18 +1,27 @@
 package io.fabric8.maven.docker;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
+import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
 import org.junit.Test;
 
+import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.ArchiveCompression;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.service.QueryService;
 import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.Logger;
 import mockit.Deencapsulation;
+import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
 import mockit.Tested;
@@ -27,6 +36,248 @@ public class SaveMojoTest {
 
     @Mocked
     ServiceHub serviceHub;
+
+    @Mocked
+    QueryService queryService;
+
+    @Mocked
+    DockerAccess dockerAccess;
+
+    @Mocked
+    MavenProject mavenProject;
+
+    @Mocked
+    Build mavenBuild;
+
+    @Mocked
+    MavenProjectHelper mavenProjectHelper;
+
+    @Test
+    public void saveWithoutNameAliasOrFile() throws DockerAccessException, MojoExecutionException {
+        ImageConfiguration image = new ImageConfiguration.Builder()
+                .name("example:latest")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        new Expectations() {{
+            mavenProject.getProperties(); result = new Properties();
+            queryService.hasImage("example:latest"); result = true;
+            dockerAccess.saveImage("example:latest", anyString, ArchiveCompression.gzip);
+            serviceHub.getQueryService(); result = queryService;
+            serviceHub.getDockerAccess(); result = dockerAccess;
+        }};
+
+        Deencapsulation.setField(saveMojo, "images", Collections.singletonList(image));
+        Deencapsulation.setField(saveMojo, "resolvedImages", Collections.singletonList(image));
+        Deencapsulation.setField(saveMojo, "project", mavenProject);
+        Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
+
+        saveMojo.executeInternal(serviceHub);
+    }
+
+    @Test
+    public void saveAndAttachWithoutNameAliasOrFile() throws DockerAccessException, MojoExecutionException {
+        ImageConfiguration image = new ImageConfiguration.Builder()
+                .name("example:latest")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        new Expectations() {{
+            mavenProject.getProperties(); result = new Properties();
+            mavenProject.getBuild(); result = mavenBuild;
+            mavenBuild.getDirectory(); result = "mock-target";
+            queryService.hasImage("example:latest"); result = true;
+            dockerAccess.saveImage("example:latest", anyString, ArchiveCompression.gzip);
+            serviceHub.getQueryService(); result = queryService;
+            serviceHub.getDockerAccess(); result = dockerAccess;
+            mavenProjectHelper.attachArtifact(mavenProject, "tar.gz", "archive", new File("mock-target/example-latest.tar.gz"));
+        }};
+
+        Deencapsulation.setField(saveMojo, "images", Collections.singletonList(image));
+        Deencapsulation.setField(saveMojo, "resolvedImages", Collections.singletonList(image));
+        Deencapsulation.setField(saveMojo, "saveAttach", true);
+        Deencapsulation.setField(saveMojo, "project", mavenProject);
+        Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
+
+        saveMojo.executeInternal(serviceHub);
+    }
+
+    @Test
+    public void saveWithFile() throws DockerAccessException, MojoExecutionException {
+        ImageConfiguration image = new ImageConfiguration.Builder()
+                .name("example:latest")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        new Expectations() {{
+            mavenProject.getProperties(); result = new Properties();
+            queryService.hasImage("example:latest"); result = true;
+            dockerAccess.saveImage("example:latest", "destination/archive-name.tar.bz2", ArchiveCompression.bzip2);
+            serviceHub.getQueryService(); result = queryService;
+            serviceHub.getDockerAccess(); result = dockerAccess;
+        }};
+
+        Deencapsulation.setField(saveMojo, "images", Collections.singletonList(image));
+        Deencapsulation.setField(saveMojo, "resolvedImages", Collections.singletonList(image));
+        Deencapsulation.setField(saveMojo, "saveFile", "destination/archive-name.tar.bz2");
+        Deencapsulation.setField(saveMojo, "project", mavenProject);
+        Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
+
+        saveMojo.executeInternal(serviceHub);
+    }
+
+    @Test
+    public void saveAndAttachWithFile() throws DockerAccessException, MojoExecutionException {
+        ImageConfiguration image = new ImageConfiguration.Builder()
+                .name("example:latest")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        new Expectations() {{
+            mavenProject.getProperties(); result = new Properties();
+            queryService.hasImage("example:latest"); result = true;
+            dockerAccess.saveImage("example:latest", "destination/archive-name.tar.bz2", ArchiveCompression.bzip2);
+            serviceHub.getQueryService(); result = queryService;
+            serviceHub.getDockerAccess(); result = dockerAccess;
+            mavenProjectHelper.attachArtifact(mavenProject, "tar.bz", "archive", new File("destination/archive-name.tar.bz2"));
+        }};
+
+        Deencapsulation.setField(saveMojo, "images", Collections.singletonList(image));
+        Deencapsulation.setField(saveMojo, "resolvedImages", Collections.singletonList(image));
+        Deencapsulation.setField(saveMojo, "saveFile", "destination/archive-name.tar.bz2");
+        Deencapsulation.setField(saveMojo, "saveAttach", true);
+        Deencapsulation.setField(saveMojo, "project", mavenProject);
+        Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
+
+        saveMojo.executeInternal(serviceHub);
+    }
+
+    @Test
+    public void saveWithAlias() throws DockerAccessException, MojoExecutionException {
+        ImageConfiguration image1 = new ImageConfiguration.Builder()
+                .name("example1:latest")
+                .alias("example1")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        ImageConfiguration image2 = new ImageConfiguration.Builder()
+                .name("example2:latest")
+                .alias("example2")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        new Expectations() {{
+            mavenProject.getProperties(); result = new Properties();
+            mavenProject.getBuild(); result = mavenBuild;
+            mavenProject.getVersion(); result = "1.2.3-SNAPSHOT";
+            mavenBuild.getDirectory(); result = "mock-target";
+            queryService.hasImage("example2:latest"); result = true;
+            dockerAccess.saveImage("example2:latest", "mock-target/example2-1.2.3-SNAPSHOT.tar.gz", ArchiveCompression.gzip);
+            serviceHub.getQueryService(); result = queryService;
+            serviceHub.getDockerAccess(); result = dockerAccess;
+        }};
+
+        Deencapsulation.setField(saveMojo, "images", Arrays.asList(image1, image2));
+        Deencapsulation.setField(saveMojo, "resolvedImages", Arrays.asList(image1, image2));
+        Deencapsulation.setField(saveMojo, "saveAlias", "example2");
+        Deencapsulation.setField(saveMojo, "project", mavenProject);
+        Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
+
+        saveMojo.executeInternal(serviceHub);
+    }
+
+    @Test
+    public void saveAndAttachWithAlias() throws DockerAccessException, MojoExecutionException {
+        ImageConfiguration image1 = new ImageConfiguration.Builder()
+                .name("example1:latest")
+                .alias("example1")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        ImageConfiguration image2 = new ImageConfiguration.Builder()
+                .name("example2:latest")
+                .alias("example2")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        new Expectations() {{
+            mavenProject.getProperties(); result = new Properties();
+            mavenProject.getBuild(); result = mavenBuild;
+            mavenProject.getVersion(); result = "1.2.3-SNAPSHOT";
+            mavenBuild.getDirectory(); result = "mock-target";
+            queryService.hasImage("example2:latest"); result = true;
+            dockerAccess.saveImage("example2:latest", "mock-target/example2-1.2.3-SNAPSHOT.tar.gz", ArchiveCompression.gzip);
+            serviceHub.getQueryService(); result = queryService;
+            serviceHub.getDockerAccess(); result = dockerAccess;
+            mavenProjectHelper.attachArtifact(mavenProject, "tar.gz", "archive-example2", new File("mock-target/example2-1.2.3-SNAPSHOT.tar.gz"));
+        }};
+
+        Deencapsulation.setField(saveMojo, "images", Arrays.asList(image1, image2));
+        Deencapsulation.setField(saveMojo, "resolvedImages", Arrays.asList(image1, image2));
+        Deencapsulation.setField(saveMojo, "saveAlias", "example2");
+        Deencapsulation.setField(saveMojo, "saveAttach", true);
+        Deencapsulation.setField(saveMojo, "project", mavenProject);
+        Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
+
+        saveMojo.executeInternal(serviceHub);
+    }
+
+    @Test
+    public void saveAndAttachWithAliasButAlsoClassifier() throws DockerAccessException, MojoExecutionException {
+        ImageConfiguration image1 = new ImageConfiguration.Builder()
+                .name("example1:latest")
+                .alias("example1")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        ImageConfiguration image2 = new ImageConfiguration.Builder()
+                .name("example2:latest")
+                .alias("example2")
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("scratch")
+                        .build())
+                .build();
+
+        new Expectations() {{
+            mavenProject.getProperties(); result = new Properties();
+            mavenProject.getBuild(); result = mavenBuild;
+            mavenProject.getVersion(); result = "1.2.3-SNAPSHOT";
+            mavenBuild.getDirectory(); result = "mock-target";
+            queryService.hasImage("example2:latest"); result = true;
+            dockerAccess.saveImage("example2:latest", "mock-target/example2-1.2.3-SNAPSHOT.tar.gz", ArchiveCompression.gzip);
+            serviceHub.getQueryService(); result = queryService;
+            serviceHub.getDockerAccess(); result = dockerAccess;
+            mavenProjectHelper.attachArtifact(mavenProject, "tar.gz", "preferred", new File("mock-target/example2-1.2.3-SNAPSHOT.tar.gz"));
+        }};
+
+        Deencapsulation.setField(saveMojo, "images", Arrays.asList(image1, image2));
+        Deencapsulation.setField(saveMojo, "resolvedImages", Arrays.asList(image1, image2));
+        Deencapsulation.setField(saveMojo, "saveAlias", "example2");
+        Deencapsulation.setField(saveMojo, "saveClassifier", "preferred");
+        Deencapsulation.setField(saveMojo, "saveAttach", true);
+        Deencapsulation.setField(saveMojo, "project", mavenProject);
+        Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
+
+        saveMojo.executeInternal(serviceHub);
+    }
 
     @Test
     public void noFailureWithEmptyImageList() throws DockerAccessException, MojoExecutionException {

--- a/src/test/java/io/fabric8/maven/docker/SaveMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/SaveMojoTest.java
@@ -99,7 +99,7 @@ public class SaveMojoTest {
 
         Deencapsulation.setField(saveMojo, "images", Collections.singletonList(image));
         Deencapsulation.setField(saveMojo, "resolvedImages", Collections.singletonList(image));
-        Deencapsulation.setField(saveMojo, "saveAttach", true);
+        Deencapsulation.setField(saveMojo, "saveClassifier", "archive");
         Deencapsulation.setField(saveMojo, "project", mavenProject);
         Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
 
@@ -153,7 +153,7 @@ public class SaveMojoTest {
         Deencapsulation.setField(saveMojo, "images", Collections.singletonList(image));
         Deencapsulation.setField(saveMojo, "resolvedImages", Collections.singletonList(image));
         Deencapsulation.setField(saveMojo, "saveFile", "destination/archive-name.tar.bz2");
-        Deencapsulation.setField(saveMojo, "saveAttach", true);
+        Deencapsulation.setField(saveMojo, "saveClassifier", "archive");
         Deencapsulation.setField(saveMojo, "project", mavenProject);
         Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
 
@@ -231,7 +231,7 @@ public class SaveMojoTest {
         Deencapsulation.setField(saveMojo, "images", Arrays.asList(image1, image2));
         Deencapsulation.setField(saveMojo, "resolvedImages", Arrays.asList(image1, image2));
         Deencapsulation.setField(saveMojo, "saveAlias", "example2");
-        Deencapsulation.setField(saveMojo, "saveAttach", true);
+        Deencapsulation.setField(saveMojo, "saveClassifier", "archive-%a");
         Deencapsulation.setField(saveMojo, "project", mavenProject);
         Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
 
@@ -272,7 +272,6 @@ public class SaveMojoTest {
         Deencapsulation.setField(saveMojo, "resolvedImages", Arrays.asList(image1, image2));
         Deencapsulation.setField(saveMojo, "saveAlias", "example2");
         Deencapsulation.setField(saveMojo, "saveClassifier", "preferred");
-        Deencapsulation.setField(saveMojo, "saveAttach", true);
         Deencapsulation.setField(saveMojo, "project", mavenProject);
         Deencapsulation.setField(saveMojo, "projectHelper", mavenProjectHelper);
 


### PR DESCRIPTION
This PR is to add the ability to attach an image archive produced by docker:save to the project as an artifact. Currently this is not possible and archives have to be attached using something like build-helper-maven-plugin.

To avoid conflict with docker:source, the default attach classifier is `archive` (or `archive-<saveAlias>`), instead of `docker` (or `docker-<alias>`) as used by that mojo.