### PR TITLE
If docker.image.tag is set to a placeholder, we should replace it.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
   - CI builds with Maven Wrapper to ensure that Maven Wrapper files and configuration are correct ([1450](https://github.com/fabric8io/docker-maven-plugin/issues/1450))
   - Using <external> properties in image configuration disables Docker cache during build ([1455](https://github.com/fabric8io/docker-maven-plugin/issues/1455))
   - Update documentation to clearly state that `docker.cacheFrom.idx` is a _list_ property and should always be used with a `idx` suffix. With this change, `docker.cacheFrom` (without _idx_) is not considered anymore.
+  - A placeholder in docker.image.tag isn't replaced by the final result when used during docker:build ([1468](https://github.com/fabric8io/docker-maven-plugin/issues/1468))
   
 * **0.35.0** (2021-04-04)
   - Building 'spring-boot-with-jib' sample fails with NoSuchMethodError ([1384](https://github.com/fabric8io/docker-maven-plugin/issues/1384))

--- a/src/test/java/io/fabric8/maven/docker/util/ImageNameFormatterTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/ImageNameFormatterTest.java
@@ -124,6 +124,19 @@ public class ImageNameFormatterTest {
     }
 
     @Test
+    public void tagWithDockerImageTagSet() {
+        new Expectations() {{
+            project.getArtifactId(); result = "docker-maven-plugin";
+            project.getGroupId(); result = "io.fabric8";
+            project.getVersion(); result = "1.2.3-SNAPSHOT";
+            project.getProperties(); result = new Properties();
+        }};
+        project.getProperties().setProperty("docker.image.tag", "%l");
+
+        assertThat(formatter.format("%g/%a:%l"), equalTo("fabric8/docker-maven-plugin:latest"));
+    }
+
+    @Test
     public void nonSnapshotArtifact() throws Exception {
         new Expectations() {{
             project.getArtifactId(); result = "docker-maven-plugin";


### PR DESCRIPTION
Fix #1468 
This occurs when docker.image.name is constructed with `${docker.image.repo}:${docker.image.tag}`.

This is a fix to #1468