### PR TITLE
fix(sec): upgrade com.google.cloud.tools:jib-core to 0.22.0

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,9 @@
   - Allow having build args with same name but different value in various sources, which are overriden in the order of precedence in resulting build args map ([1407](https://github.com/fabric8io/docker-maven-plugin/issues/1407)) @pavelsmolensky
   - Use double for `docker.cpus` property and interpret this value in the same way as Docker config option `--cpus` ([1609](https://github.com/fabric8io/docker-maven-plugin/pull/1609)) @vjuranek
   - NPE from Assembly plugin when POM packaging is used ([1146](https://github.com/fabric8io/docker-maven-plugin/issues/1146)) @slawekjaranowski
+  - Bump `org.yaml:snakeyaml` to v1.32 ([1619](https://github.com/fabric8io/docker-maven-plugin/pull/1619)) @pen4
+  - Bump `com.google.cloud.tools:jib-core` to v0.23.0 ([1620](https://github.com/fabric8io/docker-maven-plugin/pull/1620)) @pen4
+  - Bump `com.google.guava:guava` to v31.1-jre @rohanKanojia
 
 * **0.40.2** (2022-07-31):
   - Plugin doesn't abort building an image in case Podman is used and Dockerfile can't be processed ([1562](https://github.com/fabric8io/docker-maven-plugin/issues/1512)) @jh-cd 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
   <properties>
     <byte-buddy.version>1.12.10</byte-buddy.version>
     <httpclient.version>4.5.13</httpclient.version>
-    <jib-core.version>0.18.0</jib-core.version>
+    <jib-core.version>0.22.0</jib-core.version>
     <jmockit.version>1.43</jmockit.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <maven.version>3.3.9</maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>30.1-jre</version>
+      <version>31.1-jre</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.cloud.tools:jib-core 0.18.0
- [CVE-2022-25914](https://www.oscs1024.com/hd/CVE-2022-25914)


### What did I do？
Upgrade com.google.cloud.tools:jib-core from 0.18.0 to 0.22.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>