### PR TITLE
Stop should respect docker.skip

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,11 @@
 # ChangeLog
 
-* **0.40-SNAPSHOT** :
+* **0.40.0-SNAPSHOT** :
+  - `docker:stop` should respect docker.skip even when `docker.executeStopOnVMShutdown` is set to `true` ([1561](https://github.com/fabric8io/docker-maven-plugin/pull/1561)) @doyleyoung
+  - Prevent concurrent access to secDispatcher during password decryption ([1533](https://github.com/fabric8io/docker-maven-plugin/pull/1533)) @joserebelo
+  - Support for `docker run --sysctl` parameters ([1530](https://github.com/fabric8io/docker-maven-plugin/issues/1530)) @jpraet
+  - Migrate to JUnit5 and Mockito for testing ([1550](https://github.com/fabric8io/docker-maven-plugin/pull/1550)) @chonton
+  - Multi-architecture images using buildx ([1502](https://github.com/fabric8io/docker-maven-plugin/issues/1502)) @chonton
 
 * **0.39.1** (2022-02-27):
   - determineFinalArgValue respect default value if key exists but value is null ([1528](https://github.com/fabric8io/docker-maven-plugin/issues/1528)) @twendelmuth

--- a/src/main/java/io/fabric8/maven/docker/StopMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StopMojo.java
@@ -72,6 +72,9 @@ public class StopMojo extends AbstractDockerMojo {
     @Parameter(property = "docker.stopNamePattern")
     String stopNamePattern;
 
+    @Parameter(property = "docker.skip", defaultValue = "false")
+    protected boolean skip;
+
     /**
      * If true, the containers are not stopped right away, but when the build is finished (success or failed).
      */
@@ -80,6 +83,10 @@ public class StopMojo extends AbstractDockerMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if(skip) {
+            return;
+        }
+
         if (this.executeStopOnVMShutdown) {
             this.executeStopOnVMShutdown = false;
            if (!invokedTogetherWithDockerStart()) {
@@ -109,6 +116,10 @@ public class StopMojo extends AbstractDockerMojo {
 
     @Override
     protected void executeInternal(ServiceHub hub) throws MojoExecutionException, IOException, ExecException {
+        if(skip) {
+            return;
+        }
+
         QueryService queryService = hub.getQueryService();
         RunService runService = hub.getRunService();
 

--- a/src/test/java/io/fabric8/maven/docker/StopMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/StopMojoTest.java
@@ -6,7 +6,9 @@ import java.util.Collections;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.apache.maven.plugin.MojoFailureException;
 
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.ExecException;
@@ -29,6 +31,30 @@ class StopMojoTest extends MojoTestBase {
 
     @Mock
     private Container runningInstance;
+
+    @Test
+    @DisplayName("Mock project with skipRun set no actions are performed.")
+    void respectDockerSkip() throws MojoExecutionException, ExecException, IOException {
+        givenMavenProject();
+        stopMojo.skip = true;
+
+        whenMojoExecutes();
+
+        thenNoContainerLookupByImageOccurs();
+        thenNoContainerIsStopped();
+    }
+
+    @Test
+    @DisplayName("Mock project with skip set then no actions performed on execute.")
+    void respectDockerSkipEvenIfExecuteCalled() throws MojoExecutionException, ExecException, IOException, MojoFailureException {
+        givenMavenProject();
+        stopMojo.skip = true;
+
+        stopMojo.execute();
+
+        thenNoContainerLookupByImageOccurs();
+        thenNoContainerIsStopped();
+    }
 
     /**
      * Mock project with no images, no containers are stopped.


### PR DESCRIPTION
When command line contains -Ddocker.skip and stop goal configuration contains \<executeStopOnVMShutdown>true\</executeStopOnVMShutdown> the following code still throws an error:

```
            if (!invokedTogetherWithDockerStart()) {
                throw new MojoExecutionException("docker:stop with executeStopOnVMShutdown is only possible if" +
                        " the docker containers started within the same maven session.");
            }
``` 

This execution should be skipped and there should not be an error.