### PR TITLE
Fix #1182: Allow killing and removing all spawned containers

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -10,6 +10,7 @@
   - Treat bridged and default network mode the same (#1234)
   - Fix NPE when cacheFrom is missing from config (#1274)
   - Fix healthy option regression introduced in 0.25.0 (#1279)
+  - Allow killing and removing all spawned containers (#1182)
   - Deprecated "authToken" for ECR authentication in favor of "auth" (#1286)
 
 * **0.31.0** (2019-08-10)

--- a/src/main/asciidoc/inc/start/_configuration.adoc
+++ b/src/main/asciidoc/inc/start/_configuration.adoc
@@ -122,6 +122,9 @@ a| *This option is deprecated, please use a `containerNamePattern` instead* Nami
 | *skip*
 | If `true` disable creating and starting of the container. This option is best used together with a Maven property which can be set from the outside.
 
+| *stopMode*
+| Specifies how to stop a running container. It supports the modes `graceful` and `kill` as values, with `graceful` being the default.
+
 | *tmpfs*
 a| List countaintin `<mount>` elements for directories to mount with a temporary filesystem. Optionally, mount options can be appended after a ':'. See below for an example.
 

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -133,6 +133,14 @@ public interface DockerAccess {
      */
     void stopContainer(String containerId, int killWait) throws DockerAccessException;
 
+    /**
+     * Kill a container
+     *
+     * @param containerId the container id
+     * @throws DockerAccessException if container failed to be killed
+     */
+    void killContainer(String containerId) throws DockerAccessException;
+
     /** Copy an archive (must be a tar) into a running container
      * Get all containers matching a certain label. This might not be a cheap operation especially if many containers
      * are running. Use with care.

--- a/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
@@ -145,6 +145,11 @@ public final class UrlBuilder {
         return b.build();
     }
 
+    public String killContainer(String containerId) {
+        Builder b = u("containers/%s/kill", containerId);
+        return b.build();
+    }
+
     public String tagContainer(ImageName source, ImageName target, boolean force) {
         return u("images/%s/tag", source.getFullName())
                 .p("repo",target.getNameWithoutTag())

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -188,6 +188,10 @@ public class RunImageConfiguration implements Serializable {
     @Parameter
     private Boolean autoRemove;
 
+    // How to stop a container
+    @Parameter
+    private StopMode stopMode;
+
     public RunImageConfiguration() { }
 
     public String initAndValidate() {
@@ -399,6 +403,13 @@ public class RunImageConfiguration implements Serializable {
 
     public Boolean getAutoRemove() {
         return autoRemove;
+    }
+
+    public StopMode getStopMode() {
+        if (stopMode == null) {
+            return StopMode.graceful;
+        }
+        return stopMode;
     }
 
     /**
@@ -637,6 +648,11 @@ public class RunImageConfiguration implements Serializable {
 
         public Builder skip(Boolean skip) {
             config.skip = skip;
+            return this;
+        }
+
+        public Builder stopMode(StopMode stopMode) {
+            config.stopMode = stopMode;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/StopMode.java
+++ b/src/main/java/io/fabric8/maven/docker/config/StopMode.java
@@ -1,0 +1,16 @@
+package io.fabric8.maven.docker.config;
+
+/*
+ * Enum for holding information regarding stopping containers in dmp
+ */
+public enum StopMode {
+    /**
+     * Would wait for the process to terminate correctly
+     */
+    graceful,
+
+    /**
+     * Would terminate the process with a sigkill
+     */
+    kill
+}

--- a/src/main/java/io/fabric8/maven/docker/config/WatchMode.java
+++ b/src/main/java/io/fabric8/maven/docker/config/WatchMode.java
@@ -23,7 +23,7 @@ package io.fabric8.maven.docker.config;/*
 public enum WatchMode {
 
     /**
-     * Copy watched artefacts into contaienr
+     * Copy watched artefacts into container
      */
     copy(false, false, true, "build"),
 

--- a/src/main/java/io/fabric8/maven/docker/service/ContainerTracker.java
+++ b/src/main/java/io/fabric8/maven/docker/service/ContainerTracker.java
@@ -4,6 +4,7 @@ import java.util.*;
 
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.RunImageConfiguration;
+import io.fabric8.maven.docker.config.StopMode;
 import io.fabric8.maven.docker.config.WaitConfiguration;
 import io.fabric8.maven.docker.util.GavLabel;
 
@@ -188,6 +189,9 @@ public class ContainerTracker {
         // How long to wait after stop to kill container (in seconds)
         private final int killGracePeriod;
 
+        // Whether to kill or stop gracefully
+        private final StopMode stopMode;
+
 
         // Command to call before stopping container and whether to stop the build
         private String preStop;
@@ -200,6 +204,7 @@ public class ContainerTracker {
             RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
             WaitConfiguration waitConfig = runConfig != null ? runConfig.getWaitConfiguration() : null;
             this.shutdownGracePeriod = waitConfig != null && waitConfig.getShutdown() != null ? waitConfig.getShutdown() : 0;
+            this.stopMode = runConfig != null ? runConfig.getStopMode()  : StopMode.graceful;
             this.killGracePeriod = waitConfig != null && waitConfig.getKill() != null ? waitConfig.getKill() : 0;
             if (waitConfig != null && waitConfig.getExec() != null) {
                 this.preStop = waitConfig.getExec().getPreStop();
@@ -237,6 +242,10 @@ public class ContainerTracker {
 
         public boolean isBreakOnError() {
             return breakOnError;
+        }
+
+        public StopMode getStopMode() {
+            return stopMode;
         }
 
         @Override


### PR DESCRIPTION
Fix #1182 

This PR adds a parameter `stopMode` in RunImageConfiguration which accepts values `graceful` and `kill`. When doing `graceful` stop it would proceed with the usual process; In case of kill it would simply request docker daemon to kill the container.

Here are some API logs with stopMode being set to kill

```
~/work/repos/dmp-demo-project : $ mvn docker:stop -Ddocker.verbose=api,build
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------------< io.fabric8:dockerfile >------------------------
[INFO] Building dmp-sample-dockerfile 0.30-SNAPSHOT
[INFO] --------------------------------[ war ]---------------------------------
[INFO] 
[INFO] --- docker-maven-plugin:0.31-SNAPSHOT:stop (default-cli) @ dockerfile ---
[INFO] DOCKER> GETing unix://127.0.0.1:1/version
[INFO] DOCKER> GETing unix://127.0.0.1:1/v1.40/containers/json?all=1&filters=%7B%22ancestor%22%3A%5B%22te
st-db%22%5D%7D
[INFO] DOCKER> POSTing unix://127.0.0.1:1/v1.40/containers/6e016ba9cd02/kill
[INFO] DOCKER> [test-db:latest] "dockerfile": Killed and removed container 6e016ba9cd02.
[INFO] DOCKER> DELETEing unix://127.0.0.1:1/v1.40/containers/6e016ba9cd02?v=0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.588 s
[INFO] Finished at: 2019-11-22T01:06:37+05:30
[INFO] ------------------------------------------------------------------------
~/work/repos/dmp-demo-project : $ 

```