### PR TITLE
Prefer HOME environment variable

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-* 0.34-SNAPSHOT
+* **0.34-SNAPSHOT**
   - Building 'spring-boot-with-jib' sample fails with NoSuchMethodError ([1384](https://github.com/fabric8io/docker-maven-plugin/issues/1384))
   - Loading Image tarball into docker daemon fails in JIB mode ([1385](https://github.com/fabric8io/docker-maven-plugin/issues/1385))
   - `assembly.inline` is removed when external properties are enabled ([1082](https://github.com/fabric8io/docker-maven-plugin/issues/1082))
@@ -16,6 +16,7 @@
   - Retry port mapping to avoid race condition where complete port information may not be initially available in Docker Engine 20.10.5 ([1447](https://github.com/fabric8io/docker-maven-plugin/pull/1447))
   - New `copy` goal for copying files and directories from containers to host ([752](https://github.com/fabric8io/docker-maven-plugin/issues/752) and [1405](https://github.com/fabric8io/docker-maven-plugin/pull/1405))
   - Add support for multiple copy layers using multiple assemblies ([554](https://github.com/fabric8io/docker-maven-plugin/issues/554))
+  - Prefer HOME environment variable over the Java system property to determine the user's home directory to better resemble the golang client's behavior ([#1236](https://github.com/fabric8io/docker-maven-plugin/pull/1263)
   
 * **0.34.1** (2020-09-27)
   - Fix NPE with "skipPush" and no build configuration given ([#1381](https://github.com/fabric8io/docker-maven-plugin/issues/1381))

--- a/src/main/asciidoc/inc/start/_volumes.adoc
+++ b/src/main/asciidoc/inc/start/_volumes.adoc
@@ -45,7 +45,7 @@ You can use Maven variables in the path specifications. This should even work fo
 ----
 
 You can also use relative paths.  Relative paths are interpreted relative to the Maven project base directory.  Paths
-that begin with `~` are interpreted relative to the JVM's `user.home` directory.
+that begin with `~` are interpreted relative to the JVM's `HOME` or `user.home` directory.
 
 .Example with relative paths
 [source,xml]

--- a/src/main/java/io/fabric8/maven/docker/access/DockerConnectionDetector.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerConnectionDetector.java
@@ -6,6 +6,8 @@ import java.util.*;
 import io.fabric8.maven.docker.access.util.LocalSocketUtil;
 import io.fabric8.maven.docker.util.*;
 
+import static io.fabric8.maven.docker.util.EnvUtil.getUserHome;
+
 /**
  * Detector for determining the Docker access mechanism
  */
@@ -167,7 +169,7 @@ public class DockerConnectionDetector {
             this.certPath = certPath != null ? certPath : System.getenv("DOCKER_CERT_PATH");
             // Try default locations as last resort
             if (this.certPath == null) {
-                File dockerHome = new File(System.getProperty("user.home") + "/.docker");
+                File dockerHome = new File(getUserHome() + "/.docker");
                 if (dockerHome.isDirectory()) {
                     String[] entries = dockerHome.list(SuffixFileFilter.PEM_FILTER);
                     if (entries == null) {

--- a/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,6 +45,8 @@ import org.yaml.snakeyaml.Yaml;
 public class DockerFileUtil {
 
     private static final String ARG_PATTERN_REGEX = "\\$(?:\\{(.*)\\}|(.*))";
+    // injection point for unit tests
+    private static UnaryOperator<String> systemGetEnv = System::getenv;
 
     private DockerFileUtil() {}
 
@@ -249,9 +252,9 @@ public class DockerFileUtil {
     }
 
     private static File getHomeDir() {
-        String homeDir = System.getProperty("user.home");
+        String homeDir = systemGetEnv.apply("HOME");
         if (homeDir == null) {
-            homeDir = System.getenv("HOME");
+            homeDir = System.getProperty("user.home");
         }
         return new File(homeDir);
     }

--- a/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,6 +35,8 @@ import org.codehaus.plexus.interpolation.fixed.FixedStringSearchInterpolator;
 import io.fabric8.maven.docker.assembly.DockerAssemblyConfigurationSource;
 import org.yaml.snakeyaml.Yaml;
 
+import static io.fabric8.maven.docker.util.EnvUtil.getUserHome;
+
 
 /**
  * Utility class for dealing with dockerfiles
@@ -45,8 +46,6 @@ import org.yaml.snakeyaml.Yaml;
 public class DockerFileUtil {
 
     private static final String ARG_PATTERN_REGEX = "\\$(?:\\{(.*)\\}|(.*))";
-    // injection point for unit tests
-    private static UnaryOperator<String> systemGetEnv = System::getenv;
 
     private DockerFileUtil() {}
 
@@ -252,11 +251,7 @@ public class DockerFileUtil {
     }
 
     private static File getHomeDir() {
-        String homeDir = systemGetEnv.apply("HOME");
-        if (homeDir == null) {
-            homeDir = System.getProperty("user.home");
-        }
-        return new File(homeDir);
+        return new File(getUserHome());
     }
 
     private static void updateMapWithArgValue(Map<String, String> result, Map<String, String> args, String argString) {

--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,6 +37,9 @@ public class EnvUtil {
     public static final String DOCKER_HTTP_PORT = "2375";
 
     public static final String PROPERTY_COMBINE_POLICY_SUFFIX = "_combine";
+
+    // injection point for unit tests
+    private static UnaryOperator<String> systemGetEnv = System::getenv;
 
     private EnvUtil() {}
 
@@ -509,5 +513,17 @@ public class EnvUtil {
         // and it turns out that System.getProperty("maven.version") does not return the value.
         String mavenVersion = mavenSession.getSystemProperties().getProperty("maven.version", "3");
         return greaterOrEqualsVersion(mavenVersion, "3.5.0");
+    }
+
+    /**
+     * Get User's HOME directory path
+     * @return a String value for user's home directory
+     */
+    public static String getUserHome() {
+        String homeDir = systemGetEnv.apply("HOME");
+        if (homeDir == null) {
+            homeDir =  System.getProperty("user.home");
+        }
+        return homeDir;
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/util/VolumeBindingUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/VolumeBindingUtil.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import static io.fabric8.maven.docker.util.DockerPathUtil.resolveAbsolutely;
+import static io.fabric8.maven.docker.util.EnvUtil.getUserHome;
 
 /**
  * Utility methods for working with Docker volume bindings.
@@ -169,7 +170,7 @@ public class VolumeBindingUtil {
         if (isRelativePath(localPath)) {
             File resolvedFile;
             if (isUserHomeRelativePath(localPath)) {
-                resolvedFile = resolveAbsolutely(prepareUserHomeRelativePath(localPath), System.getProperty("user.home"));
+                resolvedFile = resolveAbsolutely(prepareUserHomeRelativePath(localPath), getUserHome());
             } else {
                 if (!baseDir.isAbsolute()) {
                     throw new IllegalArgumentException("Base directory '" + baseDir + "' must be absolute.");

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
@@ -300,7 +300,7 @@ public class AuthConfigFactoryTest {
         String userHome = System.getProperty("user.home");
         environmentVariables.clear("KUBECONFIG");
         try {
-            Field envField = DockerFileUtil.class.getDeclaredField("systemGetEnv");
+            Field envField = EnvUtil.class.getDeclaredField("systemGetEnv");
             ReflectionAccessor.getInstance().makeAccessible(envField);
             @SuppressWarnings("unchecked")
             UnaryOperator<String> origEnv = (UnaryOperator<String>) envField.get(null);


### PR DESCRIPTION
The Java system property is filled by a syscall to determine the user's home directory. This is not matching the typical implementation of the docker and kubectl binaries, which prefer the HOME OS environment variable over the syscall.