### PR TITLE
Fix for "Global Configuration" table in documentation

### DIFF
--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -138,7 +138,8 @@ By default a progress meter is printed out on the console, which is omitted when
 | `docker.skip.push`
 
 | *skipPom*
-| If set to `true` this plugin will skip every projects, where `project.packaging` is set to `pom`. Property: `docker.skip.pom`
+| If set to `true` this plugin will skip every projects, where `project.packaging` is set to `pom`.
+| `docker.skip.pom`
 
 | *skipRun*
 | If set dont create and start any containers with `{plugin}:start` or `{plugin}:run`


### PR DESCRIPTION
Fixed "Global Configuration" table in documentation - restored missing column in a row describing `skipPom` element. Refer to [that comment](https://github.com/fabric8io/docker-maven-plugin/pull/1388/files#r604321124) for details about the issue.