### PR TITLE
[1457] pull cacheFrom images during build

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.35-SNAPSHOT**:
+  - Add pulling of `cacheFrom` images during build ([1457](https://github.com/fabric8io/docker-maven-plugin/issues/1457))
 
 * **0.35.0** (2021-04-04)
   - Building 'spring-boot-with-jib' sample fails with NoSuchMethodError ([1384](https://github.com/fabric8io/docker-maven-plugin/issues/1384))

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -96,7 +96,7 @@ a| Scan the archive specified in `dockerArchive` and find the actual repository 
 | Squash newly built layers into a single new layer. This can be overwritten by setting a system property `docker.squash` when running Maven.
 
 | *cacheFrom*
-| A list of `<image>` elements specifying image names to use as cache sources.
+| A list of `<image>` elements specifying image names to use as cache sources. During image build, it will attempt to pull these images, but not fail the build. Follows `imagePullPolicy` semantics.
 
 | *optimise*
 | if set to true then it will compress all the `runCmds` into a single `RUN` directive so that only one image layer is created.

--- a/src/main/asciidoc/inc/misc/_startup.adoc
+++ b/src/main/asciidoc/inc/misc/_startup.adoc
@@ -29,10 +29,10 @@ Either shell or params should be specified.
 .Example
 [source,xml]
 ----
-<entrypoint>
+<entryPoint>
    <!-- shell form  -->
    <shell>java -jar $HOME/server.jar</shell>
-</entrypoint>
+</entryPoint>
 ----
 
 or
@@ -40,14 +40,14 @@ or
 .Example
 [source,xml]
 ----
-<entrypoint>
+<entryPoint>
    <!-- exec form  -->
    <exec>
      <arg>java</arg>
      <arg>-jar</arg>
      <arg>/opt/demo/server.jar</arg>
    </exec>
-</entrypoint>
+</entryPoint>
 ----
 
 This can be formulated also more dense with:
@@ -56,7 +56,7 @@ This can be formulated also more dense with:
 [source,xml]
 ----
 <!-- shell form  -->
-<entrypoint>java -jar $HOME/server.jar</entrypoint>
+<entryPoint>java -jar $HOME/server.jar</entryPoint>
 ----
 
 or
@@ -64,11 +64,11 @@ or
 .Example
 [source,xml]
 ----
-<entrypoint>
+<entryPoint>
   <!-- exec form  -->
   <arg>java</arg>
   <arg>-jar</arg>
   <arg>/opt/demo/server.jar</arg>
-</entrypoint>
+</entryPoint>
 ----
 


### PR DESCRIPTION
First PR on this project, so not sure about processes and conventions.

I wasn't sure if this feature should have its own configuration or not. For me it makes sense to always try to pull the `cacheFrom` images in a non-failing way, while adhering to `config.imagePullPolicy`.

---

fixes https://github.com/fabric8io/docker-maven-plugin/issues/1457