### PR TITLE
Allow overriding build network from properties

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 * **0.41-SNAPSHOT** :
   - multi-arch build should use provided repository ([1597](https://github.com/fabric8io/docker-maven-plugin/issues/1597)) @merikan
+  - new property docker.build.network to override the network for RUN directives for docker build ([1636](https://github.com/fabric8io/docker-maven-plugin/pull/1636)) @tulinkry
 
 * **0.40.3** (2022-12-18):
   - image/squash option is taken into account when using buildx ([1605](https://github.com/fabric8io/docker-maven-plugin/pull/1605)) @kevinleturc

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -70,6 +70,9 @@ when a `docker.from` or a `docker.fromExt` is set.
 | *docker.bind.idx*
 | Sets a list of paths to bind/expose in the container. See <<list-properties>>.
 
+| *docker.build.network.VARIABLE*
+| Set the networking mode for the RUN instructions during build
+
 | *docker.buildArg.VARIABLE*
 | Set a ARG to be available during build of image. *Note*: this is handled separately from external configuration, and is always available. See <<property-buildargs,Build Args>> for more details.
 

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -70,7 +70,7 @@ when a `docker.from` or a `docker.fromExt` is set.
 | *docker.bind.idx*
 | Sets a list of paths to bind/expose in the container. See <<list-properties>>.
 
-| *docker.build.network.VARIABLE*
+| *docker.build.network*
 | Set the networking mode for the RUN instructions during build
 
 | *docker.buildArg.VARIABLE*

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -99,6 +99,7 @@ public enum ConfigKey {
     NAME,
     NAMING_STRATEGY,
     NET,
+    BUILD_NETWORK("build.network")
     NETWORK_MODE("network.mode"),
     NETWORK_NAME("network.name"),
     NETWORK_ALIAS("network.alias"),

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -99,7 +99,7 @@ public enum ConfigKey {
     NAME,
     NAMING_STRATEGY,
     NET,
-    BUILD_NETWORK("build.network")
+    BUILD_NETWORK("build.network"),
     NETWORK_MODE("network.mode"),
     NETWORK_NAME("network.name"),
     NETWORK_ALIAS("network.alias"),

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -169,7 +169,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .volumes(valueProvider.getList(VOLUMES, config.getVolumes()))
             .tags(valueProvider.getList(TAGS, config.getTags()))
             .maintainer(valueProvider.getString(MAINTAINER, config.getMaintainer()))
-            .network(valueProvider.getString(NETWORK, config.getNetwork()))
+            .network(valueProvider.getString(BUILD_NETWORK, config.getNetwork()))
             .workdir(valueProvider.getString(WORKDIR, config.getWorkdir()))
             .skip(valueProvider.getBoolean(SKIP_BUILD, config.getSkip()))
             .skipPush(valueProvider.getBoolean(SKIP_PUSH, config.getSkipPush()))

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -169,6 +169,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .volumes(valueProvider.getList(VOLUMES, config.getVolumes()))
             .tags(valueProvider.getList(TAGS, config.getTags()))
             .maintainer(valueProvider.getString(MAINTAINER, config.getMaintainer()))
+            .network(valueProvider.getString(NETWORK, config.getNetwork()))
             .workdir(valueProvider.getString(WORKDIR, config.getWorkdir()))
             .skip(valueProvider.getBoolean(SKIP_BUILD, config.getSkip()))
             .skipPush(valueProvider.getBoolean(SKIP_PUSH, config.getSkipPush()))


### PR DESCRIPTION
The configuration of
```
<images>
  <image>
      <name>xx/%a:%l</name>
      <alias>xxxx</alias>
      <build>
          <dockerFile>${project.basedir}/Dockerfile</dockerFile>
          <network>host</network>
      </build>

      <external>
          <type>properties</type>
          <prefix>docker</prefix>
          <mode>override</mode>
      </external>
  </image>
</images>
```

simply does not propagate the network option further. When omitting "external" it works as expected. The network field is not resolved when external configuration resolution takes place.


Network field was introduced in https://github.com/fabric8io/docker-maven-plugin/pull/1288