### PR TITLE
Enable Jacoco profile for CircleCI Sonar-related jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
         key: dmp-sonar-pr-{{ checksum "pom.xml" }}
     - run: |
         if [ -n "${CIRCLE_PR_NUMBER}" ]; then
-          mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar \
+          mvn clean -Pjacoco org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar \
              -Dsonar.pullrequest.base=master \
              -Dsonar.pullrequest.branch=${CIRCLE_BRANCH} \
              -Dsonar.pullrequest.key=${CIRCLE_PR_NUMBER} \
@@ -66,7 +66,7 @@ jobs:
     - restore_cache:
         key: dmp-sonar-{{ checksum "pom.xml" }}
     - run: |
-        mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar \
+        mvn clean -Pjacoco org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar \
         -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.login=${SONARQUBE_TOKEN}
     - save_cache:


### PR DESCRIPTION
As @rhuss pointed out in #1300 currently SonarCloud check shows that code coverage is 0% and does not meet Quality Gate of 80%.
After some time of trying to locate the issue I've noticed that jacoco profile is enabled neither for 'sonar' nor 'sonar-pr' CircleCI jobs.
It is worth noting that although changes made make sure that appropriate profile is enabled for both of those jobs, Quality Gate of 80% is not passed (it is 57.9% in my case) so it is worth to consider lowering it for the time being.