### PR TITLE
Issue #1558: Multiple assemblies use the name "maven". Please assign each assembly a unique name. - using only single assembly

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -146,7 +146,7 @@ public class DockerAssemblyManager {
             throws MojoExecutionException {
 
         final BuildDirs buildDirs = createBuildDirs(imageName, params);
-        final List<AssemblyConfiguration> assemblyConfigurations = buildConfig.getAssemblyConfigurations();
+        final List<AssemblyConfiguration> assemblyConfigurations = buildConfig.getAllAssemblyConfigurations();
 
         final List<ArchiverCustomizer> archiveCustomizers = new ArrayList<>();
 
@@ -241,7 +241,7 @@ public class DockerAssemblyManager {
 
     // visible for testing
     void verifyGivenDockerfile(File dockerFile, BuildImageConfiguration buildConfig, FixedStringSearchInterpolator interpolator, Logger log) throws IOException {
-        List<AssemblyConfiguration> assemblyConfigs = buildConfig.getAssemblyConfigurations();
+        List<AssemblyConfiguration> assemblyConfigs = buildConfig.getAllAssemblyConfigurations();
         if (assemblyConfigs.isEmpty()) {
             return;
         }

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -13,13 +13,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nonnull;
+
+import org.apache.maven.plugins.annotations.Parameter;
 
 import io.fabric8.maven.docker.util.DeepCopy;
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.docker.util.MojoParameters;
-import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * @author roland
@@ -295,16 +297,21 @@ public class BuildImageConfiguration implements Serializable {
     }
 
     /**
-     * @deprecated Use {@link #getAssemblyConfigurations()} instead.
+     * @deprecated Use {@link #getAllAssemblyConfigurations()} instead.
      */
     @Deprecated
     public AssemblyConfiguration getAssemblyConfiguration() {
         return assembly;
     }
 
+
+    /**
+     * Use {@link #getAllAssemblyConfigurations()} unless you specifically want the configuration defined only by <code>assemblies</code>.
+     */
     @Nonnull
-    public List<AssemblyConfiguration> getAssemblyConfigurations() {
+    public List<AssemblyConfiguration> getAssembliesConfiguration() {
         final List<AssemblyConfiguration> assemblyConfigurations = new ArrayList<>();
+
         if (assemblies != null) {
             for (AssemblyConfiguration config : assemblies) {
                 if (config != null) {
@@ -312,9 +319,18 @@ public class BuildImageConfiguration implements Serializable {
                 }
             }
         }
+
+        return assemblyConfigurations;
+    }
+
+    @Nonnull
+    public List<AssemblyConfiguration> getAllAssemblyConfigurations() {
+        final List<AssemblyConfiguration> assemblyConfigurations = getAssembliesConfiguration();
+
         if (assembly != null) {
             assemblyConfigurations.add(assembly);
         }
+
         return assemblyConfigurations;
     }
 
@@ -762,7 +778,7 @@ public class BuildImageConfiguration implements Serializable {
     }
 
     private void ensureUniqueAssemblyNames(Logger log) {
-        List<AssemblyConfiguration> assemblyConfigurations = getAssemblyConfigurations();
+        List<AssemblyConfiguration> assemblyConfigurations = getAllAssemblyConfigurations();
         Set<String> assemblyNames = new HashSet<>();
         for (AssemblyConfiguration config : assemblyConfigurations) {
             String assemblyName = config.getName();
@@ -822,7 +838,7 @@ public class BuildImageConfiguration implements Serializable {
         // TODO: Remove the following deprecated handling section
         if (dockerArchive == null) {
             Optional<String> deprecatedDockerFileDir =
-                    getAssemblyConfigurations().stream()
+                    getAllAssemblyConfigurations().stream()
                             .map(AssemblyConfiguration::getDockerFileDir)
                             .filter(Objects::nonNull)
                             .findFirst();

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -26,6 +26,7 @@ public enum ConfigKey {
     ALIAS,
     ARGS(ValueCombinePolicy.Merge),
     ASSEMBLIES,
+    ASSEMBLY,
     ASSEMBLY_BASEDIR("assembly.baseDir"),
     ASSEMBLY_DESCRIPTOR("assembly.descriptor"),
     ASSEMBLY_DESCRIPTOR_REF("assembly.descriptorRef"),

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -153,7 +153,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .optimise(valueProvider.getBoolean(OPTIMISE, config.getOptimise()))
             .entryPoint(extractArguments(valueProvider, ENTRYPOINT, config.getEntryPoint()))
             .assembly(extractAssembly(config.getAssemblyConfiguration(), valueProvider))
-            .assemblies(extractAssemblies(config.getAssemblyConfigurations(), valueProvider))
+            .assemblies(extractAssemblies(config.getAssembliesConfiguration(), valueProvider))
             .env(CollectionUtils.mergeMaps(
                 valueProvider.getMap(ENV_BUILD, config.getEnv()),
                 valueProvider.getMap(ENV, Collections.emptyMap())
@@ -275,6 +275,12 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
 
     @SuppressWarnings("deprecation")
     private AssemblyConfiguration extractAssembly(AssemblyConfiguration config, ValueProvider valueProvider) {
+        Map<String, String> assemblyProperties = valueProvider.getMap(ASSEMBLY, Collections.emptyMap());
+
+        if (assemblyProperties == null || assemblyProperties.isEmpty()) {
+            return config;
+        }
+
         if (config == null) {
             config = new AssemblyConfiguration();
         }

--- a/src/main/java/io/fabric8/maven/docker/service/ArchiveService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/ArchiveService.java
@@ -105,7 +105,7 @@ public class ArchiveService {
 
         String name = imageConfig.getName();
         try {
-            List<AssemblyConfiguration> assemblyConfigurations = imageConfig.getBuildConfiguration().getAssemblyConfigurations();
+            List<AssemblyConfiguration> assemblyConfigurations = imageConfig.getBuildConfiguration().getAllAssemblyConfigurations();
             AssemblyConfiguration assemblyConfig = assemblyConfigurations.stream().filter(a -> a.getName().equals(assemblyName)).findFirst().orElse(null);
 
             if (assemblyConfig == null) {

--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -419,7 +419,7 @@ public class BuildService {
         String fromImage;
         fromImage = buildConfig.getFrom();
         if (fromImage == null) {
-            List<AssemblyConfiguration> assemblyConfig = buildConfig.getAssemblyConfigurations();
+            List<AssemblyConfiguration> assemblyConfig = buildConfig.getAllAssemblyConfigurations();
             if (assemblyConfig.isEmpty()) {
                 fromImage = DockerAssemblyManager.DEFAULT_DATA_BASE_IMAGE;
             }

--- a/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
@@ -59,7 +59,7 @@ public class JibBuildService {
 
             File dockerTarArchive = getAssemblyTarArchive(imageConfig, serviceHub, mojoParameters, log);
 
-            for (AssemblyConfiguration assemblyConfiguration : imageConfig.getBuildConfiguration().getAssemblyConfigurations()) {
+            for (AssemblyConfiguration assemblyConfiguration : imageConfig.getBuildConfiguration().getAllAssemblyConfigurations()) {
                 // TODO: Improve Assembly Manager so that the effective assemblyFileEntries computed can be properly shared
                 // the call to DockerAssemblyManager.getInstance().createDockerTarArchive should not be necessary,
                 // files should be added using the AssemblyFileEntry list. DockerAssemblyManager, should provide

--- a/src/main/java/io/fabric8/maven/docker/service/WatchService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WatchService.java
@@ -78,7 +78,7 @@ public class WatchService {
                 ArrayList<String> tasks = new ArrayList<>();
 
                 if (imageConfig.getBuildConfiguration() != null) {
-                    for (AssemblyConfiguration assemblyConfiguration : imageConfig.getBuildConfiguration().getAssemblyConfigurations()) {
+                    for (AssemblyConfiguration assemblyConfiguration : imageConfig.getBuildConfiguration().getAllAssemblyConfigurations()) {
                         if (watcher.isCopy()) {
                             String containerBaseDir = assemblyConfiguration.getTargetDir();
                             schedule(executor, createCopyWatchTask(watcher, assemblyConfiguration.getName(), context.getMojoParameters(), containerBaseDir), interval);

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyManagerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyManagerTest.java
@@ -31,7 +31,6 @@ import org.codehaus.plexus.components.io.resources.PlexusIoResource;
 import org.codehaus.plexus.interpolation.fixed.FixedStringSearchInterpolator;
 import org.codehaus.plexus.util.ReflectionUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -76,7 +75,7 @@ class DockerAssemblyManagerTest {
     @Test
     void testNoAssembly() {
         BuildImageConfiguration buildConfig = new BuildImageConfiguration();
-        List<AssemblyConfiguration> assemblyConfig = buildConfig.getAssemblyConfigurations();
+        List<AssemblyConfiguration> assemblyConfig = buildConfig.getAllAssemblyConfigurations();
 
         String content =
             assemblyManager.createDockerFileBuilder(
@@ -94,7 +93,7 @@ class DockerAssemblyManagerTest {
                 .build();
 
         DockerFileBuilder builder =
-            assemblyManager.createDockerFileBuilder(buildConfig, buildConfig.getAssemblyConfigurations());
+            assemblyManager.createDockerFileBuilder(buildConfig, buildConfig.getAllAssemblyConfigurations());
         String content = builder.content();
 
         Assertions.assertTrue(content.contains("SHELL [\"/bin/sh\",\"echo\",\"hello\"]"));
@@ -111,7 +110,7 @@ class DockerAssemblyManagerTest {
 
         BuildImageConfiguration buildConfig = createBuildConfig();
 
-        assemblyManager.getAssemblyFiles("testImage", buildConfig.getAssemblyConfigurations().get(0), mojoParams, new AnsiLogger(new SystemStreamLog(), true, "build"));
+        assemblyManager.getAssemblyFiles("testImage", buildConfig.getAllAssemblyConfigurations().get(0), mojoParams, new AnsiLogger(new SystemStreamLog(), true, "build"));
         Mockito.verify(assemblyArchiver).createArchive(Mockito.eq(assembly), Mockito.eq("maven"), Mockito.eq("track"), Mockito.any(DockerAssemblyConfigurationSource.class),
             Mockito.eq(false), Mockito.any());
     }
@@ -128,10 +127,10 @@ class DockerAssemblyManagerTest {
 
         BuildImageConfiguration buildConfig = createBuildConfigMultiAssembly();
 
-        AssemblyFiles files = assemblyManager.getAssemblyFiles("testImage", buildConfig.getAssemblyConfigurations().get(0), mojoParams,
+        AssemblyFiles files = assemblyManager.getAssemblyFiles("testImage", buildConfig.getAllAssemblyConfigurations().get(0), mojoParams,
             new AnsiLogger(new SystemStreamLog(), true, "build"));
         Assertions.assertNotNull(files);
-        files = assemblyManager.getAssemblyFiles("testImage", buildConfig.getAssemblyConfigurations().get(1), mojoParams, new AnsiLogger(new SystemStreamLog(), true, "build"));
+        files = assemblyManager.getAssemblyFiles("testImage", buildConfig.getAllAssemblyConfigurations().get(1), mojoParams, new AnsiLogger(new SystemStreamLog(), true, "build"));
         Assertions.assertNotNull(files);
     }
 

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -947,16 +947,6 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         validateRunConfiguration(resolved.getRunConfiguration());
     }
 
-    @Test
-    void testResolveAssembly() {
-
-    }
-
-    @Test
-    void testResolveAssembliesWithSingleAssembly() {
-
-    }
-
     @Override
     protected String getEnvPropertyFile() {
         return "/tmp/envProps.txt";

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -29,6 +29,8 @@ import io.fabric8.maven.docker.config.RunImageConfiguration;
 import io.fabric8.maven.docker.config.UlimitConfig;
 import io.fabric8.maven.docker.config.WaitConfiguration;
 import io.fabric8.maven.docker.config.handler.AbstractConfigHandlerTest;
+import io.fabric8.maven.docker.util.Logger;
+
 import org.apache.maven.plugins.assembly.model.Assembly;
 import org.apache.maven.plugins.assembly.model.DependencySet;
 import org.apache.maven.project.MavenProject;
@@ -658,8 +660,9 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
     void testAssembly() {
         List<ImageConfiguration> configs = resolveImage(imageConfiguration, props(getTestAssemblyData()));
         Assertions.assertEquals(1, configs.size());
+        configs.get(0).initAndValidate(ConfigHelper.NameFormatter.IDENTITY, null);
 
-        List<AssemblyConfiguration> assemblies = configs.get(0).getBuildConfiguration().getAssemblyConfigurations();
+        List<AssemblyConfiguration> assemblies = configs.get(0).getBuildConfiguration().getAllAssemblyConfigurations();
         Assertions.assertEquals(1, assemblies.size());
 
         AssemblyConfiguration config = assemblies.get(0);
@@ -673,8 +676,9 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
     void testMultipleAssemblies() {
         List<ImageConfiguration> configs = resolveImage(imageConfiguration, props(getTestMultipleAssemblyData()));
         Assertions.assertEquals(1, configs.size());
+        configs.get(0).initAndValidate(ConfigHelper.NameFormatter.IDENTITY, null);
 
-        List<AssemblyConfiguration> assemblies = configs.get(0).getBuildConfiguration().getAssemblyConfigurations();
+        List<AssemblyConfiguration> assemblies = configs.get(0).getBuildConfiguration().getAllAssemblyConfigurations();
         Assertions.assertEquals(2, assemblies.size());
 
         AssemblyConfiguration config = assemblies.get(0);
@@ -707,10 +711,13 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
         List<ImageConfiguration> configs = resolveImage(imageConfiguration, props(getTestAssemblyData()));
         Assertions.assertEquals(1, configs.size());
+        configs.get(0).initAndValidate(ConfigHelper.NameFormatter.IDENTITY, null);
 
-        AssemblyConfiguration config = configs.get(0).getBuildConfiguration().getAssemblyConfiguration();
-        Assertions.assertNotNull(config.getInline());
-        Assertions.assertEquals(1, config.getInline().getDependencySets().size());
+        List<AssemblyConfiguration> assemblyConfigurations = configs.get(0).getBuildConfiguration().getAllAssemblyConfigurations();
+        Assertions.assertEquals(1, assemblyConfigurations.size());
+        AssemblyConfiguration assemblyConfiguration = assemblyConfigurations.get(0);
+        Assertions.assertNotNull(assemblyConfiguration.getInline());
+        Assertions.assertEquals(1, assemblyConfiguration.getInline().getDependencySets().size());
     }
 
     @Test
@@ -940,6 +947,16 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         validateRunConfiguration(resolved.getRunConfiguration());
     }
 
+    @Test
+    void testResolveAssembly() {
+
+    }
+
+    @Test
+    void testResolveAssembliesWithSingleAssembly() {
+
+    }
+
     @Override
     protected String getEnvPropertyFile() {
         return "/tmp/envProps.txt";
@@ -1023,7 +1040,7 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
          * validate only the descriptor is required and defaults are all used, 'testAssembly' validates
          * all options can be set
          */
-        List<AssemblyConfiguration> assemblyConfigurations = buildConfig.getAssemblyConfigurations();
+        List<AssemblyConfiguration> assemblyConfigurations = buildConfig.getAllAssemblyConfigurations();
         Assertions.assertEquals(1, assemblyConfigurations.size());
 
         AssemblyConfiguration assemblyConfig = assemblyConfigurations.get(0);

--- a/src/test/java/io/fabric8/maven/docker/service/ArchiveServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/ArchiveServiceTest.java
@@ -1,0 +1,56 @@
+package io.fabric8.maven.docker.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.maven.plugins.assembly.model.Assembly;
+import org.apache.maven.plugins.assembly.model.FileItem;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.fabric8.maven.docker.assembly.AssemblyFiles;
+import io.fabric8.maven.docker.assembly.DockerAssemblyManager;
+import io.fabric8.maven.docker.config.AssemblyConfiguration;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.docker.util.MojoParameters;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveServiceTest {
+
+    @Mock
+    private DockerAssemblyManager dockerAssemblyManager;
+
+    @Mock
+    private Logger log;
+
+    private ArchiveService archiveService;
+
+    @BeforeEach
+    void setUp() {
+        archiveService = new ArchiveService(dockerAssemblyManager, null);
+    }
+
+    @Test
+    void testGetAssemblyFiles() throws Exception {
+        // ARRANGE
+        when(dockerAssemblyManager.getAssemblyFiles(any(), any(), any(), any())).thenReturn(mock(AssemblyFiles.class));
+        AssemblyConfiguration assemblyConfiguration = new AssemblyConfiguration();
+        BuildImageConfiguration build = new BuildImageConfiguration.Builder().assembly(assemblyConfiguration).build();
+        ImageConfiguration imageConfiguration = new ImageConfiguration.Builder().buildConfig(build).build();
+
+        // ACT
+        AssemblyFiles assemblyFiles = archiveService.getAssemblyFiles(imageConfiguration, assemblyConfiguration.getName(), mock(MojoParameters.class));
+
+        // ASSERT
+        Assertions.assertNotNull(assemblyFiles);
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/service/WatchServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/WatchServiceTest.java
@@ -1,0 +1,90 @@
+package io.fabric8.maven.docker.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockSettings;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.config.RunImageConfiguration;
+import io.fabric8.maven.docker.config.WatchImageConfiguration;
+import io.fabric8.maven.docker.config.WatchMode;
+import io.fabric8.maven.docker.model.Image;
+import io.fabric8.maven.docker.util.AnsiLogger;
+import io.fabric8.maven.docker.util.AuthConfigFactory;
+import io.fabric8.maven.docker.util.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class WatchServiceTest {
+    @Mock
+    private ArchiveService archiveService;
+    @Mock
+    private BuildService buildService;
+    @Mock
+    private DockerAccess dockerAccess;
+    @Mock
+    private MojoExecutionService mojoExecutionService;
+    @Mock
+    private QueryService queryService;
+    @Mock
+    private RunService runService;
+    @Mock
+    private Logger log;
+    private WatchService watchService;
+
+
+    @BeforeEach
+    void setUp() {
+        watchService = new WatchService(archiveService, buildService, dockerAccess, mojoExecutionService, queryService, runService, log);
+    }
+
+    @Test
+    void testWatchCallsGetAllAssemblyConfigurations() {
+        // ARRANGE
+        ImageConfiguration imageConfiguration = mock(ImageConfiguration.class);
+        BuildImageConfiguration buildImageConfiguration = mock(BuildImageConfiguration.class);
+        when(imageConfiguration.getBuildConfiguration()).thenReturn(buildImageConfiguration);
+        when(runService.getImagesConfigsInOrder(any(), any())).thenReturn(Collections.singletonList(imageConfiguration));
+
+        WatchService.WatchContext watchContext = mock(WatchService.WatchContext.class);
+        when(watchContext.getWatchMode()).thenReturn(WatchMode.none);
+        BuildService.BuildContext buildContext = mock(BuildService.BuildContext.class);
+        List<ImageConfiguration> imageConfigurations = Collections.emptyList();
+
+        // ACT
+        Executors.newSingleThreadExecutor().submit(() -> {
+            try {
+                watchService.watch(watchContext, buildContext, imageConfigurations);
+            } catch (Exception ignored) {}
+        });
+
+        // ASSERT
+        verify(buildImageConfiguration, timeout(10_000).times(1)).getAllAssemblyConfigurations();
+    }
+
+}


### PR DESCRIPTION
Fix #1558 

Fixes an issue #1558 where the way assemblies are gathered caused a singe inline configuration to be added twice and therefore causing incorrect error "Multiple assemblies use the name "maven". Please assign each assembly a unique name.".