### PR TITLE
  Annotate build mojo as threadSafe

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -30,7 +30,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @author roland
  * @since 28.07.14
  */
-@Mojo(name = "build", defaultPhase = LifecyclePhase.INSTALL)
+@Mojo(name = "build", defaultPhase = LifecyclePhase.INSTALL, threadSafe = true)
 public class BuildMojo extends AbstractBuildSupportMojo {
 
     public static final String DMP_PLUGIN_DESCRIPTOR = "META-INF/maven/io.fabric8/dmp-plugin";


### PR DESCRIPTION
I went through the code base, and didn't see any (obvious) reason for the mojos to not be thread-safe. I have been using multi-threaded builds for a few years now, seemingly without issues, apart from #1533.

Are there any known reasons for the mojos to not be annotated as threadSafe? At least the build-related mojos.

Opening this pull request to start the discussion, as the changes are quite simple - please let me know if I should open an issue instead.