### PR TITLE
Pick up AWS credentials from ENV

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@
   - Allow killing and removing all spawned containers (#1182)
   - Deprecated "authToken" for ECR authentication in favor of "auth" (#1286)
   - Allow overriding of existing image in creation of temporary one with same tag before push ([#838](https://github.com/fabric8io/docker-maven-plugin/issues/838))
+  - Pick up AWS credentials from ENV variables (#1310)
 
 * **0.31.0** (2019-08-10)
   - Fix test cases on Windows ([#1220](https://github.com/fabric8io/docker-maven-plugin/issues/1220))

--- a/src/main/asciidoc/inc/_authentication.adoc
+++ b/src/main/asciidoc/inc/_authentication.adoc
@@ -186,8 +186,8 @@ Use the IAM *Access key ID* as the username and the *Secret access key* as the p
 In case you're using temporary security credentials provided by the AWS Security Token Service (AWS STS), you have to provide the *security token* as well.
 To do so, either specify the `docker.auth` system property or provide an `<auth>` element alongside username & password in the `authConfig`.
 
-In case you are running on an EC2 instance OR ECS with fargate deployment (OR ECS with EC2 with ECS_AWSVPC_BLOCK_IMDS as "true") that has an appropriate IAM role assigned
-(e.g. a role that grants the AWS built-in policy _AmazonEC2ContainerRegistryPowerUser_)
-authentication information doesn't need to be provided at all. Instead the instance
-meta-data service or task metadata endpoint in case of ECS is queried for temporary access credentials supplied by the
-assigned role.
+d-m-p will attempt to read AWS credentials from some well-known spots in case there is no explicit configuration:
+* it will pick up ENV variables link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html[as documented for the AWS CLI]
+* it will pick up temporary credentials of link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html[the IAM role of an EC2 instance]
+* it will pick up temporary credentials of link:https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html[the IAM role of a fargate task (OR ECS with EC2 with ECS_AWSVPC_BLOCK_IMDS as "true")]
+If any of these authentication information is accessible, it will be used.

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
@@ -550,6 +550,41 @@ public class AuthConfigFactoryTest {
         verifyAuthConfig(authConfig, accessKeyId, secretAccessKey, null, sessionToken);
     }
 
+    @Test
+    public void awsTemporaryCredentialsArePickedUpFromEnvironment() throws MojoExecutionException {
+        String accessKeyId = randomUUID().toString();
+        String secretAccessKey = randomUUID().toString();
+        String sessionToken = randomUUID().toString();
+        environmentVariables.set("AWS_ACCESS_KEY_ID", accessKeyId);
+        environmentVariables.set("AWS_SECRET_ACCESS_KEY", secretAccessKey);
+        environmentVariables.set("AWS_SESSION_TOKEN", sessionToken);
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, settings, "user", ECR_NAME);
+
+        verifyAuthConfig(authConfig, accessKeyId, secretAccessKey, null, sessionToken);
+    }
+
+    @Test
+    public void awsStaticCredentialsArePickedUpFromEnvironment() throws MojoExecutionException {
+        String accessKeyId = randomUUID().toString();
+        String secretAccessKey = randomUUID().toString();
+        environmentVariables.set("AWS_ACCESS_KEY_ID", accessKeyId);
+        environmentVariables.set("AWS_SECRET_ACCESS_KEY", secretAccessKey);
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, settings, "user", ECR_NAME);
+
+        verifyAuthConfig(authConfig, accessKeyId, secretAccessKey, null, null);
+    }
+
+    @Test
+    public void incompleteAwsCredentialsAreIgnored() throws MojoExecutionException {
+        environmentVariables.set("AWS_ACCESS_KEY_ID", randomUUID().toString());
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, settings, "user", ECR_NAME);
+
+        assertNull(authConfig);
+    }
+
     private void setupServers() {
         new Expectations() {{
             List<Server> servers = new ArrayList<>();


### PR DESCRIPTION
With various AWS authentication mechanisms already in place, one of the most basic ones is yet missing: configuring credentials via environment variables.

See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html