### PR TITLE
Adds missing dash to --build-arg

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@
   - Support for `docker run --sysctl` parameters ([1530](https://github.com/fabric8io/docker-maven-plugin/issues/1530)) @jpraet
   - Migrate to JUnit5 and Mockito for testing ([1550](https://github.com/fabric8io/docker-maven-plugin/pull/1550)) @chonton
   - Multi-architecture images using buildx ([1502](https://github.com/fabric8io/docker-maven-plugin/issues/1502)) @chonton
+  - Add missing dash to buildx `--build-arg` ([1559](https://github.com/fabric8io/docker-maven-plugin/pull/1559)) @elektro-wolle
 
 * **0.39.1** (2022-02-27):
   - determineFinalArgValue respect default value if key exists but value is null ([1528](https://github.com/fabric8io/docker-maven-plugin/issues/1528)) @twendelmuth

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -123,7 +123,7 @@ public class BuildXService {
         Map<String, String> args = buildConfiguration.getArgs();
         if (args != null) {
             args.forEach((key, value) -> {
-                cmdLine.add("--buildarg");
+                cmdLine.add("--build-arg");
                 cmdLine.add(key + '=' + value);
             });
         }

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -119,13 +119,13 @@ class BuildMojoTest extends MojoTestBase {
 
         Mockito.verify(exec).process(Arrays.asList("docker", "--config", config, "buildx",
             "build", "--progress=plain", "--builder", builderName,
-            "--platform", "linux/amd64,linux/arm64", "--tag", "example:latest",
+            "--platform", "linux/amd64,linux/arm64", "--tag", "example:latest", "--build-arg", "foo=bar",
             "--cache-to=type=local,dest=" + cacheDir, "--cache-from=type=local,src=" + cacheDir,
             buildDir));
 
         Mockito.verify(exec).process(Arrays.asList("docker", "--config", config, "buildx",
             "build", "--progress=plain", "--builder", builderName,
-            "--platform", "linux/amd64", "--tag", "example:latest",
+            "--platform", "linux/amd64", "--tag", "example:latest", "--build-arg", "foo=bar",
             "--load",
             "--cache-to=type=local,dest=" + cacheDir, "--cache-from=type=local,src=" + cacheDir,
             buildDir));

--- a/src/test/java/io/fabric8/maven/docker/MojoTestBase.java
+++ b/src/test/java/io/fabric8/maven/docker/MojoTestBase.java
@@ -121,6 +121,7 @@ abstract class MojoTestBase {
             .buildConfig(new BuildImageConfiguration.Builder()
                 .from("scratch")
                 .buildx(buildx)
+                .args(Collections.singletonMap("foo", "bar"))
                 .build())
             .build();
     }


### PR DESCRIPTION
According to the help-output of `docker buildx build --help`:

```
Usage:  docker buildx build [OPTIONS] PATH | URL | -
[...]
Options:
      --add-host strings              Add a custom host-to-IP mapping (format: "host:ip")
      --allow strings                 Allow extra privileged entitlement (e.g., "network.host", "security.insecure")
      --build-arg stringArray         Set build-time variables
[...]
```