### PR TITLE
fix: multi-arch build should use provided repository

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,6 @@
 # ChangeLog
 * **0.41-SNAPSHOT** :
+  - multi-arch build should use provided repository ([1597](https://github.com/fabric8io/docker-maven-plugin/issues/1597)) @merikan
 
 * **0.40.3** (2022-12-18):
   - image/squash option is taken into account when using buildx ([1605](https://github.com/fabric8io/docker-maven-plugin/pull/1605)) @kevinleturc

--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -102,7 +102,7 @@ public class BuildMojo extends AbstractBuildSupportMojo {
         File buildArchiveFile = buildService.buildArchive(imageConfig, buildContext, resolveBuildArchiveParameter());
         if (Boolean.FALSE.equals(shallBuildArchiveOnly())) {
             if (imageConfig.isBuildX()) {
-                hub.getBuildXService().build(createProjectPaths(), imageConfig, getAuthConfig(imageConfig), buildArchiveFile);
+                hub.getBuildXService().build(createProjectPaths(), imageConfig, null, getAuthConfig(imageConfig), buildArchiveFile);
             } else {
                 buildService.buildImage(imageConfig, pullManager, buildContext, buildArchiveFile);
                 if (!skipTag) {

--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -68,7 +68,7 @@ public class RegistryService {
 
             AuthConfig authConfig = createAuthConfig(true, imageName.getUser(), configuredRegistry, registryConfig);
             if (imageConfig.isBuildX()) {
-                buildXService.push(projectPaths, imageConfig, authConfig);
+                buildXService.push(projectPaths, imageConfig, configuredRegistry, authConfig);
             } else {
                 dockerPush(retries, skipTag, buildConfig, name, configuredRegistry, authConfig);
             }


### PR DESCRIPTION
`repository` should be used when pushing multi-arch images with buildx.

repository (config and docker.push.registry)was ignored when using buildx  and instead, the default Docker Hub was used and yielded the the following error `error: failed to solve: server message: insufficient_scope: authorization failed` 

Fixes #1597 #1593 

Signed-off-by: Peter Merikan <peter@merikan.com>