### PR TITLE
Required Maven version should be the same as used Maven - 3.3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
   </developers>
 
   <prerequisites>
-    <maven>3.0.3</maven>
+    <maven>${maven.version}</maven>
   </prerequisites>
 
   <scm>


### PR DESCRIPTION
Maven verify `prerequisites.maven` before executing plugin 
so when you set lower version that used in code
some incompatibility can occur on older Maven.

Signed-off-by: Slawomir Jaranowski <s.jaranowski@gmail.com>