### PR TITLE
inconsistent names of the `entryPoint` configuration parameter

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,9 @@
   - Allow replacement in tags. Added a new replacement `%T` which always adds a timestamp. ([#1491](https://github.com/fabric8io/docker-maven-plugin/pull/1491))
   - Only push the `latest` tag if no other tags where specified in docker mode. This can break your build, if you rely on the automatic `latest` tag. ([#1496](https://github.com/fabric8io/docker-maven-plugin/pull/1496))
   - Only push the `latest` tag if no other tags where specified in jib mode. This can break your build, if you rely on the automatic `latest` tag. ([#1498](https://github.com/fabric8io/docker-maven-plugin/pull/1498))
+  - Deprecate `entrypoint` parameter in `<run>` configuration ([1488](https://github.com/fabric8io/docker-maven-plugin/pull/1488))
+
+**Note:** `entrypoint` parameter in `<run>` configuration is marked as deprecated. Users are advised to use `entryPoint` parameter instead.
 
 * **0.37.0** (2021-08-15)
   - Fix stop mojo by taking container name pattern into account (#1168)

--- a/src/main/asciidoc/inc/misc/_startup.adoc
+++ b/src/main/asciidoc/inc/misc/_startup.adoc
@@ -29,10 +29,10 @@ Either shell or params should be specified.
 .Example
 [source,xml]
 ----
-<entrypoint>
+<entryPoint>
    <!-- shell form  -->
    <shell>java -jar $HOME/server.jar</shell>
-</entrypoint>
+</entryPoint>
 ----
 
 or
@@ -40,14 +40,14 @@ or
 .Example
 [source,xml]
 ----
-<entrypoint>
+<entryPoint>
    <!-- exec form  -->
    <exec>
      <arg>java</arg>
      <arg>-jar</arg>
      <arg>/opt/demo/server.jar</arg>
    </exec>
-</entrypoint>
+</entryPoint>
 ----
 
 This can be formulated also more dense with:
@@ -56,7 +56,7 @@ This can be formulated also more dense with:
 [source,xml]
 ----
 <!-- shell form  -->
-<entrypoint>java -jar $HOME/server.jar</entrypoint>
+<entryPoint>java -jar $HOME/server.jar</entryPoint>
 ----
 
 or
@@ -64,11 +64,11 @@ or
 .Example
 [source,xml]
 ----
-<entrypoint>
+<entryPoint>
   <!-- exec form  -->
   <arg>java</arg>
   <arg>-jar</arg>
   <arg>/opt/demo/server.jar</arg>
-</entrypoint>
+</entryPoint>
 ----
 

--- a/src/main/asciidoc/inc/misc/_startup.adoc
+++ b/src/main/asciidoc/inc/misc/_startup.adoc
@@ -29,10 +29,10 @@ Either shell or params should be specified.
 .Example
 [source,xml]
 ----
-<entryPoint>
+<entrypoint>
    <!-- shell form  -->
    <shell>java -jar $HOME/server.jar</shell>
-</entryPoint>
+</entrypoint>
 ----
 
 or
@@ -40,14 +40,14 @@ or
 .Example
 [source,xml]
 ----
-<entryPoint>
+<entrypoint>
    <!-- exec form  -->
    <exec>
      <arg>java</arg>
      <arg>-jar</arg>
      <arg>/opt/demo/server.jar</arg>
    </exec>
-</entryPoint>
+</entrypoint>
 ----
 
 This can be formulated also more dense with:
@@ -56,7 +56,7 @@ This can be formulated also more dense with:
 [source,xml]
 ----
 <!-- shell form  -->
-<entryPoint>java -jar $HOME/server.jar</entryPoint>
+<entrypoint>java -jar $HOME/server.jar</entrypoint>
 ----
 
 or
@@ -64,11 +64,11 @@ or
 .Example
 [source,xml]
 ----
-<entryPoint>
+<entrypoint>
   <!-- exec form  -->
   <arg>java</arg>
   <arg>-jar</arg>
   <arg>/opt/demo/server.jar</arg>
-</entryPoint>
+</entrypoint>
 ----
 

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -47,9 +47,16 @@ public class RunImageConfiguration implements Serializable {
     @Parameter
     private List<String> dependsOn;
 
-    // container entry point
+    /**
+     * container entry point
+     * @deprecated This field would be removed in upcoming releases. Use <code>entryPoint</code> instead.
+     */
     @Parameter
+    @Deprecated
     private Arguments entrypoint;
+
+    @Parameter
+    private Arguments entryPoint;
 
     // container hostname
     @Parameter
@@ -201,6 +208,9 @@ public class RunImageConfiguration implements Serializable {
         if (entrypoint != null) {
             entrypoint.validate();
         }
+        if (entryPoint != null) {
+            entryPoint.validate();
+        }
         if (cmd != null) {
             cmd.validate();
         }
@@ -227,7 +237,10 @@ public class RunImageConfiguration implements Serializable {
     }
 
     public Arguments getEntrypoint() {
-        return entrypoint;
+        if (entrypoint != null) {
+            return entrypoint;
+        }
+        return entryPoint;
     }
 
     public String getHostname() {
@@ -478,6 +491,7 @@ public class RunImageConfiguration implements Serializable {
 
         public Builder entrypoint(Arguments args) {
             config.entrypoint = args;
+            config.entryPoint = args;
             return this;
         }
 


### PR DESCRIPTION
maven 3.6.3 error:
> Unable to parse configuration of mojo io.fabric8:docker-maven-plugin:0.37.0:start for parameter entryPoint: Cannot find 'entryPoint' in class io.fabric8.maven.docker.config.RunImageConfiguration