### PR TITLE
Fix documentation anchor for multiarch builds

### DIFF
--- a/src/main/asciidoc/inc/_docker-build.adoc
+++ b/src/main/asciidoc/inc/_docker-build.adoc
@@ -33,7 +33,7 @@ include::build/_buildargs.adoc[]
 
 include::build/_healthcheck.adoc[]
 
-[[build-healthcheck]]
+[[build-buildx]]
 === Multi-Architecture Build
 
 include::build/_buildx.adoc[]


### PR DESCRIPTION
This fixes the "5.1.6. Multi-Architecture Build" link on https://dmp.fabric8.io/. Currently it's linking to the healthcheck section.