### PR TITLE
Fix logic bug to remove dangling images

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,8 +1,9 @@
 # ChangeLog
 
 * **0.39-SNAPSHOT** :
-  - `skipPom` is ignored by "push" goal ([1482](https://github.com/fabric8io/docker-maven-plugin/issues/1482))
+  - `skipPom` is ignored by "push" goal ([1482](https://github.com/fabric8io/docker-maven-plugin/issues/1482)) @rohanKanojia
   - Cleanup dangling images as a result of image tagging, auto-pulling a base image, or auto-pulling a cacheFrom image ([#1513](https://github.com/fabric8io/docker-maven-plugin/pull/1513)) @rkhmelichek
+  - Fix logic bug to remove dangling images in BuildService ([1522](https://github.com/fabric8io/docker-maven-plugin/pull/1522)) @rkhmelichek
   - Enable Create Image (pull) HTTP API option ([#1516](https://github.com/fabric8io/docker-maven-plugin/issues/1516)) @rohanKanojia
 
 * **0.38.1** (2021-12-18):

--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -459,7 +459,7 @@ public class BuildService {
                 // Verify that the image is indeed dangling and remove it (or skip removal altogether).
                 List<String> oldImageTags = docker.getImageTags(oldImageId);
                 if (oldImageTags != null) {
-                    if (!oldImageTags.isEmpty()) {
+                    if (oldImageTags.isEmpty()) {
                         removeImage(oldImageName, oldImageId, cleanupMode, false);
                     } else {
                         log.warn("%s: Skipped removing image %s; still tagged with: ", oldImageName, oldImageId, String.join(",", oldImageTags));


### PR DESCRIPTION
Hi @rohanKanojia,
As a follow up to #1513, I've been testing a private build of the changes on our CI machines, and discovered a logic bug.
The condition to remove the image only if there are no other associated tags/repos should be reversed.

Additionally I'm looking to address one other scenario of dangling images.
That happens when pushing tags.
For example, the following code could result in a dangling image that will never be cleaned up, so I'm thinking of extending the logic to clean it up here as well.
```java
        if (alreadyHasImage) {
            log.warn("Target image '%s' already exists. Tagging of '%s' will replace existing image",
                targetImage, fullName);
        }
```