### PR TITLE
Add docs about docker:build network config

### DIFF
--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -89,6 +89,9 @@ a| Scan the archive specified in `dockerArchive` and find the actual repository 
 | *maintainer*
 | The author (`MAINTAINER`) field for the generated image
 
+| *network*
+| Set the networking mode for the RUN instructions during build
+
 | *noCache*
 | Don't use Docker's build cache. This can be overwritten by setting a system property `docker.noCache` when running Maven.
 


### PR DESCRIPTION
This adds the documentation that was missing from #1288 