### PR TITLE
chore: Update to jnr-unixsocket 0.38.14

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.39-SNAPSHOT** :
+  - Update to jnr-unixsocket 0.38.14 to solve UnsatisfiedLinkError on Apple M1 #1257
 
 * **0.38.0** (2021-11-09):
   - Allow replacement in tags. Added a new replacement `%T` which always adds a timestamp. ([#1491](https://github.com/fabric8io/docker-maven-plugin/pull/1491))

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.25</version>
+      <version>0.38.14</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This should fix the UnsatisfiedLinkError on Apple M1 machines. [#1257](https://github.com/fabric8io/docker-maven-plugin/issues/1257)


If it had been possible I would have used a previous version number, to reduce side effects. But after updating some dependencies in the jnr-unixsocket projekt, 0.38.14 is the first version to make docker-maven-plugin work with native java on an apple silicon.