### PR TITLE
bug fix for Volume binding bug in windows #1338

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -17,6 +17,7 @@
   - New `copy` goal for copying files and directories from containers to host ([752](https://github.com/fabric8io/docker-maven-plugin/issues/752) and [1405](https://github.com/fabric8io/docker-maven-plugin/pull/1405))
   - Add support for multiple copy layers using multiple assemblies ([554](https://github.com/fabric8io/docker-maven-plugin/issues/554))
   - Prefer HOME environment variable over the Java system property to determine the user's home directory to better resemble the golang client's behavior ([#1236](https://github.com/fabric8io/docker-maven-plugin/pull/1263)
+  - Volume binding bug in windows ([1338](https://github.com/fabric8io/docker-maven-plugin/issues/1338))
   
 * **0.34.1** (2020-09-27)
   - Fix NPE with "skipPush" and no build configuration given ([#1381](https://github.com/fabric8io/docker-maven-plugin/issues/1381))

--- a/src/test/java/io/fabric8/maven/docker/util/VolumeBindingUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/VolumeBindingUtilTest.java
@@ -1,6 +1,7 @@
 package io.fabric8.maven.docker.util;
 
 import io.fabric8.maven.docker.config.RunVolumeConfiguration;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -301,5 +302,21 @@ public class VolumeBindingUtilTest {
         assertFalse(isRelativePath("x:\\bar"));                            // x:\bar
         assertFalse(isRelativePath("C:\\"));                               // C:\
         assertFalse(isRelativePath("\\"));                                 // \
+    }
+
+    /**
+     * Insures that a host volume binding string that contains a windows path with .. is correctly canonicalized
+     */
+    @Test
+
+    public void testResolveAbsoluteWindowsVolumePath() {
+        Assume.assumeTrue(System.getProperty("os.name").toLowerCase().startsWith("win"));
+        String volumeString = format(BIND_STRING_FMT, "C:\\dir/subdir/../", CONTAINER_PATH);
+
+        String relativizedVolumeString = resolveRelativeVolumeBinding(ABS_BASEDIR, volumeString);
+
+        String expectedBindingString = format(BIND_STRING_FMT,
+                "C:\\dir", CONTAINER_PATH);
+        assertEquals(expectedBindingString, relativizedVolumeString);
     }
 }


### PR DESCRIPTION
Hi this is a pull request for issue #1338 
I fixed only the specific issue I was having because when I tried to make the code more generic some tests were failing. The current code considers the initial rel of 'rel:/path/to/container/dir' as an absolute path which is not, when I tried to align the code considering rel as a relative some tests were failing and I do not have enough knowledge about this project in order to make a wider fix.

Fix #1338 