### PR TITLE
Fix #1112: portPropertyFile not written anymore

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,7 +4,7 @@
   - Fix test cases on Windows ([#1220](https://github.com/fabric8io/docker-maven-plugin/issues/1220))
   - ECR credentials from IAM Task role for ECS Fargate deployment ([#1233](https://github.com/fabric8io/docker-maven-plugin/issues/1233))
   - Fix bug in properties names extracted from docker config json file ([#1237](https://github.com/fabric8io/docker-maven-plugin/issues/1237))
-  - Fix #1112: portPropertyFile not written anymore
+  - Fix that portPropertyFile is not written anymore [F#1112]
 
 * **0.30.0** (2019-04-21)
   - Restore ANSI color to Maven logging if disabled during plugin execution and enable color for Windows with Maven 3.5.0 or later. Color logging is enabled by default, but disabled if the Maven CLI disables color (e.g. in batch mode) ([#1108](https://github.com/fabric8io/docker-maven-plugin/issues/1108))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
   - Fix test cases on Windows ([#1220](https://github.com/fabric8io/docker-maven-plugin/issues/1220))
   - ECR credentials from IAM Task role for ECS Fargate deployment ([#1233](https://github.com/fabric8io/docker-maven-plugin/issues/1233))
   - Fix bug in properties names extracted from docker config json file ([#1237](https://github.com/fabric8io/docker-maven-plugin/issues/1237))
+  - Fix #1112: portPropertyFile not written anymore
 
 * **0.30.0** (2019-04-21)
   - Restore ANSI color to Maven logging if disabled during plugin execution and enable color for Windows with Maven 3.5.0 or later. Color logging is enabled by default, but disabled if the Maven CLI disables color (e.g. in batch mode) ([#1108](https://github.com/fabric8io/docker-maven-plugin/issues/1108))

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -297,11 +297,12 @@ public class StartMojo extends AbstractDockerMojo {
 
         startingContainers.submit(() -> {
 
+            String containerId = startExecutor.startContainers();
+
             // Update port-mapping writer
             portMappingPropertyWriteHelper.add(portMapping, runConfig.getPortPropertyFile());
 
 
-            String containerId = startExecutor.startContainers();
 
             return new StartedContainer(imageConfig, containerId);
         });


### PR DESCRIPTION
Fix #1112 

port mappings should be written after we start containers.

Tested on https://github.com/r0haaaan/dmp-demo-project project with and without this patch. With this patch, I was able to see ports.properties file getting generated:

```
~/work/repos/dmp-demo-project : $ mvn docker:start
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------------< io.fabric8:dockerfile >------------------------
[INFO] Building dmp-sample-dockerfile 0.30-SNAPSHOT
[INFO] --------------------------------[ war ]---------------------------------
[INFO] 
[INFO] --- docker-maven-plugin:0.30-SNAPSHOT:start (default-cli) @ dockerfile ---
[INFO] DOCKER> [test-db:latest] "dockerfile": Start container 32772f1b0130
[INFO] DOCKER> [test-db:latest] "dockerfile": Pausing for 5000 ms
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.936 s
[INFO] Finished at: 2019-07-27T21:53:29+05:30
[INFO] ------------------------------------------------------------------------
~/work/repos/dmp-demo-project : $ cat src/main/resources/ports.properties 
#Docker ports
#Sat Jul 27 21:53:29 IST 2019
host.port=32787
~/work/repos/dmp-demo-project : $ 
```