### PR TITLE
Prevent concurrent access to secDispatcher during password decryption

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -650,7 +650,9 @@ public class AuthConfigFactory {
             // Done by reflection since I have classloader issues otherwise
             Object secDispatcher = container.lookup(SecDispatcher.ROLE, "maven");
             Method method = secDispatcher.getClass().getMethod("decrypt",String.class);
-            return (String) method.invoke(secDispatcher,password);
+            synchronized(secDispatcher) {
+                return (String) method.invoke(secDispatcher, password);
+            }
         } catch (ComponentLookupException e) {
             throw new MojoExecutionException("Error looking security dispatcher",e);
         } catch (ReflectiveOperationException e) {


### PR DESCRIPTION
secDispatcher is not thread-safe, as it keeps some internal state when decrypting the password. This would make multi-thread maven builds sometimes.

With this, I believe that we could probably even annotate the mojos as threadSafe - at least I haven't found any further issues so far - but I also don't have a very deep knowledge of the code base.