### PR TITLE
Update RegistryService.java

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -98,7 +98,7 @@ public class RegistryService {
             imageName.getRegistry(),
             registryConfig.getRegistry());
         docker.pullImage(imageName.getFullName(),
-                         createAuthConfig(false, null, actualRegistry, registryConfig), actualRegistry);
+                         createAuthConfig(false, imageName.getUser(), actualRegistry, registryConfig), actualRegistry);
         log.info("Pulled %s in %s", imageName.getFullName(), EnvUtil.formatDurationTill(time));
         pullManager.pulled(image);
 


### PR DESCRIPTION
Fix #1337 take into account the imageName.getUser() when determining credentials for the pull