### PR TITLE
Fix #1082 where `assembly.inline` is removed when external properties are enabled

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,8 @@
 * 0.34-SNAPSHOT
   - Building 'spring-boot-with-jib' sample fails with NoSuchMethodError ([1384](https://github.com/fabric8io/docker-maven-plugin/issues/1384))
   - Loading Image tarball into docker daemon fails in JIB mode ([1385](https://github.com/fabric8io/docker-maven-plugin/issues/1385))
+  - `assembly.inline` is removed when external properties are enabled ([1082](https://github.com/fabric8io/docker-maven-plugin/issues/1082))
+  - Fix Support for Podman REST API(when configured) Related to ([1330](https://github.com/fabric8io/docker-maven-plugin/issues/1330))
 
 * **0.34.1** (2020-09-27)
   - Fix NPE with "skipPush" and no build configuration given ([#1381](https://github.com/fabric8io/docker-maven-plugin/issues/1381))

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -247,6 +247,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .user(valueProvider.getString(ASSEMBLY_USER, config == null ? null : config.getUser()))
                 .mode(valueProvider.getString(ASSEMBLY_MODE, config == null ? null : config.getModeRaw()))
                 .tarLongFileMode(valueProvider.getString(ASSEMBLY_TARLONGFILEMODE, config == null ? null : config.getTarLongFileMode()))
+                .assemblyDef(config == null ? null : config.getInline())
                 .build();
     }
 

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -40,6 +40,8 @@ import io.fabric8.maven.docker.config.WaitConfiguration;
 import io.fabric8.maven.docker.config.handler.AbstractConfigHandlerTest;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.maven.plugins.assembly.model.Assembly;
+import org.apache.maven.plugins.assembly.model.DependencySet;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
@@ -671,6 +673,28 @@ public class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         assertEquals("project", config.getDescriptorRef());
         assertFalse(config.exportTargetDir());
         assertTrue(config.isIgnorePermissions());
+    }
+
+    @Test
+    public void testAssemblyInline() throws Exception {
+        Assembly assembly = new Assembly();
+        assembly.addDependencySet(new DependencySet());
+
+        imageConfiguration = new ImageConfiguration.Builder()
+                        .registry("docker.io")
+                        .name("test")
+                        .buildConfig(new BuildImageConfiguration.Builder()
+                                .assembly(new AssemblyConfiguration.Builder().assemblyDef(assembly).build())
+                                .build())
+                        .externalConfig(externalConfigMode(PropertyMode.Only))
+                        .build();
+
+        List<ImageConfiguration> configs = resolveImage(imageConfiguration, props(getTestAssemblyData()));
+        assertEquals(1, configs.size());
+
+        AssemblyConfiguration config = configs.get(0).getBuildConfiguration().getAssemblyConfiguration();
+        assertNotNull(config.getInline());
+        assertEquals(1, config.getInline().getDependencySets().size());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1082 and fixes #1356 

This is based on the solution provided in #1082. I also added a test to show that the solution fixes the issue.