### PR TITLE
Cleanup dangling images

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.39-SNAPSHOT** :
+  - Cleanup dangling images as a result of image tagging, auto-pulling a base image, or auto-pulling a cacheFrom image ([#1513](https://github.com/fabric8io/docker-maven-plugin/pull/1513)) @rkhmelichek
 
 * **0.38.1** (2021-12-18):
   - Update to jnr-unixsocket 0.38.14 to solve UnsatisfiedLinkError on Apple M1 ([#1257](https://github.com/fabric8io/docker-maven-plugin/pull/1507)) @henningn

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -26,7 +26,7 @@ https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#build-imag
 (e.g.: memory, shmsize). If you use the respective configuration options for build options natively supported by the build configuration (i.e. `squash`, `noCache`, `cleanup=remove` for buildoption `forcerm=1` and `args` for build args) then these will override any corresponding options given here. The key-value syntax is the same as when defining environment variables or labels as described in <<misc-env,Setting Environment Variables and Labels>>.
 
 | *cleanup*
-| Cleanup dangling (untagged) images after each build (including any containers created from them). Default is `try` which tries to remove the old image, but doesn't fail the build if this is not possible because e.g. the image is still used by a running container. Use `remove` if you want to fail the build and `none` if no cleanup is requested.
+| Cleanup dangling (untagged) images after each build, including any stopped containers created from them. Also cleanup dangling images as a result of image tagging, auto-pulling a base image, or auto-pulling a cacheFrom image. Default is `try`, which tries to remove the old image, but doesn't fail the build if this is not possible (e.g. because the image is still used by a running container). Other possible values are `remove`, if you want to fail the build, or `none`, to skip cleanup altogether.
 
 | [[context-dir]]*contextDir*
 | Path to a directory used for the build's context. You can specify the `Dockerfile` to use with *dockerFile*, which by default is the Dockerfile found in the `contextDir`. The Dockerfile can be also located outside of the `contextDir`, if provided with an absolute file path. See <<external-dockerfile, External Dockerfile>> for details.

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -80,7 +80,7 @@ when a `docker.from` or a `docker.fromExt` is set.
 | List of kernel capabilities to remove from the container. See <<list-properties>>.
 
 | *docker.cleanup*
-| Cleanup dangling (untagged) images after each build (including any containers created from them). Default is `try` (which wont fail the build if removing fails), other possible values are `none` (no cleanup) or `remove` (remove but fail if unsuccessful)
+| Cleanup dangling (untagged) images after each build, including any stopped containers created from them. Also cleanup dangling images as a result of image tagging, auto-pulling a base image, or auto-pulling a cacheFrom image. Default is `try`, which tries to remove the old image, but doesn't fail the build if this is not possible (e.g. because the image is still used by a running container). Other possible values are `remove`, if you want to fail the build, or `none`, to skip cleanup altogether.
 
 | *docker.cmd*
 | Command to execute. This is used both when running a container and as default command when creating an image.

--- a/src/main/java/io/fabric8/maven/docker/TagMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/TagMojo.java
@@ -1,6 +1,7 @@
 package io.fabric8.maven.docker;
 
 import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -33,7 +34,9 @@ public class TagMojo extends AbstractDockerMojo {
 
         List<ImageConfiguration> imageConfigs = getResolvedImages();
         for (ImageConfiguration imageConfig : imageConfigs) {
-            hub.getBuildService().tagImage(imageConfig.getName(), tagName, repo);
+            BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
+
+            hub.getBuildService().tagImage(imageConfig.getName(), tagName, repo, buildConfig.cleanupMode());
         }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -66,6 +66,14 @@ public interface DockerAccess {
     String getImageId(String name) throws DockerAccessException;
 
     /**
+     * Get the list of tags of a given image name or <code>null</code> if no such image exists
+     *
+     * @param name name to lookup
+     * @return the list of image tags or <code>null</code>
+     */
+    List<String> getImageTags(String name) throws DockerAccessException;
+
+    /**
      * List all containers from the Docker server.
      *
      * @param all whether to fetch also stopped containers. If false only running containers are returned

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -468,6 +468,22 @@ public class DockerAccessWithHcClient implements DockerAccess {
         return imageDetails.get("Id").getAsString().substring(0, 12);
     }
 
+    @Override
+    public List<String> getImageTags(String name) throws DockerAccessException {
+        HttpBodyAndStatus response = inspectImage(name);
+        if (response.getStatusCode() == HTTP_NOT_FOUND) {
+            return null;
+        }
+        JsonObject imageDetails = JsonFactory.newJsonObject(response.getBody());
+        JsonArray tagsArr = imageDetails.get("RepoTags").getAsJsonArray();
+        if (tagsArr.size() == 0) {
+            return Collections.emptyList();
+        }
+        List<String> tags = new ArrayList<>();
+        tagsArr.forEach(tag-> tags.add(tag.getAsString()));
+        return tags;
+    }
+
     private HttpBodyAndStatus inspectImage(String name) throws DockerAccessException {
         String url = urlBuilder.inspectImage(name);
         try {

--- a/src/test/java/io/fabric8/maven/docker/service/BuildServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildServiceTest.java
@@ -222,7 +222,7 @@ public class BuildServiceTest {
 
         // When
         whenBuildImage(false, true);
-        buildService.tagImage(imageConfig.getName(), "1.1.0", "quay.io/someuser");
+        buildService.tagImage(imageConfig.getName(), "1.1.0", "quay.io/someuser", imageConfig.getBuildConfiguration().cleanupMode());
 
         // Then
         thenImageIsBuilt();


### PR DESCRIPTION
There is a `cleanup` build configuration option that will by default 'cleanup dangling (untagged) images after each build'.
I would propose extending that to also cleanup dangling images as a result of:
tagging
auto-pulling of base images
auto-pulling of cache-from images

We use docker-maven-plugin on a CI server and auto-removing dangling images keeps the server from filling up with old image versions.