### PR TITLE
#1658 Fallback to default docker driver to speed-up build time in buildx mode - useBuildxOnlyOnPush param

### DIFF
--- a/src/main/asciidoc/inc/build/_buildx.adoc
+++ b/src/main/asciidoc/inc/build/_buildx.adoc
@@ -4,6 +4,7 @@
 Buildx is enabled when there is a non-empty `<platform>` element inside the  `<buildx>` configuration.  Only the native platform
 is built and saved in the local image cache by the `build` goal.  All specified platforms are built and pushed into the remote
 repository by the `push` goal. This behavior is to prevent non-native images from tainting the local image cache.
+Alternatively, `useBuildxOnlyOnPush` can be set. This will force the plugin to use buildx only on push making local builds faster.
 
 The local image cache cannot hold multi-architecture images nor can it have two platform specific images of the same name. The
 recommended `<buildx>` configuration is to specify all supported platforms, including the native platform, in the `<platforms>`
@@ -38,6 +39,9 @@ is relative to the user's home directory.
 linux/arm64, darwin/amd64).  Each `<platform>` element may have a comma separated list of platforms.  Empty `<platform>`
 elements are ignored.  If no platform architecture is specified, buildx is *not* used.  You can use
 
+| *useBuildxOnlyOnPush*
+| Forces the plugin to use buildx only on push. This may speed up local development as buildx `--load` used to load built images
+to the local repository is relatively slow.
 |===
 
 .Examples

--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -101,7 +101,7 @@ public class BuildMojo extends AbstractBuildSupportMojo {
         BuildService buildService= hub.getBuildService();
         File buildArchiveFile = buildService.buildArchive(imageConfig, buildContext, resolveBuildArchiveParameter());
         if (Boolean.FALSE.equals(shallBuildArchiveOnly())) {
-            if (imageConfig.isBuildX()) {
+            if (imageConfig.isBuildX() && !imageConfig.getBuildConfiguration().getBuildX().useBuildxOnlyOnPush()) {
                 hub.getBuildXService().build(createProjectPaths(), imageConfig, null, getAuthConfig(imageConfig), buildArchiveFile);
             } else {
                 buildService.buildImage(imageConfig, pullManager, buildContext, buildArchiveFile);

--- a/src/main/java/io/fabric8/maven/docker/config/BuildXConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildXConfiguration.java
@@ -32,6 +32,14 @@ public class BuildXConfiguration implements Serializable {
     @Parameter
     private List<String> platforms;
 
+    /**
+     * Use buildx only on push phase.
+     * This will speed up the build overall as buildx will not
+     * be used to load the image locally
+     */
+    @Parameter(defaultValue = "false")
+    private boolean useBuildxOnlyOnPush;
+
     @Nonnull
     public List<String> getPlatforms() {
         return EnvUtil.splitAtCommasAndTrim(platforms);
@@ -53,6 +61,9 @@ public class BuildXConfiguration implements Serializable {
         return !getPlatforms().isEmpty();
     }
 
+    public boolean useBuildxOnlyOnPush() {
+        return useBuildxOnlyOnPush;
+    }
 
     public static class Builder {
 
@@ -92,6 +103,11 @@ public class BuildXConfiguration implements Serializable {
             if (!config.platforms.isEmpty()) {
                 isEmpty = false;
             }
+            return this;
+        }
+
+        public Builder useBuildxOnlyOnPush(boolean useBuildxOnlyOnPush) {
+            config.useBuildxOnlyOnPush = useBuildxOnlyOnPush;
             return this;
         }
     }

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -145,6 +145,17 @@ class BuildMojoTest extends MojoTestBase {
         thenBuildxRun(null, null, true, "--squash");
     }
 
+    @Test
+    void buildUsingBuildxOnPushOnly() throws IOException, MojoExecutionException {
+        givenMavenProject(buildMojo);
+        givenResolvedImages(buildMojo, Collections.singletonList(singleBuildXImageWithBuildxOnPush()));
+        givenPackaging("jar");
+
+        whenMojoExecutes();
+
+        Mockito.verifyNoInteractions(exec);
+    }
+
     private void givenBuildXService() {
         BuildXService buildXService = new BuildXService(dockerAccess, dockerAssemblyManager, log, exec);
 
@@ -228,6 +239,14 @@ class BuildMojoTest extends MojoTestBase {
 
     private ImageConfiguration singleBuildXImageWithSquash() {
         return singleImageConfigurationWithBuildWithSquash(getBuildXConfiguration(null, TWO_BUILDX_PLATFORMS), null);
+    }
+
+    private ImageConfiguration singleBuildXImageWithBuildxOnPush() {
+        return singleImageConfiguration(new BuildXConfiguration.Builder()
+                        .configFile(null)
+                        .platforms(Arrays.asList(TWO_BUILDX_PLATFORMS))
+                        .useBuildxOnlyOnPush(true)
+                        .build(), null);
     }
 
 }


### PR DESCRIPTION
Resolves #1658 by adding the `useBuildxOnlyOnPush` parameter,
 
```xml
<configuration>
  <images>
    <image>
      <name>example-image</name>
      <build>
        <buildx>
          <useBuildxOnlyOnPush>true</useBuildxOnlyOnPush>
          <platforms>
            ....
```
Adjusted the docu, see PR.
