### PR TITLE
Use top-level authentication for extended auth

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/RegistryAuthConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RegistryAuthConfiguration.java
@@ -45,6 +45,7 @@ public class RegistryAuthConfiguration implements Serializable {
         }
         if (StringUtils.isNotBlank(authToken)) {
             authMap.put(AuthConfigFactory.AUTH_AUTHTOKEN, authToken);
+            authMap.put("auth", authToken);
         }
         if (StringUtils.isNotBlank(email)) {
             authMap.put(AuthConfigFactory.AUTH_EMAIL,email);


### PR DESCRIPTION
When relying on [Extended Authentication](https://dmp.fabric8.io/#extended-authentication) for ECR, we unfortunately have to configure the `push` and `pull` sections, even though they are the same. The problem seems to be that the AWS session token has to be put into the `<auth>` element, whereas the general section only knows an `<authToken>` element. This change would allow Extended Authentication to work with the general configuration.

Maybe the proper way forward would be to deprecate the `authToken` property and introduce `auth` - or vice versa.