### PR TITLE
Handle authentication tokens returned from credential helpers.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,7 +1,9 @@
 # ChangeLog
 
-* **0.33.0** (2020-01-21)
+* **0.33-SNAPSHOT**
   - Handle authentication tokens returned from credential helpers ([#1348](https://github.com/fabric8io/docker-maven-plugin/issues/1348))
+
+* **0.33.0** (2020-01-21)
   - Update to jnr-unixsocket 0.25 to solve concurrency issues ([#552](https://github.com/fabric8io/docker-maven-plugin/issues/552))
   - Udate ECR AuthorizationToken URL to new endpoint ([#1317](https://github.com/fabric8io/docker-maven-plugin/issues/1317))
   - Allow including `com.amazonaws:aws-java-sdk-core` as plugin dependency to pick up various forms of AWS credentials with which to authenticate at AWS ECR ([#1311](https://github.com/fabric8io/docker-maven-plugin/issues/1311))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.33.0** (2020-01-21)
+  - Handle authentication tokens returned from credential helpers ([#1348](https://github.com/fabric8io/docker-maven-plugin/issues/1348))
   - Update to jnr-unixsocket 0.25 to solve concurrency issues ([#552](https://github.com/fabric8io/docker-maven-plugin/issues/552))
   - Udate ECR AuthorizationToken URL to new endpoint ([#1317](https://github.com/fabric8io/docker-maven-plugin/issues/1317))
   - Allow including `com.amazonaws:aws-java-sdk-core` as plugin dependency to pick up various forms of AWS credentials with which to authenticate at AWS ECR ([#1311](https://github.com/fabric8io/docker-maven-plugin/issues/1311))

--- a/src/main/java/io/fabric8/maven/docker/util/CredentialHelperClient.java
+++ b/src/main/java/io/fabric8/maven/docker/util/CredentialHelperClient.java
@@ -16,6 +16,8 @@ public class CredentialHelperClient {
 
     static final String SECRET_KEY = "Secret";
     static final String USERNAME_KEY = "Username";
+    static final String TOKEN_USERNAME = "<token>";
+
     private final String credentialHelperName;
     private final Logger log;
 
@@ -54,6 +56,11 @@ public class CredentialHelperClient {
         }
         String password = credential.get(CredentialHelperClient.SECRET_KEY).getAsString();
         String userKey = credential.get(CredentialHelperClient.USERNAME_KEY).getAsString();
+        if(TOKEN_USERNAME.equals(userKey)) {
+            // If userKey is <token>, the password is actually a token
+            return new AuthConfig(null, null, null, null, password);
+        }
+
         return new AuthConfig(userKey,password, null,null);
     }
 

--- a/src/main/java/io/fabric8/maven/docker/util/CredentialHelperClient.java
+++ b/src/main/java/io/fabric8/maven/docker/util/CredentialHelperClient.java
@@ -50,7 +50,7 @@ public class CredentialHelperClient {
         }
     }
 
-    private AuthConfig toAuthConfig(JsonObject credential){
+    AuthConfig toAuthConfig(JsonObject credential){
         if (credential == null) {
             return null;
         }

--- a/src/test/java/io/fabric8/maven/docker/util/CredentialHelperClientTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/CredentialHelperClientTest.java
@@ -1,0 +1,60 @@
+package io.fabric8.maven.docker.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.fabric8.maven.docker.access.AuthConfig;
+import mockit.Mocked;
+import mockit.Tested;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class CredentialHelperClientTest {
+    private final Gson gson = new Gson();
+
+    @Mocked
+    private Logger logger;
+
+    private CredentialHelperClient credentialHelperClient;
+
+    private JsonObject jsonObject;
+
+    private AuthConfig authConfig;
+
+    @Before
+    public void givenCredentialHelperClient() {
+        this.credentialHelperClient = new CredentialHelperClient(logger, "desktop");
+    }
+
+    @Test
+    public void testUsernamePasswordAuthConfig() {
+        givenJson("{\"ServerURL\":\"registry.mycompany.com\",\"Username\":\"jane_doe\",\"Secret\":\"not-really\"}");
+
+        whenJsonObjectConvertedToAuthConfig();
+        
+        assertEquals("username should match", "jane_doe", this.authConfig.getUsername());
+        assertEquals("password should match", "not-really", this.authConfig.getPassword());
+        assertNull("identityToken should not be set", this.authConfig.getIdentityToken());
+    }
+
+    @Test
+    public void testTokenAuthConfig() {
+        givenJson("{\"ServerURL\":\"registry.cloud-provider.com\",\"Username\":\"<token>\",\"Secret\":\"gigantic-mess-of-jwt\"}");
+
+        whenJsonObjectConvertedToAuthConfig();
+
+        assertNull("username should not be set", this.authConfig.getUsername());
+        assertNull("password should not be set", this.authConfig.getPassword());
+        assertEquals("identity token should match", "gigantic-mess-of-jwt", this.authConfig.getIdentityToken());
+    }
+
+    private void givenJson(String json) {
+        this.jsonObject = this.gson.fromJson(json, JsonObject.class);
+    }
+
+    private void whenJsonObjectConvertedToAuthConfig() {
+        this.authConfig = this.credentialHelperClient.toAuthConfig(this.jsonObject);
+    }
+}


### PR DESCRIPTION
This PR fixes #1348 by checking for the special username ```<token>``` that the docker login command uses to indicate the password is actually an authentication token.