### PR TITLE
Avoid race condition when creating port bindings

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@
   - Add a skipPom parameter, skipping a project if packaging is pom ([1388](https://github.com/fabric8io/docker-maven-plugin/pull/1388))
   - Add support for config to specify isolation technology for container ([1376](https://github.com/fabric8io/docker-maven-plugin/pull/1376))
   - Add Docker build cache friendly example utilizing Spring Boot Layered JAR and Maven Assembly Plugin ([1412](https://github.com/fabric8io/docker-maven-plugin/pull/1412))
+  - Retry port mapping to avoid race condition where complete port information may not be initially available in Docker Engine 20.10.5 ([1447](https://github.com/fabric8io/docker-maven-plugin/pull/1447))
   
 * **0.34.1** (2020-09-27)
   - Fix NPE with "skipPush" and no build configuration given ([#1381](https://github.com/fabric8io/docker-maven-plugin/issues/1381))

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,12 @@
       <artifactId>plexus-interpolation</artifactId>
       <version>1.24</version>
     </dependency>
+    
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>failsafe</artifactId>
+      <version>2.4.0</version>
+    </dependency>
 
 
     <!-- =============================================================================== -->

--- a/src/main/java/io/fabric8/maven/docker/model/ContainerDetails.java
+++ b/src/main/java/io/fabric8/maven/docker/model/ContainerDetails.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 
@@ -196,8 +198,12 @@ public class ContainerDetails implements Container {
             if (ports.get(port).isJsonNull()) {
                 addPortMapping(port, (PortBinding) null, portBindings);
             } else {
+                JsonArray hostMappings = ports.getAsJsonArray(port);
+                if (hostMappings.isJsonNull() || hostMappings.size() == 0) {
+                    throw new PortBindingException(port, ports);
+                }
                 // use the first entry in the array
-                JsonObject hostConfig = ports.getAsJsonArray(port).get(0).getAsJsonObject();
+                JsonObject hostConfig = hostMappings.get(0).getAsJsonObject();
                 addPortMapping(port, hostConfig, portBindings);
             }
         }

--- a/src/main/java/io/fabric8/maven/docker/model/PortBindingException.java
+++ b/src/main/java/io/fabric8/maven/docker/model/PortBindingException.java
@@ -1,0 +1,9 @@
+package io.fabric8.maven.docker.model;
+
+import com.google.gson.JsonObject;
+
+public class PortBindingException extends RuntimeException {
+    public PortBindingException(String port, JsonObject portDetails) {
+        super(String.format("Failed to create binding for port '%s'. Container ports: %s", port, portDetails));
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -21,6 +21,7 @@ import static io.fabric8.maven.docker.util.VolumeBindingUtil.resolveRelativeVolu
 
 import java.io.File;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -469,8 +470,8 @@ public class RunService {
 
     private void updateMappedPortsAndAddresses(String containerId, PortMapping mappedPorts) throws DockerAccessException {
         RetryPolicy<Void> retryPolicy = new RetryPolicy<Void>()
-                .withMaxAttempts(10)
-                .withDelay(Duration.ofMillis(250))
+                .withMaxAttempts(20)
+                .withBackoff(10, 100, ChronoUnit.MILLIS)
                 .handle(PortBindingException.class)
                 .onFailedAttempt(f -> log.debug("Failed to update mapped ports for container %s (attempt %d), retrying", 
                         containerId, f.getAttemptCount()))

--- a/src/test/java/io/fabric8/maven/docker/model/ContainerDetailsTest.java
+++ b/src/test/java/io/fabric8/maven/docker/model/ContainerDetailsTest.java
@@ -133,6 +133,13 @@ public class ContainerDetailsTest {
         thenValidateContainer();
     }
 
+    @Test(expected = PortBindingException.class)
+    public void testCreateContainerWithEmptyPortBindings() throws Exception {
+        givenAContainerWithUnboundPorts();
+        whenCreateContainer();
+        container.getPortBindings();
+    }
+
     private JsonArray createHostIpAndPort(int port, String ip) {
         JsonObject object = new JsonObject();
 
@@ -171,6 +178,15 @@ public class ContainerDetailsTest {
 
     private void givenAContainerWithoutPorts() {
         json.add(ContainerDetails.NETWORK_SETTINGS, new JsonObject());
+    }
+    
+    private void givenAContainerWithUnboundPorts() {
+        JsonObject ports = new JsonObject();
+        ports.add("80/tcp", new JsonArray());
+        ports.add("52/udp", new JsonArray());
+        JsonObject networkSettings = new JsonObject();
+        networkSettings.add(ContainerDetails.PORTS, ports);
+        json.add(ContainerDetails.NETWORK_SETTINGS, networkSettings);
     }
 
     private void givenContainerData() {

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -371,7 +371,7 @@ public class RunServiceTest {
         new Expectations() {{
             docker.createContainer(withAny(new ContainerCreateConfig("img")), anyString); result = "containerId";
             portMapping.needsPropertiesUpdate(); result = true;
-            queryService.getMandatoryContainer("containerId"); result = container; times = 10;
+            queryService.getMandatoryContainer("containerId"); result = container; times = 20;
             container.isRunning(); result = true;
             container.getPortBindings(); result = new PortBindingException("5432/tcp", new Gson().fromJson("{\"5432/tcp\": []}", JsonObject.class));
         }};


### PR DESCRIPTION
See https://github.com/fabric8io/docker-maven-plugin/issues/1446

Welcome feedback to my approach, to be frank I am not well versed with this code base and may have got some terminology wrong (especially in the unit test). If you can think of a better way to handle this I would love to hear it and happy to change the PR to implement.

On container startup, sometimes the port information retrieved from the
docker API is incomplete with port details being empty arrays, e.g.
Ports:{"2525/tcp":[]}. This causes an IndexOutOfBoundsException to be thrown
as the createPortBindings method assumes there will be at least one entry in
the mapping. In these cases we should retry the API call to get the more
complete port information.

Fixes #1446 