### PR TITLE
Add a skipPom parameter, skipping a project if packaging is pom

### DIFF
--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -137,6 +137,9 @@ By default a progress meter is printed out on the console, which is omitted when
 | If set dont push any images even when `{plugin}:push` is called.
 | `docker.skip.push`
 
+| *skipPom*
+| If set to `true` this plugin will skip every projects, where `project.packaging` is set to `pom`. Property: `docker.skip.pom`
+
 | *skipRun*
 | If set dont create and start any containers with `{plugin}:start` or `{plugin}:run`
 | `docker.skip.run`

--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -39,8 +39,14 @@ public class BuildMojo extends AbstractBuildSupportMojo {
     @Parameter(property = "docker.skip.build", defaultValue = "false")
     protected boolean skipBuild;
 
+    @Parameter(property = "docker.skip.pom", defaultValue = "false")
+    protected boolean skipPom;
+
     @Parameter(property = "docker.name", defaultValue = "")
     protected String name;
+
+    @Parameter(defaultValue = "${project.packaging}", required = true)
+    protected String packaging;
 
     /**
      * Skip Sending created tarball to docker daemon
@@ -145,7 +151,7 @@ public class BuildMojo extends AbstractBuildSupportMojo {
         BuildImageConfiguration buildConfig = aImageConfig.getBuildConfiguration();
 
         if (buildConfig != null) {
-            if(buildConfig.skip()) {
+            if(buildConfig.skip() || (skipPom && packaging.equalsIgnoreCase("pom"))) {
                 log.info("%s : Skipped building", aImageConfig.getDescription());
             } else {
                 buildAndTag(hub, aImageConfig);

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -1,0 +1,74 @@
+package io.fabric8.maven.docker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+import io.fabric8.maven.docker.access.BuildOptions;
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.service.BuildService;
+import io.fabric8.maven.docker.service.ImagePullManager;
+import mockit.Deencapsulation;
+import mockit.Mocked;
+import mockit.Tested;
+import mockit.Verifications;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+
+public class BuildMojoTest extends BaseMojoTest {
+    @Tested(fullyInitialized = false)
+    private BuildMojo buildMojo;
+
+    @Mocked
+    private BuildService buildService;
+
+    @Test
+    public void skipWhenPom() throws IOException, MojoExecutionException {
+        Deencapsulation.setField(serviceHub, "buildService", buildService);
+        givenMavenProject(buildMojo);
+        givenPackaging("pom");
+        givenSkipPom(true);
+
+        whenMojoExecutes();
+
+        thenBuildNotRun();
+    }
+
+    @Test
+    public void noSkipWhenNotPom() throws IOException, MojoExecutionException {
+        Deencapsulation.setField(serviceHub, "buildService", buildService);
+        givenMavenProject(buildMojo);
+        givenResolvedImages(buildMojo, Collections.singletonList(singleImageWithBuild()));
+        givenPackaging("jar");
+        givenSkipPom(true);
+
+        whenMojoExecutes();
+
+        thenBuildRun();
+    }
+
+    private void thenBuildRun() throws DockerAccessException, MojoExecutionException {
+        new Verifications() {{
+            buildService.buildImage((ImageConfiguration)any, (ImagePullManager) any, (BuildService.BuildContext)any, (File)any); times = 1;
+        }};
+    }
+
+    private void thenBuildNotRun() throws DockerAccessException, MojoExecutionException {
+        new Verifications() {{
+            buildService.buildImage((ImageConfiguration)any, (ImagePullManager) any, (BuildService.BuildContext)any, (File)any); times = 0;
+        }};
+    }
+
+    private void givenPackaging(String packaging) {
+        Deencapsulation.setField(buildMojo, "packaging", packaging);
+    }
+
+    private void givenSkipPom(boolean skipPom) {
+        Deencapsulation.setField(buildMojo, "skipPom", skipPom);
+    }
+
+    private void whenMojoExecutes() throws IOException, MojoExecutionException {
+        buildMojo.executeInternal(serviceHub);
+    }
+}


### PR DESCRIPTION
The usecase for this feature:

There are multiple projects which use the same docker-maven-plugin configuration. A logical way to extract that config to one place is to use the `pluginManagement` tag.

However, this leaves the need to define the plugin in every project wanting to use that configuration.

A ready solution is to define the plugin in the parent pom, but than the build will fail, because the docker build goal cannot find the packaged jar archive.

Here comes this PR, which tells the docker build goal to skip if the currently built project is a pom.