### PR TITLE
Support both ECS & Fargate tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,13 @@
       <version>2.6.0</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -10,7 +10,6 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -366,7 +366,7 @@ public class AuthConfigFactory {
         try {
             return new URI(ecsMetadataEndpoint + awsContainerCredentialsUri);
         } catch (URISyntaxException e) {
-            log.warn("Failed to construct path to ECS credentials", e);
+            log.warn("Failed to construct path to ECS metadata endpoint for credentials", e);
             return null;
         }
     }

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
@@ -56,8 +56,9 @@ import static org.junit.Assert.assertNull;
 
 public class AuthConfigFactoryTest {
 
-    public static final String ECR_NAME = "123456789012.dkr.ecr.bla.amazonaws.com";@Rule
+    public static final String ECR_NAME = "123456789012.dkr.ecr.bla.amazonaws.com";
 
+    @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Mocked

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
@@ -605,13 +605,13 @@ public class AuthConfigFactoryTest {
     private void verifyAuthConfig(AuthConfig config, String username, String password, String email, String auth) {
         assertNotNull(config);
         JsonObject params = gsonBuilder.create().fromJson(new String(Base64.decodeBase64(config.toHeaderValue().getBytes())), JsonObject.class);
-        assertEquals(username, params.get("username").getAsString());
-        assertEquals(password, params.get("password").getAsString());
+        assertEquals(username, params.get(AuthConfig.AUTH_USERNAME).getAsString());
+        assertEquals(password, params.get(AuthConfig.AUTH_PASSWORD).getAsString());
         if (email != null) {
-            assertEquals(email, params.get("email").getAsString());
+            assertEquals(email, params.get(AuthConfig.AUTH_EMAIL).getAsString());
         }
         if (auth != null) {
-            assertEquals(auth, params.get("auth").getAsString());
+            assertEquals(auth, params.get(AuthConfig.AUTH_AUTH).getAsString());
         }
     }
 

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.ExpectedException;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 
@@ -55,7 +56,9 @@ import static org.junit.Assert.assertNull;
 
 public class AuthConfigFactoryTest {
 
-    public static final String ECR_NAME = "123456789012.dkr.ecr.bla.amazonaws.com";
+    public static final String ECR_NAME = "123456789012.dkr.ecr.bla.amazonaws.com";@Rule
+
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Mocked
     Settings settings;
@@ -593,16 +596,9 @@ public class AuthConfigFactoryTest {
     }
 
     private void setupEcsMetadataConfiguration(HttpServer httpServer, String containerCredentialsUri) {
-        new Expectations() {{
-            settings.getServer("junit.ecs-meta");
-            HashMap<String, Object> testConfiuration = new HashMap<>();
-            testConfiuration.put("host", httpServer.getInetAddress().getHostAddress());
-            testConfiuration.put("port", httpServer.getLocalPort());
-            testConfiuration.put("path", containerCredentialsUri);
-            Server server = new Server();
-            server.setConfiguration(testConfiuration);
-            result = server;
-        }};
+        environmentVariables.set("ECS_METADATA_ENDPOINT", "http://" +
+                httpServer.getInetAddress().getHostAddress()+":" + httpServer.getLocalPort());
+        environmentVariables.set("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", containerCredentialsUri);
     }
 
     private void verifyAuthConfig(AuthConfig config, String username, String password, String email, String auth) {


### PR DESCRIPTION
The feature to pick up [AWS credentials for Fargate tasks](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-fargate.html) was introduced with #1235 
The same mechanism applies to [ECS-based tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html), but the composition of the URI is either slightly different or the underlying implementation more sensitive to the correctness of the URL: the current implementation of the plugin calculates `http://169.254.170.2/$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, whereas `http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` would be appropriate for ECS-based tasks.

This PR extends the feature to work for both scenarios, and adds unit tests for both of them.
Instead of adding another framework like e.g. [WireMock](http://wiremock.org/), I opted to use the HTTP server shipped with [Apache HttpCore](https://hc.apache.org/httpcomponents-core-ga/), which is already in the dependency list; I hope that's ok.

I would kindly ask @yadavnikhil to test this feature before integrating/releasing it; since I have no real-world scenario with which I could validate this PR on Fargate.