### PR TITLE
Fix #1242: docker.container.<alias>.ip property is no longer set

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -7,6 +7,7 @@
     The handling of Y changes when the week straddle the New year ([Stack Overflow](https://stackoverflow.com/questions/26431882/difference-between-year-of-era-and-week-based-year))
   - Fix JSON error when parsin tafs (#1354)
   - Add `skipPush` option to build image configuration ([#1243](https://github.com/fabric8io/docker-maven-plugin/issues/1243))
+  - docker.container.<alias>.ip property is no longer set ([#1242](https://github.com/fabric8io/docker-maven-plugin/issues/1242))
   - Support `squash` in build options to squash newly built layers into a single layer ([#785](https://github.com/fabric8io/docker-maven-plugin/issues/785)) 
 
 * **0.33.0** (2020-01-21)

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -298,9 +298,8 @@ public class StartMojo extends AbstractDockerMojo {
 
         startingContainers.submit(() -> {
 
-            ImmutablePair<String, Properties> containerIdToProperties = startExecutor.startContainers();
-            String containerId = containerIdToProperties.getKey();
-            project.getProperties().putAll(containerIdToProperties.getValue());
+            String containerId = startExecutor.startContainers();
+            project.getProperties().putAll(startExecutor.queryContainerProperties(containerId));
 
             // Update port-mapping writer
             portMappingPropertyWriteHelper.add(portMapping, runConfig.getPortPropertyFile());

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -42,6 +42,7 @@ import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.service.helper.StartContainerExecutor;
 import io.fabric8.maven.docker.util.ContainerNamingUtil;
 import io.fabric8.maven.docker.util.StartOrderResolver;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -297,11 +298,12 @@ public class StartMojo extends AbstractDockerMojo {
 
         startingContainers.submit(() -> {
 
-            String containerId = startExecutor.startContainers();
+            ImmutablePair<String, Properties> containerIdToProperties = startExecutor.startContainers();
+            String containerId = containerIdToProperties.getKey();
+            project.getProperties().putAll(containerIdToProperties.getValue());
 
             // Update port-mapping writer
             portMappingPropertyWriteHelper.add(portMapping, runConfig.getPortPropertyFile());
-
 
 
             return new StartedContainer(imageConfig, containerId);

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -42,7 +42,6 @@ import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.service.helper.StartContainerExecutor;
 import io.fabric8.maven.docker.util.ContainerNamingUtil;
 import io.fabric8.maven.docker.util.StartOrderResolver;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -179,7 +178,6 @@ public class StartMojo extends AbstractDockerMojo {
                     waitForStartedContainer(containerStartupService, startedContainerAliases, imagesStarting);
                 }
             }
-
             portMappingPropertyWriteHelper.write();
 
             if (follow) {
@@ -298,12 +296,10 @@ public class StartMojo extends AbstractDockerMojo {
 
         startingContainers.submit(() -> {
 
-            String containerId = startExecutor.startContainers();
-            project.getProperties().putAll(startExecutor.queryContainerProperties(containerId));
+            String containerId = startExecutor.startContainer();
 
             // Update port-mapping writer
             portMappingPropertyWriteHelper.add(portMapping, runConfig.getPortPropertyFile());
-
 
             return new StartedContainer(imageConfig, containerId);
         });

--- a/src/main/java/io/fabric8/maven/docker/service/WatchService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WatchService.java
@@ -254,9 +254,8 @@ public class WatchService {
                     .buildTimestamp(watcher.watchContext.buildTimestamp)
                     .build();
 
-            ImmutablePair<String, Properties> containerIdToProperties = helper.startContainers();
-            String containerId = containerIdToProperties.getKey();
-            watcher.watchContext.mojoParameters.getProject().getProperties().putAll(containerIdToProperties.getValue());
+            String containerId = helper.startContainers();
+            watcher.watchContext.mojoParameters.getProject().getProperties().putAll(helper.queryContainerProperties(containerId));
 
             watcher.setContainerId(containerId);
         };

--- a/src/main/java/io/fabric8/maven/docker/service/WatchService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WatchService.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -26,6 +27,7 @@ import io.fabric8.maven.docker.util.MojoParameters;
 import io.fabric8.maven.docker.util.GavLabel;
 import io.fabric8.maven.docker.util.StartOrderResolver;
 import io.fabric8.maven.docker.util.Task;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.StringUtils;
@@ -252,7 +254,9 @@ public class WatchService {
                     .buildTimestamp(watcher.watchContext.buildTimestamp)
                     .build();
 
-            String containerId = helper.startContainers();
+            ImmutablePair<String, Properties> containerIdToProperties = helper.startContainers();
+            String containerId = containerIdToProperties.getKey();
+            watcher.watchContext.mojoParameters.getProject().getProperties().putAll(containerIdToProperties.getValue());
 
             watcher.setContainerId(containerId);
         };

--- a/src/main/java/io/fabric8/maven/docker/service/WatchService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WatchService.java
@@ -6,7 +6,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -22,12 +21,11 @@ import io.fabric8.maven.docker.config.WatchImageConfiguration;
 import io.fabric8.maven.docker.config.WatchMode;
 import io.fabric8.maven.docker.log.LogDispatcher;
 import io.fabric8.maven.docker.service.helper.StartContainerExecutor;
+import io.fabric8.maven.docker.util.GavLabel;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.docker.util.MojoParameters;
-import io.fabric8.maven.docker.util.GavLabel;
 import io.fabric8.maven.docker.util.StartOrderResolver;
 import io.fabric8.maven.docker.util.Task;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.StringUtils;
@@ -254,9 +252,7 @@ public class WatchService {
                     .buildTimestamp(watcher.watchContext.buildTimestamp)
                     .build();
 
-            String containerId = helper.startContainers();
-            watcher.watchContext.mojoParameters.getProject().getProperties().putAll(helper.queryContainerProperties(containerId));
-
+            String containerId = helper.startContainer();
             watcher.setContainerId(containerId);
         };
     }

--- a/src/main/java/io/fabric8/maven/docker/service/helper/StartContainerExecutor.java
+++ b/src/main/java/io/fabric8/maven/docker/service/helper/StartContainerExecutor.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.codehaus.plexus.util.StringUtils;
 
 import io.fabric8.maven.docker.access.DockerAccessException;
@@ -42,19 +41,19 @@ public class StartContainerExecutor {
 
     private StartContainerExecutor(){}
 
-    public ImmutablePair<String, Properties> startContainers() throws IOException, ExecException {
+    public String startContainers() throws IOException, ExecException {
         final Properties projProperties = projectProperties;
 
         final String containerId = hub.getRunService().createAndStartContainer(imageConfig, portMapping, gavLabel, projProperties, basedir, containerNamePattern, buildDate);
 
         showLogsIfRequested(containerId);
-        Properties exposedProperties = exposeContainerProps(containerId);
+        projProperties.putAll(queryContainerProperties(containerId));
         waitAndPostExec(containerId, projProperties);
 
-        return new ImmutablePair<>(containerId, exposedProperties);
+        return containerId;
     }
 
-    private Properties exposeContainerProps(String containerId)
+    public Properties queryContainerProperties(String containerId)
         throws DockerAccessException {
         String propKey = getExposedPropertyKeyPart();
         Properties exposedProperties = new Properties();

--- a/src/main/java/io/fabric8/maven/docker/service/helper/StartContainerExecutor.java
+++ b/src/main/java/io/fabric8/maven/docker/service/helper/StartContainerExecutor.java
@@ -41,13 +41,14 @@ public class StartContainerExecutor {
 
     private StartContainerExecutor(){}
 
-    public String startContainers() throws IOException, ExecException {
+    public String startContainer() throws IOException, ExecException {
         final Properties projProperties = projectProperties;
 
         final String containerId = hub.getRunService().createAndStartContainer(imageConfig, portMapping, gavLabel, projProperties, basedir, containerNamePattern, buildDate);
 
         showLogsIfRequested(containerId);
-        projProperties.putAll(queryContainerProperties(containerId));
+        Properties exposedProps = queryContainerProperties(containerId);
+        projProperties.putAll(exposedProps);
         waitAndPostExec(containerId, projProperties);
 
         return containerId;

--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -353,7 +353,8 @@ public class AuthConfigFactory {
         // get temporary credentials
         log.debug("Getting temporary security credentials from: %s", uri);
         try (CloseableHttpClient client = HttpClients.custom().useSystemProperties().build()) {
-            RequestConfig conf = RequestConfig.custom().setConnectionRequestTimeout(1000).setConnectTimeout(1000)
+            RequestConfig conf =
+                RequestConfig.custom().setConnectionRequestTimeout(1000).setConnectTimeout(1000)
                     .setSocketTimeout(1000).build();
             HttpGet request = new HttpGet(uri);
             request.setConfig(conf);

--- a/src/test/java/io/fabric8/maven/docker/service/helper/StartContainerExecutorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/helper/StartContainerExecutorTest.java
@@ -15,7 +15,6 @@ import io.fabric8.maven.docker.util.JsonFactory;
 import io.fabric8.maven.docker.util.Logger;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.Test;
 
 import io.fabric8.maven.docker.config.ImageConfiguration;
@@ -284,11 +283,10 @@ public class StartContainerExecutorTest {
             .build();
 
     // When
-    String containerId = startContainerExecutor.startContainers();
-    Properties containerProps = startContainerExecutor.queryContainerProperties(containerId);
+    String containerId = startContainerExecutor.startContainer();
     // Then
     assertEquals("container-name", containerId);
-    assertEquals("container-name", containerProps.getProperty("docker.container.alias.id"));
-    assertEquals("192.168.1.2", containerProps.getProperty("docker.container.alias.ip"));
+    assertEquals("container-name", projectProps.getProperty("docker.container.alias.id"));
+    assertEquals("192.168.1.2", projectProps.getProperty("docker.container.alias.ip"));
   }
 }

--- a/src/test/java/io/fabric8/maven/docker/service/helper/StartContainerExecutorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/helper/StartContainerExecutorTest.java
@@ -255,9 +255,7 @@ public class StartContainerExecutorTest {
     // Given
     new Expectations() {{
       dockerAccess.createContainer((ContainerCreateConfig) any, anyString);
-      result = "container-name";
-
-      dockerAccess.getContainer(anyString);
+      result = "container-name";dockerAccess.getContainer(anyString);
       result = new ContainerDetails(JsonFactory.newJsonObject("{\"NetworkSettings\":{\"IPAddress\":\"192.168.1.2\"}}"));
 
       QueryService queryService = new QueryService(dockerAccess);
@@ -286,12 +284,11 @@ public class StartContainerExecutorTest {
             .build();
 
     // When
-    ImmutablePair<String, Properties> result = startContainerExecutor.startContainers();
-
+    String containerId = startContainerExecutor.startContainers();
+    Properties containerProps = startContainerExecutor.queryContainerProperties(containerId);
     // Then
-    assertNotNull(result);
-    assertEquals("container-name", result.getKey());
-    assertEquals("container-name", result.getValue().getProperty("docker.container.alias.id"));
-    assertEquals("192.168.1.2", result.getValue().getProperty("docker.container.alias.ip"));
+    assertEquals("container-name", containerId);
+    assertEquals("container-name", containerProps.getProperty("docker.container.alias.id"));
+    assertEquals("192.168.1.2", containerProps.getProperty("docker.container.alias.ip"));
   }
 }


### PR DESCRIPTION
Fix #1242 

Adding a `log.info(project.getProperties().toString()` in `StartMojo` seems to validate that properties are now getting set after this change.
```
~/work/repos/dmp-demo-project : $ mvn docker:start
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------------< io.fabric8:dockerfile >------------------------
[INFO] Building dmp-sample-dockerfile 0.30-SNAPSHOT
[INFO] --------------------------------[ war ]---------------------------------
[INFO] 
[INFO] --- docker-maven-plugin:0.33-SNAPSHOT:start (default-cli) @ dockerfile ---
[INFO] DOCKER> [test-db:latest] "rohankumar": Start container 77677e638894
[INFO] DOCKER> [test-db:latest] "rohankumar": Pausing for 5000 ms
[INFO] DOCKER> {docker.host.address=localhost, base=jetty, host.port=32772, project.artifactId=dockerfile, file=welcome.txt, docker.container.rohankumar.id=77677e638894, maven.compiler.target=1.8, docker.container.rohankumar.net.bridge.ip=172.17.0.4, docker.container.rohankumar.ip=172.17.0.4, maven.compiler.source=1.8}
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.099 s
[INFO] Finished at: 2020-01-25T19:29:42+05:30
[INFO] ------------------------------------------------------------------------
~/work/repos/dmp-demo-project : $ 

```