### PR TITLE
Update BouncyCastle, Snakeyaml and Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.57</version>
+      <version>1.65</version>
     </dependency>
 
     <dependency>
@@ -166,13 +166,13 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.18</version>
+      <version>1.26</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.0-android</version>
+      <version>29.0-android</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Signed-off-by: Colm O hEigeartaigh <coheigea@apache.org>

This fixes the following CVE reports:


bcprov-jdk15on-1.57.jar (pkg:maven/org.bouncycastle/bcprov-jdk15on@1.57, cpe:2.3:a:bouncycastle:legion-of-the-bouncy-castle-java-crytography-api:1.57:*:*:*:*:*:*:*) : CVE-2017-13098, CVE-2018-1000180, CVE-2018-1000613
guava-23.0-android.jar (pkg:maven/com.google.guava/guava@23.0-android, cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*) : CVE-2018-10237
snakeyaml-1.18.jar (pkg:maven/org.yaml/snakeyaml@1.18, cpe:2.3:a:snakeyaml_project:snakeyaml:1.18:*:*:*:*:*:*:*) : CVE-2017-18640
