### PR TITLE
Jib: Only push the latest tag if no other tags where specified.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,7 @@
 
 * **0.37-SNAPSHOT**:
   - Allow replacement in tags. Added a new replacement `%T` which always adds a timestamp. ([#1491](https://github.com/fabric8io/docker-maven-plugin/pull/1491))
+  - Only push the `latest` tag if no other tags where specified in jib mode. This can break your build, if you rely on the automatic `latest` tag. ([#1498](https://github.com/fabric8io/docker-maven-plugin/pull/1498))
 
 * **0.37.0** (2021-08-15)
   - Fix stop mojo by taking container name pattern into account (#1168)

--- a/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
@@ -90,7 +90,7 @@ public class JibBuildService {
                 JibServiceUtil.jibPush(
                         imageConfiguration,
                         getRegistryCredentials(registryConfig, true, imageConfiguration, log),
-                        getBuildTarArchive(imageConfiguration, mojoParameters),
+                        getBuildTarArchive(imageConfiguration, mojoParameters), skipTag,
                         log
                 );
             }

--- a/src/test/java/io/fabric8/maven/docker/service/JibBuildServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/JibBuildServiceTest.java
@@ -140,7 +140,7 @@ public class JibBuildServiceTest {
         // Then
         // @formatter:off
         new Verifications() {{
-            JibServiceUtil.jibPush((ImageConfiguration) any, (Credential) any, (File) any, logger); times = 0;
+            JibServiceUtil.jibPush((ImageConfiguration) any, (Credential) any, (File) any, false, logger); times = 0;
         }};
         // @formatter:on
     }
@@ -164,6 +164,7 @@ public class JibBuildServiceTest {
                     imageConfiguration,
                     Credential.from("testuserpush", "testpass"),
                     (File)any,
+                    false,
                     logger);
             times = 1;
         }};

--- a/src/test/java/io/fabric8/maven/docker/util/JibServiceUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/JibServiceUtilTest.java
@@ -1,6 +1,12 @@
 package io.fabric8.maven.docker.util;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
+import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.Credential;
+import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.RegistryException;
+import com.google.cloud.tools.jib.api.TarImage;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
@@ -11,6 +17,11 @@ import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.config.AssemblyConfiguration;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
+import mockit.Capturing;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import mockit.Verifications;
 import org.apache.maven.plugins.assembly.model.Assembly;
@@ -21,12 +32,15 @@ import org.junit.experimental.categories.Category;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static io.fabric8.maven.docker.util.JibServiceUtil.BUSYBOX;
 import static io.fabric8.maven.docker.util.JibServiceUtil.containerFromImageConfiguration;
@@ -36,6 +50,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class JibServiceUtilTest {
+    @Mocked
+    private Logger logger;
+
+    @Capturing
+    JibContainerBuilder jibContainerBuilder;
+
     @Test
     public void testGetBaseImageWithNullBuildConfig() {
         assertEquals(BUSYBOX, JibServiceUtil.getBaseImage(new ImageConfiguration.Builder().build()));
@@ -48,6 +68,47 @@ public class JibServiceUtilTest {
                         .from("quay.io/jkubeio/jkube-test-image:0.0.1")
                         .build())
                 .build()));
+    }
+
+    @Test
+    public void testPushedImageTags() {
+        File buildArchive = new File("docker-build.tar");
+
+        ImageConfiguration imageWithoutTags = new ImageConfiguration.Builder()
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("quay.io/jkubeio/jkube-test-image:0.0.1")
+                        .build())
+                .name("without-tags")
+                .build();
+
+        ImageConfiguration imageWithTags = new ImageConfiguration.Builder()
+                .buildConfig(new BuildImageConfiguration.Builder()
+                        .from("quay.io/jkubeio/jkube-test-image:0.0.1")
+                        .tags(Arrays.asList("foo", "bar"))
+                        .build())
+                .name("with-tags")
+                .build();
+
+        List<String> imageNames = new ArrayList<>();
+        new MockUp<JibServiceUtil>() {
+            @Mock
+            public void pushImage(TarImage baseImage, String targetImageName, Credential credential, Logger logger) {
+                imageNames.add(targetImageName);
+            }
+        };
+
+        JibServiceUtil.jibPush(imageWithoutTags, null, buildArchive, false, logger);
+        JibServiceUtil.jibPush(imageWithTags, null, buildArchive, true, logger);
+        JibServiceUtil.jibPush(imageWithTags, null, buildArchive, false, logger);
+
+        // latest tag is used, because no other tags are specified
+        assertEquals(imageWithoutTags.getName()+":latest", imageNames.get(0));
+        // latest tag is used, because skipTag = true
+        assertEquals(imageWithTags.getName()+":latest", imageNames.get(1));
+
+        // skipTag = false => both specified tags have to be pushed
+        assertEquals(imageWithTags.getName()+":foo", imageNames.get(2));
+        assertEquals(imageWithTags.getName()+":bar", imageNames.get(3));
     }
 
     @Test
@@ -101,20 +162,6 @@ public class JibServiceUtilTest {
             assertEquals(AbsoluteUnixPath.fromPath(Paths.get(temporaryFile.getAbsolutePath().substring(tmpRoot.length()))),
                     fileEntriesLayer.getEntries().get(0).getExtractionPath());
         }};
-    }
-
-    @Test
-    public void testAppendOriginalImageNameTagIfApplicable() {
-        // Given
-        List<String> imageTagList = Arrays.asList("0.0.1", "0.0.1-SNAPSHOT");
-
-        // When
-        Set<String> result = JibServiceUtil.getAllImageTags(imageTagList, "test-project");
-
-        // Then
-        assertNotNull(result);
-        assertEquals(3, result.size());
-        assertArrayEquals(new String[]{"0.0.1-SNAPSHOT", "0.0.1", "latest"}, result.toArray());
     }
 
     @Test


### PR DESCRIPTION
Currently, there is no way to only push the specified tags. Latest is always pushed for  jib mode.
I changed jib mode to behave as follows:
* latest is only automaticly pushed when no other tags are specified
* Otherwise if tags are specified, only those are pushed.

Jib however did not respect skipTag, which I also implemented.

relates to #1495