### PR TITLE
Avoid buffering and stream the response if the headers indicate it is JSON

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
   - Allow having build args with same name but different value in various sources, which are overriden in the order of precedence in resulting build args map ([1407](https://github.com/fabric8io/docker-maven-plugin/issues/1407)) @pavelsmolensky
   - Use double for `docker.cpus` property and interpret this value in the same way as Docker config option `--cpus` ([1609](https://github.com/fabric8io/docker-maven-plugin/pull/1609)) @vjuranek
   - NPE from Assembly plugin when POM packaging is used ([1146](https://github.com/fabric8io/docker-maven-plugin/issues/1146)) @slawekjaranowski
+  - Docker pulling progress only shown after pull has completed and not in real-time ([1598](https://github.com/fabric8io/docker-maven-plugin/issues/1598)) @causalnet
   - Bump `org.yaml:snakeyaml` to v1.32 ([1619](https://github.com/fabric8io/docker-maven-plugin/pull/1619)) @pen4
   - Bump `com.google.cloud.tools:jib-core` to v0.23.0 ([1620](https://github.com/fabric8io/docker-maven-plugin/pull/1620)) @pen4
   - Bump `com.google.guava:guava` to v31.1-jre @rohanKanojia

--- a/src/test/java/io/fabric8/maven/docker/access/hc/HcChunkedResponseHandlerWrapperTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/HcChunkedResponseHandlerWrapperTest.java
@@ -4,12 +4,15 @@ import io.fabric8.maven.docker.access.chunked.EntityStreamReaderUtil;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.entity.StringEntity;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.message.BasicHeader;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalMatchers;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -26,17 +29,26 @@ class HcChunkedResponseHandlerWrapperTest {
     private EntityStreamReaderUtil.JsonEntityResponseHandler handler;
     @Mock
     private HttpResponse response;
-    @Mock
-    private HttpEntity entity;
-    @Mock
-    private EntityStreamReaderUtil entityStreamReaderUtil;
+
+    private MockedStatic<EntityStreamReaderUtil> entityStreamReaderUtilMock;
 
     private Header[] headers;
     private HcChunkedResponseHandlerWrapper hcChunkedResponseHandlerWrapper;
+    private InputStream responseInputStream;
+    private HttpEntity entity;
 
     @BeforeEach
     void setUp() {
+        responseInputStream = new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8));
+        entity = new InputStreamEntity(responseInputStream);
         hcChunkedResponseHandlerWrapper = new HcChunkedResponseHandlerWrapper(handler);
+        entityStreamReaderUtilMock = Mockito.mockStatic(EntityStreamReaderUtil.class);
+        entityStreamReaderUtilMock.when(() -> EntityStreamReaderUtil.processJsonStream(Mockito.any(), Mockito.any())).thenCallRealMethod();
+    }
+
+    @AfterEach
+    void tearDown() {
+        entityStreamReaderUtilMock.close();
     }
 
     @Test
@@ -44,6 +56,7 @@ class HcChunkedResponseHandlerWrapperTest {
         givenResponseHeaders(new BasicHeader("ConTenT-Type", "application/json; charset=UTF-8"));
         hcChunkedResponseHandlerWrapper.handleResponse(response);
         verifyProcessJsonStream(1);
+        verifyResponseUnbuffered();
     }
 
     @Test
@@ -60,14 +73,25 @@ class HcChunkedResponseHandlerWrapperTest {
         // timesCalled is 1 here because without "Content-Type" handleResponse() tries to parse the body to
         // detect if it is JSON or not. See HcChunkedResponseHandlerWrapper.handleResponse() for more details.
         verifyProcessJsonStream(1);
+        verifyResponseBuffered();
     }
 
     private void givenResponseHeaders(Header... headers) throws IOException {
         Mockito.doReturn(headers).when(response).getAllHeaders();
-        Mockito.doReturn(new StringEntity("{}")).when(response).getEntity();
+        Mockito.doReturn(entity).when(response).getEntity();
     }
 
     private void verifyProcessJsonStream(int timesCalled) throws IOException {
         Mockito.verify(handler, Mockito.times(timesCalled)).stop();
+    }
+
+    // Response is unbuffered when processJsonStream() called on original stream
+    private void verifyResponseUnbuffered() {
+        entityStreamReaderUtilMock.verify(() -> EntityStreamReaderUtil.processJsonStream(Mockito.eq(handler), Mockito.eq(responseInputStream)));
+    }
+
+    // Response is buffered when processJsonStream() not called on original stream
+    private void verifyResponseBuffered() {
+        entityStreamReaderUtilMock.verify(() -> EntityStreamReaderUtil.processJsonStream(Mockito.eq(handler), AdditionalMatchers.not(Mockito.eq(responseInputStream))));
     }
 }


### PR DESCRIPTION
Fix https://github.com/fabric8io/docker-maven-plugin/issues/1598

Instead of always buffering the response, stream the response to the handler if the headers indicate it is definitely JSON.  Buffer like before if there are no content-type headers and the body needs to be checked.

This will allow pull progress to be displayed in real time for all situations where there is a JSON content type, which would be for the majority of cases.