### PR TITLE
Allow having build args with same name but different value in various sources, which are overridden in the order of precedence in resulting build args map

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 * **0.41-SNAPSHOT** :
   - image/squash option is taken into account when using buildx ([1605](https://github.com/fabric8io/docker-maven-plugin/pull/1605)) @kevinleturc
+  - Allow having build args with same name but different value in various sources, which are overriden in the order of precedence in resulting build args map ([1407](https://github.com/fabric8io/docker-maven-plugin/issues/1407)) @pavelsmolensky
 
 * **0.40.2** (2022-07-31):
   - Plugin doesn't abort building an image in case Podman is used and Dockerfile can't be processed ([1562](https://github.com/fabric8io/docker-maven-plugin/issues/1512)) @jh-cd 

--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -298,12 +298,15 @@ public class BuildService {
         Map<String, String> buildArgsFromProject = addBuildArgsFromProperties(buildContext.getMojoParameters().getProject().getProperties());
         Map<String, String> buildArgsFromSystem = addBuildArgsFromProperties(System.getProperties());
         Map<String, String> buildArgsFromDockerConfig = addBuildArgsFromDockerConfig();
-        return ImmutableMap.<String, String>builder()
-                .putAll(buildArgsFromDockerConfig)
-                .putAll(buildContext.getBuildArgs() != null ? buildContext.getBuildArgs() : Collections.<String, String>emptyMap())
-                .putAll(buildArgsFromProject)
-                .putAll(buildArgsFromSystem)
-                .build();
+
+        //merge build args from all the sources into one map. Different sources maps are allowed to contain duplicate keys between them
+        Map<String, String> mergedBuildArgs = new HashMap<>();
+        mergedBuildArgs.putAll(buildArgsFromDockerConfig);
+        mergedBuildArgs.putAll(buildContext.getBuildArgs() != null ? buildContext.getBuildArgs() : Collections.<String, String>emptyMap());
+        mergedBuildArgs.putAll(buildArgsFromProject);
+        mergedBuildArgs.putAll(buildArgsFromSystem);
+
+        return ImmutableMap.copyOf(mergedBuildArgs);
     }
 
     private Map<String, String> addBuildArgsFromProperties(Properties properties) {


### PR DESCRIPTION
Fixing https://github.com/fabric8io/docker-maven-plugin/issues/1407 

**Use case**: when the parent pom of a project contains
```
        <docker.buildArg.http_proxy>http://example.com<docker.buildArg.http_proxy>
``` 
and ~/.docker/config.json also contains `proxies.default.httpProxy` definition, docker-maven-plugin fails to build an image with "Multiple entries with same key" error. 
This PR solves it