### PR TITLE
Warning, instead of exception, on temporary image existence

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -12,6 +12,7 @@
   - Fix healthy option regression introduced in 0.25.0 (#1279)
   - Allow killing and removing all spawned containers (#1182)
   - Deprecated "authToken" for ECR authentication in favor of "auth" (#1286)
+  - Allow overriding of existing image in creation of temporary one with same tag before push ([#838](https://github.com/fabric8io/docker-maven-plugin/issues/838))
 
 * **0.31.0** (2019-08-10)
   - Fix test cases on Windows ([#1220](https://github.com/fabric8io/docker-maven-plugin/issues/1220))


### PR DESCRIPTION
Fixes #838 

There are some scenarios that docker image with the same tag as the one created as temporary to be pushed to registry already exists. This could be the situation when image was tagged manually or pulled by some other process. Currently in this situation image will not be tagged and process will fail with exception.

After these changes 3 modes for handling of temporary images will be allowed:

- image of expected tag DOES exist - image with given tag will be updated and NOT removed after push,
- image of expected tag DOES NOT exist - tagged image will be treated as temporary and is removed after push,
- image push to registry failed - image will be tagged, because build was successful, but push failed.

#1170 already seems to try to solve this problem but it seems to be stale and proposed solution lacks proper logging