### PR TITLE
[#1528] determineFinalArgValue respect default value if key exists but value is null

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.40-SNAPSHOT** :
+  - determineFinalArgValue respect default value if key exists but value is null ([1528](https://github.com/fabric8io/docker-maven-plugin/issues/1528)) @twendelmuth
 
 * **0.39.0** (2022-02-06):
   - `skipPom` is ignored by "push" goal ([1482](https://github.com/fabric8io/docker-maven-plugin/issues/1482)) @rohanKanojia

--- a/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java
@@ -280,7 +280,7 @@ public class DockerFileUtil {
 
     private static String determineFinalArgValue(String argString, String[] argStringParts, Map<String, String> args) {
         String argStringValue = argString.substring(argStringParts[0].length() + 1);
-        if(args == null){
+        if(args == null || args.get(argStringParts[0]) == null){
             return argStringValue;
         }
         return args.getOrDefault(argStringParts[0], argStringValue);

--- a/src/test/java/io/fabric8/maven/docker/util/DockerFileUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/DockerFileUtilTest.java
@@ -107,6 +107,12 @@ public class DockerFileUtilTest {
         assertEquals("{busyboxVersion=latest}", DockerFileUtil.extractArgsFromLines(Collections.singletonList(new String[]{"ARG", "busyboxVersion=latest"}), null).toString());
     }
 
+    @Test
+    public void testExtractArgsFromDockerFile_parameterMapWithNullValues() {
+        assertEquals("{VERSION=latest, FULL_IMAGE=busybox:latest}", DockerFileUtil.extractArgsFromLines(Arrays.asList(new String[]{"ARG", "VERSION:latest"}, new String[] {"ARG", "FULL_IMAGE=busybox:latest"}), Collections.singletonMap("VERSION", null)).toString());
+        assertEquals("{VERSION=latest, FULL_IMAGE=busybox:latest}", DockerFileUtil.extractArgsFromLines(Arrays.asList(new String[]{"ARG", "VERSION=latest"}, new String[] {"ARG", "FULL_IMAGE=busybox:latest"}), Collections.singletonMap("VERSION", null)).toString());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidArgWithSpacesFromDockerfile() {
         DockerFileUtil.extractArgsFromLines(Collections.singletonList(new String[]{"ARG", "MY_IMAGE image with spaces"}), Collections.emptyMap());


### PR DESCRIPTION
Fix #1528

See #1528 - will return the default value when `argMap.getValue() == null`