### PR TITLE
Add an option to dump the logs to an output file

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -5,7 +5,8 @@
   - Using <external> properties in image configuration disables Docker cache during build ([1455](https://github.com/fabric8io/docker-maven-plugin/issues/1455))
   - Update documentation to clearly state that `docker.cacheFrom.idx` is a _list_ property and should always be used with a `idx` suffix. With this change, `docker.cacheFrom` (without _idx_) is not considered anymore.
   - A placeholder in docker.image.tag isn't replaced by the final result when used during docker:build ([1468](https://github.com/fabric8io/docker-maven-plugin/issues/1468))
-  
+  - Add a property(`outputFile`) to dump the output of Docker commands to file ([1472]https://github.com/fabric8io/docker-maven-plugin/pull/1472)
+
 * **0.35.0** (2021-04-04)
   - Building 'spring-boot-with-jib' sample fails with NoSuchMethodError ([1384](https://github.com/fabric8io/docker-maven-plugin/issues/1384))
   - Loading Image tarball into docker daemon fails in JIB mode ([1385](https://github.com/fabric8io/docker-maven-plugin/issues/1385))

--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -163,6 +163,10 @@ If set to `true` this plugin won't remove any tags with `{plugin}:remove`. +
 | Whether to use colored log output. By default this is switched on when running on a console, off otherwise.
 | `docker.useColor`
 
+| *outputFile*
+| If specified, this parameter will cause the logs to be written to the path specified, instead of writing to the console.
+| `outputFile`
+
 | *verbose*
 | String attribute for switching on verbose output on standard output (stdout). It takes a comma separated list of string values to switch on various verbosity groups.
 

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -268,7 +268,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
                         access = dockerAccessFactory.createDockerAccess(dockerAccessContext);
                     }
                     ServiceHub serviceHub = serviceHubFactory.createServiceHub(project, session, access, log, logSpecFactory);
-                    executeInternal(serviceHub);
+                    try {
+                        executeInternal(serviceHub);
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                        throw ex;
+                    }
                 } catch (IOException | ExecException exp) {
                     logException(exp);
                     throw new MojoExecutionException(log.errorMessage(exp.getMessage()), exp);

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -268,12 +268,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
                         access = dockerAccessFactory.createDockerAccess(dockerAccessContext);
                     }
                     ServiceHub serviceHub = serviceHubFactory.createServiceHub(project, session, access, log, logSpecFactory);
-                    try {
-                        executeInternal(serviceHub);
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
-                        throw ex;
-                    }
+                    executeInternal(serviceHub);
                 } catch (IOException | ExecException exp) {
                     logException(exp);
                     throw new MojoExecutionException(log.errorMessage(exp.getMessage()), exp);

--- a/src/test/java/io/fabric8/maven/docker/BaseMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BaseMojoTest.java
@@ -47,7 +47,7 @@ public class BaseMojoTest {
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Injectable
-    protected Logger log;
+    protected AnsiLogger log;
 
     @Mocked
     protected ServiceHub serviceHub;

--- a/src/test/java/io/fabric8/maven/docker/VolumeCreateMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/VolumeCreateMojoTest.java
@@ -2,6 +2,7 @@ package io.fabric8.maven.docker;
 
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.util.AnsiLogger;
 import io.fabric8.maven.docker.util.Logger;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -13,7 +14,7 @@ import org.junit.Test;
 public class VolumeCreateMojoTest {
 
     @Injectable
-    Logger log;
+    AnsiLogger log;
 
     @Tested(fullyInitialized = false)
     private VolumeCreateMojo volumeCreateMojo;

--- a/src/test/java/io/fabric8/maven/docker/VolumeRemoveMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/VolumeRemoveMojoTest.java
@@ -2,6 +2,7 @@ package io.fabric8.maven.docker;
 
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.service.ServiceHub;
+import io.fabric8.maven.docker.util.AnsiLogger;
 import io.fabric8.maven.docker.util.Logger;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -13,7 +14,7 @@ import org.junit.Test;
 public class VolumeRemoveMojoTest {
 
     @Injectable
-    Logger log;
+    AnsiLogger log;
 
     @Tested(fullyInitialized = false)
     private VolumeRemoveMojo volumeRemoveMojo;


### PR DESCRIPTION
This option is designed after:
https://maven.apache.org/plugins/maven-dependency-plugin/list-mojo.html#outputFile

Basically, it redirects the output logs to a file that can be processed by something else (another Mojo, external tools, etc.)

For context:
I'm working on Maven plugin that needs(in this case) to extract the pushed image `sha`.