### PR TITLE
Fix #1450: CI builds with Maven Wrapper to ensure that Maven Wrapper files and configuration are correct

### DIFF
--- a/.github/workflows/linux-mavenwrapper-build.yml
+++ b/.github/workflows/linux-mavenwrapper-build.yml
@@ -1,4 +1,4 @@
-name: Windows Maven Build
+name: Linux Maven Wrapper Build
 
 on:
   push:
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    name: Windows Java ${{ matrix.java }} Maven
-    runs-on: windows-latest
+    name: Linux Java ${{ matrix.java }} Maven Wrapper
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,4 +21,4 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build Project
-        run: mvn clean install
+        run: ./mvnw -B -C -V -ntp clean install

--- a/.github/workflows/windows-mavenwrapper-build.yml
+++ b/.github/workflows/windows-mavenwrapper-build.yml
@@ -1,4 +1,4 @@
-name: Windows Maven Build
+name: Windows Maven Wrapper Build
 
 on:
   push:
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-    name: Windows Java ${{ matrix.java }} Maven
+    name: Windows Java ${{ matrix.java }} Maven Wrapper
     runs-on: windows-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,4 +21,4 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build Project
-        run: mvn clean install
+        run: ./mvnw.cmd clean install

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,8 @@
 # ChangeLog
 
 * **0.35-SNAPSHOT**:
+  - CI builds with Maven Wrapper to ensure that Maven Wrapper files and configuration are correct ([1450](https://github.com/fabric8io/docker-maven-plugin/issues/1450))
+
 
 * **0.35.0** (2021-04-04)
   - Building 'spring-boot-with-jib' sample fails with NoSuchMethodError ([1384](https://github.com/fabric8io/docker-maven-plugin/issues/1384))


### PR DESCRIPTION
Fix #1450 

+ Add Linux and Windows Github workflows for maven wrapper builds
+ Updated maven wrapper files as per maven 3.6.3