### PR TITLE
Wait service should treat default network mode same as bridge (#1234)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/WaitService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WaitService.java
@@ -176,7 +176,7 @@ public class WaitService {
         } else {
             final String networkMode = container.getNetworkMode();
             log.info("%s: Network mode: %s", imageConfigDesc, networkMode);
-            if (networkMode == null || networkMode.isEmpty() || "bridge".equals(networkMode)) {
+            if (networkMode == null || networkMode.isEmpty() || "default".equals(networkMode) || "bridge".equals(networkMode)) {
                 // Safe mode when network mode is not present
                 host = container.getIPAddress();
             } else if (!"host".equals(networkMode)) {


### PR DESCRIPTION
This is a fix for https://github.com/fabric8io/docker-maven-plugin/issues/1234

If the network mode is not specified, the networkMode string is "default". Although it is technically bridge mode, this if block doesn't think it is, so it fails to get the host.