### PR TITLE
Issue #1608: use double for docker.cpus property

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,7 @@
 * **0.41-SNAPSHOT** :
   - image/squash option is taken into account when using buildx ([1605](https://github.com/fabric8io/docker-maven-plugin/pull/1605)) @kevinleturc
   - Allow having build args with same name but different value in various sources, which are overriden in the order of precedence in resulting build args map ([1407](https://github.com/fabric8io/docker-maven-plugin/issues/1407)) @pavelsmolensky
+  - Use double for `docker.cpus` property and interpret this value in the same way as Docker config option `--cpus` ([1609](https://github.com/fabric8io/docker-maven-plugin/pull/1609)) @vjuranek
 
 * **0.40.2** (2022-07-31):
   - Plugin doesn't abort building an image in case Podman is used and Dockerfile can't be processed ([1562](https://github.com/fabric8io/docker-maven-plugin/issues/1512)) @jh-cd 

--- a/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
@@ -81,8 +81,8 @@ public class ContainerHostConfig {
         return add("CpuShares", cpuShares);
     }
 
-    public ContainerHostConfig cpus(Long cpus) {
-        return add ("NanoCpus", cpus);
+    public ContainerHostConfig cpus(Double cpus) {
+        return add ("NanoCpus", convertToNanoCpus(cpus));
     }
 
     public ContainerHostConfig cpuSet(String cpuSet) {
@@ -251,5 +251,12 @@ public class ContainerHostConfig {
             startConfig.addProperty(name, value);
         }
         return this;
+    }
+
+    private Long convertToNanoCpus(Double cpus){
+        if(cpus == null){
+            return null;
+        }
+        return (long)(cpus * 1_000_000_000);
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -123,7 +123,7 @@ public class RunImageConfiguration implements Serializable {
     private Long cpuShares;
 
     @Parameter
-    private Long cpus;
+    private Double cpus;
 
     @Parameter
     private String cpuSet;
@@ -282,7 +282,7 @@ public class RunImageConfiguration implements Serializable {
         return cpuShares;
     }
 
-    public Long getCpus() {
+    public Double getCpus() {
         return cpus;
     }
 
@@ -632,7 +632,7 @@ public class RunImageConfiguration implements Serializable {
             return this;
         }
 
-        public Builder cpus(Long cpus) {
+        public Builder cpus(Double cpus) {
             config.cpus = cpus;
             return this;
         }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -360,9 +360,8 @@ class DockerComposeServiceWrapper {
         return asLong("cpu_shares");
     }
 
-    public Long getCpusCount(){
-        Double cpus = asDouble("cpus");
-        return convertToNanoCpus(cpus);
+    public Double getCpusCount(){
+        return asDouble("cpus");
     }
 
     public List<String> getDevices() {
@@ -447,13 +446,6 @@ class DockerComposeServiceWrapper {
             map.put(parts[0], parts[1]);
         }
         return map;
-    }
-
-    private Long convertToNanoCpus(Double cpus){
-        if(cpus == null){
-            return null;
-        }
-        return (long)(cpus * 1000000000);
     }
 
     private void throwIllegalArgumentException(String msg) {

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -234,7 +234,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .tmpfs(valueProvider.getList(TMPFS, config.getTmpfs()))
             .isolation(valueProvider.getString(ISOLATION, config.getIsolation()))
             .cpuShares(valueProvider.getLong(CPUSHARES, config.getCpuShares()))
-            .cpus(valueProvider.getLong(CPUS, config.getCpus()))
+            .cpus(valueProvider.getDouble(CPUS, config.getCpus()))
             .cpuSet(valueProvider.getString(CPUSET, config.getCpuSet()))
             .readOnly(valueProvider.getBoolean(READ_ONLY, config.getReadOnly()))
             .autoRemove(valueProvider.getBoolean(AUTO_REMOVE, config.getAutoRemove()))

--- a/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
@@ -156,7 +156,7 @@ class DockerComposeConfigHandlerTest {
         Assertions.assertEquals((Long) 1L, runConfig.getMemory());
         Assertions.assertEquals((Long) 1L, runConfig.getMemorySwap());
         Assertions.assertEquals("0,1", runConfig.getCpuSet());
-        Assertions.assertEquals((Long) 1000000000L, runConfig.getCpus());
+        Assertions.assertEquals(1.5, runConfig.getCpus());
         Assertions.assertEquals("default", runConfig.getIsolation());
         Assertions.assertEquals((Long) 1L, runConfig.getCpuShares());
         Assertions.assertNull(runConfig.getEnvPropertyFile());

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -1071,7 +1071,7 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         Assertions.assertEquals(a("redis"), runConfig.getLinks());
         Assertions.assertEquals((Long) 1L, runConfig.getMemory());
         Assertions.assertEquals((Long) 1L, runConfig.getMemorySwap());
-        Assertions.assertEquals((Long) 1000000000L, runConfig.getCpus());
+        Assertions.assertEquals(1.5, runConfig.getCpus());
         Assertions.assertEquals("default", runConfig.getIsolation());
         Assertions.assertEquals((Long) 1L, runConfig.getCpuShares());
         Assertions.assertEquals("0,1", runConfig.getCpuSet());
@@ -1174,7 +1174,7 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
             k(ConfigKey.CAP_DROP) + ".1", "CAP",
             k(ConfigKey.SYSCTLS) + ".key", "value",
             k(ConfigKey.SECURITY_OPTS) + ".1", "seccomp=unconfined",
-            k(ConfigKey.CPUS), "1000000000",
+            k(ConfigKey.CPUS), "1.5",
             k(ConfigKey.CPUSET), "0,1",
             k(ConfigKey.ISOLATION), "default",
             k(ConfigKey.CPUSHARES), "1",

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -391,7 +391,7 @@ class RunServiceTest {
                 .shmSize(1024L)
                 .memory(1L)
                 .memorySwap(1L)
-                .cpus(1000000000L)
+                .cpus(1.5)
                 .cpuSet("0,1")
                 .isolation("default")
                 .cpuShares(1L)

--- a/src/test/resources/compose/docker-compose.yml
+++ b/src/test/resources/compose/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     isolation: default
     cpu_shares: 1
     cpuset: 0,1
-    cpus: 1
+    cpus: 1.5
     devices:
     - "/dev/device:/dev/device"
     dns: 8.8.8.8

--- a/src/test/resources/docker/containerCreateConfigAll.json
+++ b/src/test/resources/docker/containerCreateConfigAll.json
@@ -69,7 +69,7 @@
     ],
     "Isolation": "default",
     "CpuShares":1,
-    "NanoCpus": 1000000000,
+    "NanoCpus": 1500000000,
     "CpusetCpus":"0,1",
     "ReadonlyRootfs":false,    
     "AutoRemove":false,    

--- a/src/test/resources/docker/containerHostConfigAll.json
+++ b/src/test/resources/docker/containerHostConfigAll.json
@@ -49,7 +49,7 @@
   ],
   "Isolation": "default",
   "CpuShares":1,
-  "NanoCpus":1000000000,
+  "NanoCpus":1500000000,
   "CpusetCpus":"0,1",
   "ReadonlyRootfs":false,    
   "AutoRemove":false,    


### PR DESCRIPTION
Docker config option `--cpus` assumes float number, while current DMP `docker.cpus` assumes integer number, which is actually `NanoCpus`.

Change this property to `double` and convert it to `NanoCpus` before passing to Docker.

Signed-off-by: Vojtech Juranek <vojtech.juranek@gmail.com>

Fixes #1608