### PR TITLE
Add capability to get ECR credentials from IAM Task role from contain…

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,7 +1,8 @@
 # ChangeLog
 
-* **0.30-SNAPSHOT** (2019-04-23)
+* **0.30-SNAPSHOT** (2019-07-01)
   - Fix test cases on Windows ([#1220](https://github.com/fabric8io/docker-maven-plugin/issues/1220))
+  - ECR credentials from IAM Task role for ECS Fargate deployment ([#1233](https://github.com/fabric8io/docker-maven-plugin/issues/1233))
 
 * **0.30.0** (2019-04-21)
   - Restore ANSI color to Maven logging if disabled during plugin execution and enable color for Windows with Maven 3.5.0 or later. Color logging is enabled by default, but disabled if the Maven CLI disables color (e.g. in batch mode) ([#1108](https://github.com/fabric8io/docker-maven-plugin/issues/1108))

--- a/src/main/asciidoc/inc/_authentication.adoc
+++ b/src/main/asciidoc/inc/_authentication.adoc
@@ -185,8 +185,8 @@ Use the IAM *Access key ID* as the username and the *Secret access key* as the p
 In case you're using temporary security credentials provided by the AWS Security Token Service (AWS STS), you have to provide the *security token* as well.
 To do so, either specify the `docker.authToken` system property or provide an `<auth>` element alongside username & password in the `authConfig`.
 
-In case you are running on an EC2 instance that has an appropriate IAM role assigned
+In case you are running on an EC2 instance OR ECS with fargate deployment (OR ECS with EC2 with ECS_AWSVPC_BLOCK_IMDS as "true") that has an appropriate IAM role assigned
 (e.g. a role that grants the AWS built-in policy _AmazonEC2ContainerRegistryPowerUser_)
 authentication information doesn't need to be provided at all. Instead the instance
-meta-data service is queried for temporary access credentials supplied by the
+meta-data service or task metadata endpoint in case of ECS is queried for temporary access credentials supplied by the
 assigned role.

--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -246,6 +246,19 @@ public class AuthConfigFactory {
                 log.debug("AuthConfig: credentials from EC2 instance role");
                 return ret;
             }
+
+            try {
+                ret = getAuthConfigFromECSTaskRole();
+            } catch (ConnectTimeoutException ex) {
+                log.debug("Connection timeout while retrieving ECS meta-data, likely not an ECS instance (%s)",
+                        ex.getMessage());
+            } catch (IOException ex) {
+                log.warn("Error while retrieving ECS Task role credentials: %s", ex.getMessage());
+            }
+            if (ret != null) {
+                log.debug("AuthConfig: credentials from ECS Task role");
+                return ret;
+            }
         }
 
         // No authentication found
@@ -297,6 +310,49 @@ public class AuthConfigFactory {
                 }
 
                 // read instance role
+                try (Reader r = new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8)) {
+                    JsonObject securityCredentials = new Gson().fromJson(r, JsonObject.class);
+
+                    String user = securityCredentials.getAsJsonPrimitive("AccessKeyId").getAsString();
+                    String password = securityCredentials.getAsJsonPrimitive("SecretAccessKey").getAsString();
+                    String token = securityCredentials.getAsJsonPrimitive("Token").getAsString();
+
+                    log.debug("Received temporary access key %s...", user.substring(0, 8));
+                    return new AuthConfig(user, password, "none", token);
+                }
+            }
+        }
+    }
+
+    // if the local credentials don't contain user and password & is not a EC2 instance, use ECS Task instance
+    // role credentials
+    private AuthConfig getAuthConfigFromECSTaskRole() throws IOException {
+        log.debug("No user and password set for ECR, checking ECS Task role");
+        try (CloseableHttpClient client = HttpClients.custom().useSystemProperties().build()) {
+            RequestConfig conf = RequestConfig.custom().setConnectionRequestTimeout(1000).setConnectTimeout(1000)
+                    .setSocketTimeout(1000).build();
+
+            // get ECS task role - if available
+            String awsContainerCredentialsUri = System.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+            if (awsContainerCredentialsUri == null) {
+                log.debug("System environment not set for variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, no task role found");
+                return null;
+            }
+
+            log.debug("Getting temporary security credentials from: %s", awsContainerCredentialsUri);
+
+            // get temporary credentials
+            HttpGet request = new HttpGet("http://169.254.170.2/" + UrlEscapers.urlPathSegmentEscaper().escape(awsContainerCredentialsUri));
+            request.setConfig(conf);
+            try (CloseableHttpResponse response = client.execute(request)) {
+                if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                    log.debug("No security credential found, return code was %d",
+                            response.getStatusLine().getStatusCode());
+                    // no task role found
+                    return null;
+                }
+
+                // read task role
                 try (Reader r = new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8)) {
                     JsonObject securityCredentials = new Gson().fromJson(r, JsonObject.class);
 


### PR DESCRIPTION
  Add capability to get ECR credentials from IAM Task role from container task metadata endpoint for ECS running with Fargate deployment type.
    For ECS with EC2 instance with will query instance metadata service if ECS_AWSVPC_BLOCK_IMDS is "false". It will query task metadata endpoint in instance metadata service is not accessible (blocked).

This fixes #1233 