### PR TITLE
Only push latest tag when no others where specified

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
@@ -90,7 +90,7 @@ public class JibBuildService {
                 JibServiceUtil.jibPush(
                         imageConfiguration,
                         getRegistryCredentials(registryConfig, true, imageConfiguration, log),
-                        getBuildTarArchive(imageConfiguration, mojoParameters),
+                        getBuildTarArchive(imageConfiguration, mojoParameters), skipTag,
                         log
                 );
             }

--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -59,16 +59,16 @@ public class RegistryService {
 
                 AuthConfig authConfig = createAuthConfig(true, new ImageName(name).getUser(), configuredRegistry, registryConfig);
 
-                long start = System.currentTimeMillis();
-                docker.pushImage(name, authConfig, configuredRegistry, retries);
-                log.info("Pushed %s in %s", name, EnvUtil.formatDurationTill(start));
-
-                if (!skipTag) {
-                    for (String tag : imageConfig.getBuildConfiguration().getTags()) {
+                if (!skipTag && !buildConfig.getTags().isEmpty()) {
+                    for (String tag : buildConfig.getTags()) {
                         if (tag != null) {
                             docker.pushImage(new ImageName(name, tag).getFullName(), authConfig, configuredRegistry, retries);
                         }
                     }
+                } else {
+                    long start = System.currentTimeMillis();
+                    docker.pushImage(name, authConfig, configuredRegistry, retries);
+                    log.info("Pushed %s in %s", name, EnvUtil.formatDurationTill(start));
                 }
             }
         }

--- a/src/test/java/io/fabric8/maven/docker/service/JibBuildServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/JibBuildServiceTest.java
@@ -140,7 +140,7 @@ public class JibBuildServiceTest {
         // Then
         // @formatter:off
         new Verifications() {{
-            JibServiceUtil.jibPush((ImageConfiguration) any, (Credential) any, (File) any, logger); times = 0;
+            JibServiceUtil.jibPush((ImageConfiguration) any, (Credential) any, (File) any, false, logger); times = 0;
         }};
         // @formatter:on
     }
@@ -164,6 +164,7 @@ public class JibBuildServiceTest {
                     imageConfiguration,
                     Credential.from("testuserpush", "testpass"),
                     (File)any,
+                    false,
                     logger);
             times = 1;
         }};

--- a/src/test/java/io/fabric8/maven/docker/util/JibServiceUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/JibServiceUtilTest.java
@@ -104,20 +104,6 @@ public class JibServiceUtilTest {
     }
 
     @Test
-    public void testAppendOriginalImageNameTagIfApplicable() {
-        // Given
-        List<String> imageTagList = Arrays.asList("0.0.1", "0.0.1-SNAPSHOT");
-
-        // When
-        Set<String> result = JibServiceUtil.getAllImageTags(imageTagList, "test-project");
-
-        // Then
-        assertNotNull(result);
-        assertEquals(3, result.size());
-        assertArrayEquals(new String[]{"0.0.1-SNAPSHOT", "0.0.1", "latest"}, result.toArray());
-    }
-
-    @Test
     public void testGetFullImageNameWithDefaultTag() {
         assertEquals("test/test-project:latest", JibServiceUtil.getFullImageName(getSampleImageConfiguration(), null));
     }


### PR DESCRIPTION
Currently, there is no way to only push the specified tags. Latest is always pushed, for docker and jib mode.
I changed both build modes, so they now behave as follows.
* latest is only automaticly pushed when no other tags are specified
* Otherwise if tags are specified, only those are pushed.

Jib however did not respect skipTag, which I also implemented.

This is a draft pr, since this changes established behaviour of the plugin, and want feedback on it first.

closes #1495