### PR TITLE
Fix #1384: Building spring-boot-with-jib fails with NoSuchMethodEror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           mvn clean install -DskipTests
           PROJECT_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
           cd it/
-          find . -type f -exec sed -i 's/0.29-SNAPSHOT/'"$PROJECT_VERSION"'/g' {} +
+          find . -type f -exec sed -i 's/0.34-SNAPSHOT/'"$PROJECT_VERSION"'/g' {} +
           mvn clean install
     - save_cache:
         key: dmp-{{ checksum "pom.xml" }}

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+* 0.34-SNAPSHOT
+  - Building 'spring-boot-with-jib' sample fails with NoSuchMethodError ([1384](https://github.com/fabric8io/docker-maven-plugin/issues/1384))
+  - Loading Image tarball into docker daemon fails in JIB mode ([1385](https://github.com/fabric8io/docker-maven-plugin/issues/1385))
+
 * **0.34.1** (2020-09-27)
   - Fix NPE with "skipPush" and no build configuration given ([#1381](https://github.com/fabric8io/docker-maven-plugin/issues/1381))
   - upgrade to jib-core 0.15.0 ([#1378](https://github.com/fabric8io/docker-maven-plugin/issues/1378))

--- a/it/docker-compose/pom.xml
+++ b/it/docker-compose/pom.xml
@@ -20,14 +20,14 @@
   -->
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>dmp-sample-docker-compose</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-docker-compose</artifactId>
+  <version>0.34-SNAPSHOT</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/it/dockerfile/pom.xml
+++ b/it/dockerfile/pom.xml
@@ -10,16 +10,16 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dockerfile</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <version>0.34-SNAPSHOT</version>
   <packaging>war</packaging>
-  <name>dmp-sample-dockerfile</name>
+  <name>dmp-it-dockerfile</name>
 
   <properties>
     <file>welcome.txt</file>
@@ -77,7 +77,7 @@
         <configuration>
           <images>
             <image>
-              <name>fabric8:dmp-sample-dockerfile</name>
+              <name>fabric8:dmp-it-dockerfile</name>
               <alias>dockerfile</alias>
               <build>
                 <!-- filter>@</filter-->

--- a/it/dockerfile/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
+++ b/it/dockerfile/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
@@ -1,4 +1,4 @@
-package io.fabric8.dmp.samples.dockerfile;
+package io.fabric8.dmp.itests.dockerfile;
 
 import java.io.File;
 import java.io.IOException;

--- a/it/dockerfile/src/main/webapp/WEB-INF/web.xml
+++ b/it/dockerfile/src/main/webapp/WEB-INF/web.xml
@@ -6,7 +6,7 @@ xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns
   <servlet>
     <display-name>HelloWold</display-name>
     <servlet-name>hello-world</servlet-name>
-    <servlet-class>io.fabric8.dmp.samples.dockerfile.HelloWorldServlet</servlet-class>
+    <servlet-class>io.fabric8.dmp.itests.dockerfile.HelloWorldServlet</servlet-class>
   </servlet>
 
   <servlet-mapping>

--- a/it/dockerignore/pom.xml
+++ b/it/dockerignore/pom.xml
@@ -8,14 +8,14 @@
   -->
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>dmp-sample-dockerignore</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-dockerignore</artifactId>
+  <version>0.34-SNAPSHOT</version>
   <packaging>docker-build</packaging>
 
   <build>
@@ -44,7 +44,7 @@
           <images>
             <image>
               <alias>simple</alias>
-              <name>dmp-sample/dockerignore</name>
+              <name>dmp-it/dockerignore</name>
               <build>
                 <dockerFileDir>${project.basedir}</dockerFileDir>
                 <compression>gzip</compression>

--- a/it/healthcheck/pom.xml
+++ b/it/healthcheck/pom.xml
@@ -10,14 +10,14 @@
   -->
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>dmp-sample-healthcheck</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-healthcheck</artifactId>
+  <version>0.34-SNAPSHOT</version>
 
 
   <build>

--- a/it/helloworld/pom.xml
+++ b/it/helloworld/pom.xml
@@ -10,17 +10,17 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
 
-  <artifactId>dmp-sample-helloworld</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-helloworld</artifactId>
+  <version>0.34-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>dmp-sample-helloworld</name>
+  <name>dmp-it-helloworld</name>
 
   <dependencies>
     <dependency>

--- a/it/log/pom.xml
+++ b/it/log/pom.xml
@@ -11,16 +11,16 @@
   -->
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
 
   <groupId>io.fabric8</groupId>
-  <artifactId>dmp-sample-log</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-log</artifactId>
+  <version>0.34-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/net/pom.xml
+++ b/it/net/pom.xml
@@ -14,14 +14,14 @@
   -->
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>dmp-sample-net</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-net</artifactId>
+  <version>0.34-SNAPSHOT</version>
 
   <profiles>
     <profile>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -19,9 +19,9 @@
 
   -->
 
-  <groupId>io.fabric8.dmp.samples</groupId>
-  <artifactId>dmp-sample-parent</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <groupId>io.fabric8.dmp.itests</groupId>
+  <artifactId>dmp-it-parent</artifactId>
+  <version>0.34-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <url>http://www.jolokia.org</url>
@@ -58,5 +58,6 @@
     <module>dockerfile</module>
     <module>log</module>
     <module>run-java</module>
+    <module>spring-boot-with-jib</module>
   </modules>
 </project>

--- a/it/properties/pom.xml
+++ b/it/properties/pom.xml
@@ -8,14 +8,14 @@
   -->
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>dmp-sample-properties</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-properties</artifactId>
+  <version>0.34-SNAPSHOT</version>
   <packaging>docker-build</packaging>
 
   <build>
@@ -23,6 +23,7 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
+        <version>${project.version}</version>
         <executions>
           <execution>
             <id>start</id>

--- a/it/run-java/pom.xml
+++ b/it/run-java/pom.xml
@@ -5,16 +5,16 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>io.fabric8.dmp.samples</groupId>
-  <artifactId>dmp-sample-run-java</artifactId>
+  <groupId>io.fabric8.dmp.itests</groupId>
+  <artifactId>dmp-it-run-java</artifactId>
   <packaging>jar</packaging>
-  <version>0.29-SNAPSHOT</version>
+  <version>0.34-SNAPSHOT</version>
 
   <build>
 

--- a/it/smallest/pom.xml
+++ b/it/smallest/pom.xml
@@ -2,15 +2,15 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>fabric8io</groupId>
-  <artifactId>dmp-sample-smallest</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-smallest</artifactId>
+  <version>0.34-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/spring-boot-with-jib/pom.xml
+++ b/it/spring-boot-with-jib/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.fabric8.dmp.itests</groupId>
+        <artifactId>dmp-it-parent</artifactId>
+        <version>0.34-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>dmp-it-spring-boot-jib</artifactId>
+    <version>0.34-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <description>Docker Maven Plugin Integration test with Spring Boot With Build Mode JIB</description>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <docker.build.jib>true</docker.build.jib>
+        <docker.user>fabric8</docker.user>
+        <spring.version>2.3.3.RELEASE</spring.version>
+    </properties>
+
+    <dependencies>
+
+        <!-- Boot generator  -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+        <!-- API, java.xml.bind module -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+
+        <!-- Runtime, com.sun.xml.bind module -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+              <groupId>io.fabric8</groupId>
+              <artifactId>docker-maven-plugin</artifactId>
+              <version>${project.version}</version>
+              <configuration>
+                <jib>true</jib>
+                <images>
+                  <image>
+                    <name>${docker.user}/spring-boot-dmp-it-jib</name>
+                    <build>
+                      <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+                      <assembly>
+                        <descriptorRef>artifact</descriptorRef>
+                      </assembly>
+                      <cmd>java -jar /maven/${project.artifactId}-${project.version}.jar</cmd>
+                      <ports>
+                        <port>8080</port>
+                      </ports>
+                    </build>
+                  </image>
+                </images>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>build</id>
+                  <phase>install</phase>
+                  <goals>
+                    <goal>build</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-antrun-plugin</artifactId>
+              <version>1.8</version>
+              <executions>
+                <execution>
+                  <id>generateSources</id>
+                  <phase>install</phase>
+                  <configuration>
+                    <tasks>
+                      <exec executable="/usr/bin/docker" failonerror="true">
+                          <arg value="load" />
+                          <arg value="-i" />
+                          <arg value="./target/docker/fabric8/spring-boot-dmp-it-jib/tmp/docker-build.tar" />
+                      </exec>
+                    </tasks>
+                  </configuration>
+                  <goals>
+                    <goal>run</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/it/spring-boot-with-jib/src/main/java/io/fabric8/maven/sample/springboot/jib/Application.java
+++ b/it/spring-boot-with-jib/src/main/java/io/fabric8/maven/sample/springboot/jib/Application.java
@@ -1,0 +1,13 @@
+package io.fabric8.maven.sample.springboot.jib;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/it/spring-boot-with-jib/src/main/java/io/fabric8/maven/sample/springboot/jib/HelloController.java
+++ b/it/spring-boot-with-jib/src/main/java/io/fabric8/maven/sample/springboot/jib/HelloController.java
@@ -1,0 +1,15 @@
+package io.fabric8.maven.sample.springboot.jib;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+public class HelloController {
+
+    @RequestMapping("/")
+    public String index() {
+        return "<h1>Greetings from Spring Boot(Powered by JIB)!!</h1>";
+    }
+
+}

--- a/it/volume/pom.xml
+++ b/it/volume/pom.xml
@@ -13,14 +13,14 @@
   -->
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>dmp-sample-volume</artifactId>
-  <version>0.29-SNAPSHOT</version>
+  <artifactId>dmp-it-volume</artifactId>
+  <version>0.34-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/zero-config/Dockerfile
+++ b/it/zero-config/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:jre
 
 #RUN VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-ARG jar_file=target/zero-config-${project.version}.jar
+ARG jar_file=target/dmp-it-zero-config-${project.version}.jar
 
 ADD $jar_file /tmp/zero-config.jar
 CMD java -cp /tmp/zero-config.jar HelloWorld

--- a/it/zero-config/pom.xml
+++ b/it/zero-config/pom.xml
@@ -5,17 +5,17 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.fabric8.dmp.samples</groupId>
-    <artifactId>dmp-sample-parent</artifactId>
-    <version>0.29-SNAPSHOT</version>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.34-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
 
-  <groupId>io.fabric8.dmp.samples</groupId>
-  <artifactId>zero-config</artifactId>
+  <groupId>io.fabric8.dmp.itests</groupId>
+  <artifactId>dmp-it-zero-config</artifactId>
   <packaging>jar</packaging>
-  <version>0.29-SNAPSHOT</version>
+  <version>0.34-SNAPSHOT</version>
 
   <properties>
     <jar_file>${project.build.directory}/${project.build.finalName}.jar</jar_file>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <jmockit.version>1.43</jmockit.version>
     <surefire.version>3.0.0-M2</surefire.version>
     <jib-core.version>0.15.0</jib-core.version>
+    <httpclient.version>4.5.10</httpclient.version>
   </properties>
 
   <dependencies>
@@ -102,7 +103,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.5</version>
+      <version>${httpclient.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -109,6 +109,10 @@ By default a progress meter is printed out on the console, which is omitted when
 | Delegate Image Build process to https://github.com/GoogleContainerTools/jib[JIB], `false` by default. Note that this option is applicable only for <<docker:build,build>> and <<docker:push,push>> goals, other goals won't work if this is enabled (since they dependend on Docker specific features)
 | `docker.build.jib`
 
+| *jibImageFormat*
+| Format of the image to be built. Values can be `oci` and `docker` with `docker` as default value
+| `docker.build.jib.imageFormat`
+
 | *outputDirectory*
 | Default output directory to be used by this plugin. The default value is `target/docker` and is only used for the goal `{plugin}:build`.
 | `docker.target.dir`

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -171,6 +171,9 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     @Parameter(property = "docker.build.jib", defaultValue = "false")
     public boolean jib;
 
+    @Parameter(property = "docker.build.jib.imageFormat", defaultValue = "docker")
+    public String jibImageFormat;
+
     @Parameter(property = "docker.source.dir", defaultValue="src/main/docker")
     public String sourceDirectory;
 

--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -89,7 +89,7 @@ public class BuildMojo extends AbstractBuildSupportMojo {
 
     private void proceedWithJibBuild(ServiceHub hub, BuildService.BuildContext buildContext, ImageConfiguration imageConfig) throws MojoExecutionException {
         log.info("Building Container image with [[B]]JIB(Java Image Builder)[[B]] mode");
-        new JibBuildService(hub, createMojoParameters(), log).build(imageConfig, buildContext.getRegistryConfig());
+        new JibBuildService(hub, createMojoParameters(), log).build(jibImageFormat, imageConfig, buildContext.getRegistryConfig());
     }
 
     private void proceedWithDockerBuild(BuildService buildService, BuildService.BuildContext buildContext, ImageConfiguration imageConfig, ImagePullManager pullManager) throws MojoExecutionException, IOException {

--- a/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
@@ -17,7 +17,6 @@ import io.fabric8.maven.docker.util.MojoParameters;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -45,7 +44,7 @@ public class JibBuildService {
         this.log = log;
     }
 
-    public void build(ImageConfiguration imageConfig, RegistryService.RegistryConfig registryConfig) throws MojoExecutionException {
+    public void build(String jibImageFormat, ImageConfiguration imageConfig, RegistryService.RegistryConfig registryConfig) throws MojoExecutionException {
         try {
             log.info("[[B]]JIB[[B]] image build started");
             if (imageConfig.getBuildConfiguration().isDockerFileMode()) {
@@ -55,7 +54,7 @@ public class JibBuildService {
             BuildDirs buildDirs = new BuildDirs(imageConfig.getName(), mojoParameters);
             final Credential pullRegistryCredential = getRegistryCredentials(
                     registryConfig, false, imageConfig, log);
-            final JibContainerBuilder containerBuilder = containerFromImageConfiguration(imageConfig, pullRegistryCredential);
+            final JibContainerBuilder containerBuilder = containerFromImageConfiguration(jibImageFormat, imageConfig, pullRegistryCredential);
 
             File dockerTarArchive = getAssemblyTarArchive(imageConfig, serviceHub, mojoParameters, log);
 

--- a/src/main/java/io/fabric8/maven/docker/util/JibServiceUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/JibServiceUtil.java
@@ -20,6 +20,7 @@ import io.fabric8.maven.docker.assembly.AssemblyFiles;
 import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.model.Image;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
@@ -97,10 +98,10 @@ public class JibServiceUtil {
         }
     }
 
-    public static JibContainerBuilder containerFromImageConfiguration(
+    public static JibContainerBuilder containerFromImageConfiguration(String jibImageFormat,
             ImageConfiguration imageConfiguration, Credential pullRegistryCredential) throws InvalidImageReferenceException {
         final JibContainerBuilder containerBuilder = Jib.from(getRegistryImage(getBaseImage(imageConfiguration), pullRegistryCredential))
-                .setFormat(ImageFormat.OCI);
+                .setFormat(getImageFormat(jibImageFormat));
         return populateContainerBuilderFromImageConfiguration(containerBuilder, imageConfiguration);
     }
 
@@ -200,6 +201,13 @@ public class JibServiceUtil {
             tagSet.add(tempImage.getTag());
         }
         return tagSet;
+    }
+
+    static ImageFormat getImageFormat(String jibImageFormat) {
+        if (jibImageFormat != null && jibImageFormat.toLowerCase().equalsIgnoreCase("oci")) {
+                return ImageFormat.OCI;
+        }
+        return ImageFormat.Docker;
     }
 
     private static void submitPushToJib(TarImage baseImage, RegistryImage targetImage, ExecutorService jibBuildExecutor, Logger logger) throws InterruptedException, ExecutionException, RegistryException, CacheDirectoryCreationException, IOException {

--- a/src/test/java/io/fabric8/maven/docker/util/JibServiceUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/JibServiceUtilTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import static io.fabric8.maven.docker.util.JibServiceUtil.BUSYBOX;
 import static io.fabric8.maven.docker.util.JibServiceUtil.containerFromImageConfiguration;
+import static io.fabric8.maven.docker.util.JibServiceUtil.getImageFormat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -52,7 +53,7 @@ public class JibServiceUtilTest {
         // Given
         ImageConfiguration imageConfiguration = getSampleImageConfiguration();
         // When
-        JibContainerBuilder jibContainerBuilder = containerFromImageConfiguration(imageConfiguration, null);
+        JibContainerBuilder jibContainerBuilder = containerFromImageConfiguration(ImageFormat.Docker.name(), imageConfiguration, null);
         // Then
         // @formatter:off
         new Verifications() {{
@@ -68,7 +69,7 @@ public class JibServiceUtilTest {
             times = 1;
             jibContainerBuilder.setVolumes(new HashSet<>(Collections.singletonList(AbsoluteUnixPath.get("/mnt/volume1"))));
             times = 1;
-            jibContainerBuilder.setFormat(ImageFormat.OCI);
+            jibContainerBuilder.setFormat(ImageFormat.Docker);
             times = 1;
         }};
         // @formatter:on
@@ -120,6 +121,13 @@ public class JibServiceUtilTest {
     @Test
     public void testGetFullImageNameWithProvidedTag() {
         assertEquals("test/test-project:0.0.1", JibServiceUtil.getFullImageName(getSampleImageConfiguration(), "0.0.1"));
+    }
+
+    @Test
+    public void testGetImageFormat() {
+        assertEquals(ImageFormat.Docker, JibServiceUtil.getImageFormat("Docker"));
+        assertEquals(ImageFormat.OCI, JibServiceUtil.getImageFormat("OCI"));
+        assertEquals(ImageFormat.OCI, JibServiceUtil.getImageFormat("oci"));
     }
 
     private ImageConfiguration getSampleImageConfiguration() {


### PR DESCRIPTION
Fix #1384 

+ Updating jib-core to 0.15.0 broke our current JIB support due to
  incompatibility with httpclient. Updated apache httpclient to 4.5.10
+ Somehow behavior of Jib setting ImageFormat has been changed(maybe it was
  not working earlier. Introduced a new parameter in mojo `docker.build.jib.imageFormat`
  to allow users specify image format(OCI or Docker) with Docker as
  default ImageFormat.
+ Minor Cleanup in Integration tests; Added an integration test for JIB mode
  which builds image tarball and verifies it by loading into docker daemon

This should also fix #1385