### PR TITLE
Correct `memorySwap` documentation

### DIFF
--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -206,10 +206,10 @@ when a `docker.from` or a `docker.fromExt` is set.
 | defines the maintainer's email as used when building an image
 
 | *docker.memory*
-| Container memory (in bytes)
+| Memory limit in bytes.
 
 | *docker.memorySwap*
-| Total memory (swap + memory) `-1` to disable swap
+| Total memory limit (memory + swap) in bytes. Set `docker.memorySwap` equal to `docker.memory` to disable swap. Set to `-1` to allow unlimited swap.
 
 | *docker.name*
 | Image name

--- a/src/main/asciidoc/inc/start/_configuration.adoc
+++ b/src/main/asciidoc/inc/start/_configuration.adoc
@@ -81,10 +81,10 @@ The `<run>` configuration element knows the following sub elements:
 | Log configuration for whether and how log messages from the running containers should be printed. This also can configure the https://docs.docker.com/engine/admin/logging/overview[log driver] to use. See <<start-logging,Logging>> for a detailed description.
 
 | *memory*
-| Memory limit in bytes
+| Memory limit in bytes.
 
 | *memorySwap*
-| Total memory usage (memory + swap); use -1 to disable swap.
+| Total memory limit (memory + swap) in bytes. Set `memorySwap` equal to `memory` to disable swap. Set to `-1` to allow unlimited swap.
 
 | *namingStrategy*
 a| *This option is deprecated, please use a `containerNamePattern` instead* Naming strategy for how the container name is created:

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -71,7 +71,7 @@ public class RunImageConfiguration implements Serializable {
     @Parameter
     private Long memory;
 
-    // total memory (swap + ram) in bytes, -1 to disable
+    // total memory (swap + ram) in bytes; set equal to memory to disable; set to -1 to allow unlimited swap
     @Parameter
     private Long memorySwap;
 


### PR DESCRIPTION
The documentation incorrectly stated that setting `memorySwap` to `-1` disables swap memory. This PR corrects that by describing how to disable swap (set `memorySwap` equal to `memory`) and that setting `memorySwap` to `-1` allows the container to use _unlimited_ swap.

See also https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details

Closes #1424 
