### PR TITLE
Use the squash option from image configuration when building with buildx

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,6 @@
 # ChangeLog
 * **0.41-SNAPSHOT** :
+  - image/squash option is taken into account when using buildx ([1605](https://github.com/fabric8io/docker-maven-plugin/pull/1605)) @kevinleturc
 
 * **0.40.2** (2022-07-31):
   - Plugin doesn't abort building an image in case Podman is used and Dockerfile can't be processed ([1562](https://github.com/fabric8io/docker-maven-plugin/issues/1512)) @jh-cd 

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -135,6 +135,9 @@ public class BuildXService {
                 cmdLine.add(key + '=' + value);
             });
         }
+        if (buildConfiguration.squash()) {
+            cmdLine.add("--squash");
+        }
         if (extraParam != null) {
             cmdLine.add(extraParam);
         }

--- a/src/test/java/io/fabric8/maven/docker/MojoTestBase.java
+++ b/src/test/java/io/fabric8/maven/docker/MojoTestBase.java
@@ -123,6 +123,22 @@ abstract class MojoTestBase {
             .build();
     }
 
+    ImageConfiguration singleImageConfigurationWithBuildWithSquash(BuildXConfiguration buildx, String contextDir) {
+        BuildImageConfiguration buildImageConfiguration = new BuildImageConfiguration.Builder()
+                .from("scratch")
+                .buildx(buildx)
+                .args(Collections.singletonMap("foo", "bar"))
+                .contextDir(contextDir)
+                .squash(true)
+                .build();
+        buildImageConfiguration.initAndValidate(log);
+
+        return new Builder()
+                .name("example:latest")
+                .buildConfig(buildImageConfiguration)
+                .build();
+    }
+
     protected ImageConfiguration singleImageWithBuildWithTags(String... tags) {
         return new ImageConfiguration.Builder()
                 .name("example:latest")


### PR DESCRIPTION
I noticed that the _image/squash_ option is not passed honored when having also the buildx option to build our images for multiple architecture.

There's probably others options that is not honored, I will be happy to contribute them too in another PRs.
This PR is also a way for me to have initial feedback on the format & coding style before moving forward.

Let me know if it needs anything else.