### PR TITLE
Add flag for convert tcp to http

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/EnvUtil.java
@@ -43,7 +43,13 @@ public class EnvUtil {
 
     // Convert docker host URL to an HTTP(s) URL
     public static String convertTcpToHttpUrl(String connect) {
-        String protocol = connect.contains(":" + DOCKER_HTTP_PORT) ? "http:" : "https:";
+        String toHTTP = System.getenv("DOCKER_TCP_TO_HTTP");
+        String protocol;
+        if ("1".equals(toHTTP) || "true".equals(toHTTP)) {
+            protocol = "http:";
+        } else {
+            protocol = connect.contains(":" + DOCKER_HTTP_PORT) ? "http:" : "https:";
+        }
         return connect.replaceFirst("^tcp:", protocol);
     }
 


### PR DESCRIPTION
https://github.com/fabric8io/docker-maven-plugin/pull/1360 is a good idea, but this idea affects too many people, so this PR can help people switch to the HTTP protocol from the TCP protocol, the default to HTTPS protocol.