### PR TITLE
Fix Boolean comparison for healthy option

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@
   - Allow merging of image configurations using <imagesMap> ([#360](https://github.com/fabric8io/docker-maven-plugin/issues/360))
   - Treat bridged and default network mode the same #1234
   - Fix NPE when cacheFrom is missing from config #1274
+  - Fix healthy option regression introduced in 0.25.0 #1279
 
 * **0.31.0** (2019-08-10)
   - Fix test cases on Windows ([#1220](https://github.com/fabric8io/docker-maven-plugin/issues/1220))

--- a/src/main/java/io/fabric8/maven/docker/service/WaitService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WaitService.java
@@ -119,7 +119,7 @@ public class WaitService {
             }
         }
 
-        if (wait.getHealthy() == Boolean.TRUE) {
+        if (Boolean.TRUE.equals(wait.getHealthy())) {
             checkers.add(new HealthCheckChecker(dockerAccess, containerId, imageConfig.getDescription(), log));
         }
 


### PR DESCRIPTION
It seems there is a regression on healthy option since 0.25.0, and the change from "boolean" to "Boolean".

It seems that "wait.getHealthy() == Boolean.TRUE" is always false, introduced in 0.25.0.
Comparison should be by value, not by reference.

Maven version : 3.5.4
JDK : 8