### PR TITLE
Allow replacements in build <tags>

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.37-SNAPSHOT**:
+  - Allow replacement in tags. Added a new replacement `%T` which always adds a timestamp. ([#1491](https://github.com/fabric8io/docker-maven-plugin/pull/1491))
 
 * **0.37.0** (2021-08-15)
   - Fix stop mojo by taking container name pattern into account (#1168)

--- a/src/main/asciidoc/inc/image/_naming.adoc
+++ b/src/main/asciidoc/inc/image/_naming.adoc
@@ -2,6 +2,8 @@
 ## Image Names
 When specifying the image name in the configuration with the `<name>` field you can use several placeholders which are replaced during runtime by this plugin. In addition you can use regular Maven properties which are resolved by Maven itself.
 
+Replacements can also be used in `<tag>` fields within the the tags of any build configuration.
+
 [cols="1,5"]
 |===
 | Placeholder | Description
@@ -20,6 +22,9 @@ When specifying the image name in the configuration with the `<name>` field you 
 
 | *%t*
 | If the project version ends with `-SNAPSHOT` this placeholder resolves to `snapshot-<timestamp>` where timestamp has the date format `yyMMdd-HHmmss-SSSS` (eg `snapshot-`). This feature is especially useful during development in oder to avoid conflicts when images are to be updated which are still in use. You need to take care yourself of cleaning up old images afterwards, though.
+
+| *%T*
+| Timestamp with the format `yyMMdd-HHmmss-SSSS`.
 |===
 
 ifeval::["{plugin}" == "docker"]

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -1,15 +1,25 @@
 package io.fabric8.maven.docker.config;
 
+import java.io.File;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
 import io.fabric8.maven.docker.util.DeepCopy;
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.docker.util.MojoParameters;
 import org.apache.maven.plugins.annotations.Parameter;
-
-import javax.annotation.Nonnull;
-import java.io.File;
-import java.io.Serializable;
-import java.util.*;
 
 /**
  * @author roland
@@ -430,6 +440,12 @@ public class BuildImageConfiguration implements Serializable {
 
     public File getAbsoluteDockerTarPath(MojoParameters mojoParams) {
         return EnvUtil.prepareAbsoluteSourceDirPath(mojoParams, getDockerArchive().getPath());
+    }
+
+    public void initTags(ConfigHelper.NameFormatter nameFormatter) {
+        if (tags != null) {
+            tags = tags.stream().map(nameFormatter::format).collect(Collectors.toList());
+        }
     }
 
     public static class Builder {

--- a/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ImageConfiguration.java
@@ -202,6 +202,7 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable, Serial
         String minimalApiVersion = null;
         if (build != null) {
             minimalApiVersion = build.initAndValidate(log);
+            build.initTags(nameFormatter);
         }
         if (run != null) {
             minimalApiVersion = EnvUtil.extractLargerVersion(minimalApiVersion, run.initAndValidate());

--- a/src/test/java/io/fabric8/maven/docker/util/ImageNameFormatterTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/ImageNameFormatterTest.java
@@ -124,6 +124,17 @@ public class ImageNameFormatterTest {
     }
 
     @Test
+    public void timestamp() throws Exception {
+        new Expectations() {{
+            project.getArtifactId(); result = "docker-maven-plugin";
+            project.getGroupId(); result = "io.fabric8";
+            project.getProperties(); result = new Properties();
+        }};
+        assertThat(formatter.format("%g/%a:%T").matches("^fabric8/docker-maven-plugin:[\\d-]+$"), is(true));
+        assertThat(formatter.format("%g/%a:test-%T").matches("^fabric8/docker-maven-plugin:test-[\\d-]+$"), is(true));
+    }
+
+    @Test
     public void tagWithDockerImageTagSet() {
         new Expectations() {{
             project.getArtifactId(); result = "docker-maven-plugin";


### PR DESCRIPTION
Fixes #1367
Allows replacement in tags and added a new replacement `%T` which always adds a timestamp, independent of the version.