### PR TITLE
Add null check for null instance in config.json for email

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -476,7 +476,7 @@ public class AuthConfigFactory {
         }
         String auth = credentials.get("auth").getAsString();
         String identityToken = credentials.has("identitytoken") ? credentials.get("identitytoken").getAsString() : null;
-        String email = credentials.has(AUTH_EMAIL) ? credentials.get(AUTH_EMAIL).getAsString() : null;
+        String email = credentials.has(AUTH_EMAIL) && !credentials.get(AUTH_EMAIL).isJsonNull() ? credentials.get(AUTH_EMAIL).getAsString() : null;
         return new AuthConfig(auth, email, identityToken);
     }
 


### PR DESCRIPTION
A quick PR to address issue found here:
https://github.com/fabric8io/docker-maven-plugin/issues/1262

Add a null check and refactor tests to accommodate serialisation of nulls when auth config file created.