### PR TITLE
Fix #1197: Unable to build dockerFile without pushing it to docker server (DockerInDocker)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.31-SNAPSHOT**
+  - Support building dockerFile without pushing it to docker server #1197
   - Update to jnr-unixsocket 0.23
   - Add null check for null instance in config.json for email (#1262)
   - Allow merging of image configurations using <imagesMap> ([#360](https://github.com/fabric8io/docker-maven-plugin/issues/360))

--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -144,7 +144,7 @@ If set to `true` this plugin won't remove any tags with `{plugin}:remove`. +
 | `docker.useColor`
 
 | *verbose*
-a| String attribute for switching on verbose output on standard output (stdout). It takes a comma separated list of string values to switch on various verbosity groups.
+| String attribute for switching on verbose output on standard output (stdout). It takes a comma separated list of string values to switch on various verbosity groups.
 
 The currently known groups are:
 
@@ -159,6 +159,17 @@ If you set an empty string (or only e.g. `-Ddocker.verbose`) then the "build" gr
 
 Default is that verbose logging is disabled.
 | `docker.verbose`
+
+| *buildArchiveOnly*
+| This option would skip the docker build step and would only create a build tar.
+
+`-Ddocker.buildArchiveOnly`=`/path/to/archive` would create the build tar with name `/path/to/archive` and then stop without actually building
+
+`-Ddocker.buildArchiveOnly`, `-Ddocker.buildArchiveOnly=true` would also skip building image, but leaving the archive in `target/` only without copying it to anywhere.
+
+`-Ddocker.buildArchiveOnly=false` which is default value would do the default docker build.
+
+| docker.buildArchiveOnly
 |===
 
 .Example

--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -3,6 +3,7 @@ package io.fabric8.maven.docker.service;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -60,14 +61,56 @@ public class BuildService {
      * @throws DockerAccessException
      * @throws MojoExecutionException
      */
-    public void buildImage(ImageConfiguration imageConfig, ImagePullManager imagePullManager, BuildContext buildContext)
+    public void buildImage(ImageConfiguration imageConfig, ImagePullManager imagePullManager, BuildContext buildContext, File buildArchiveFile)
             throws DockerAccessException, MojoExecutionException {
 
         if (imagePullManager != null) {
             autoPullBaseImage(imageConfig, imagePullManager, buildContext);
         }
 
-        buildImage(imageConfig, buildContext.getMojoParameters(), checkForNocache(imageConfig), addBuildArgs(buildContext));
+        buildImage(imageConfig, buildContext.getMojoParameters(), checkForNocache(imageConfig), addBuildArgs(buildContext), buildArchiveFile);
+    }
+
+    /**
+     * Create docker archive for building image
+     *
+     * @param imageConfiguration image configuration
+     * @param buildContext docker build context
+     * @param archivePath build archive only flag, it can have values TRUE or FALSE and also
+     *                               it can hold path to archive where it might get copied over
+     * @return tarball for docker image
+     * @throws MojoExecutionException in case any exception comes during building tarball
+     */
+    public File buildArchive(ImageConfiguration imageConfiguration, BuildContext buildContext, String archivePath)
+            throws MojoExecutionException {
+        String imageName = imageConfiguration.getName();
+        ImageName.validate(imageName);
+        BuildImageConfiguration buildConfig = imageConfiguration.getBuildConfiguration();
+        MojoParameters params = buildContext.getMojoParameters();
+
+        if (buildConfig.getDockerArchive() != null) {
+            return buildConfig.getAbsoluteDockerTarPath(params);
+        }
+        long time = System.currentTimeMillis();
+
+        File dockerArchive = archiveService.createArchive(imageName, buildConfig, params, log);
+        log.info("%s: Created %s in %s", imageConfiguration.getDescription(), dockerArchive.getName(), EnvUtil.formatDurationTill(time));
+
+        // Copy created tarball to directory if specified
+        try {
+            copyDockerArchive(imageConfiguration, dockerArchive, archivePath);
+        } catch (IOException exception) {
+            throw new MojoExecutionException("Error while copying created tar to specified buildArchive path: " + archivePath,
+                    exception);
+        }
+        return dockerArchive;
+    }
+
+    public void copyDockerArchive(ImageConfiguration imageConfiguration, File dockerArchive, String archivePath) throws IOException {
+        if (archivePath != null && !archivePath.isEmpty()) {
+            Files.copy(dockerArchive.toPath(), new File(archivePath, dockerArchive.getName()).toPath());
+            log.info("%s: Copied created tarball to %s", imageConfiguration.getDescription(), archivePath);
+        }
     }
 
     public void tagImage(String imageName, ImageConfiguration imageConfig) throws DockerAccessException {
@@ -92,11 +135,11 @@ public class BuildService {
      * @param imageConfig the image configuration
      * @param params mojo params for the project
      * @param noCache if not null, dictate the caching behaviour. Otherwise its taken from the build configuration
-     * @param buildArgs
+     * @param buildArgs docker build args
      * @throws DockerAccessException
      * @throws MojoExecutionException
      */
-    protected void buildImage(ImageConfiguration imageConfig, MojoParameters params, boolean noCache, Map<String, String> buildArgs)
+    protected void buildImage(ImageConfiguration imageConfig, MojoParameters params, boolean noCache, Map<String, String> buildArgs, File dockerArchive)
             throws DockerAccessException, MojoExecutionException {
 
         String imageName = imageConfig.getName();
@@ -126,11 +169,6 @@ public class BuildService {
 
             return;
         }
-
-        long time = System.currentTimeMillis();
-
-        File dockerArchive = archiveService.createArchive(imageName, buildConfig, params, log);
-        log.info("%s: Created %s in %s", imageConfig.getDescription(), dockerArchive.getName(), EnvUtil.formatDurationTill(time));
 
         Map<String, String> mergedBuildMap = prepareBuildArgs(buildArgs, buildConfig);
 

--- a/src/main/java/io/fabric8/maven/docker/service/WatchService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WatchService.java
@@ -173,7 +173,7 @@ public class WatchService {
                             watcher.getWatchContext().getImageCustomizer().execute(imageConfig);
                         }
 
-                        buildService.buildImage(imageConfig, null, buildContext);
+                        buildService.buildImage(imageConfig, null, buildContext, buildService.buildArchive(imageConfig, buildContext, "false"));
 
                         String name = imageConfig.getName();
                         watcher.setImageId(queryService.getImageId(name));

--- a/src/test/java/io/fabric8/maven/docker/service/LoadImageTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/LoadImageTest.java
@@ -84,7 +84,7 @@ public class LoadImageTest {
     }
 
     private void whenBuildImage() throws DockerAccessException, MojoExecutionException {
-        buildService.buildImage(imageConfig, params, false, Collections.<String, String>emptyMap());
+        buildService.buildImage(imageConfig, params, false, Collections.<String, String>emptyMap(), new File("/maven-project/src/main/docker/test.tar"));
     }
 
     private void thenImageIsBuilt() throws DockerAccessException {


### PR DESCRIPTION
Fix #1197 

with `docker.skip.build.image` flag we can skip pushing created docker archive to docker daemon.
![Peek 2019-11-21 20-29](https://user-images.githubusercontent.com/13834498/69349824-79707280-0c9e-11ea-932b-8144f85ddbfc.gif)
