### PR TITLE
Make `--config` from buildx command string generation optional

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.44-SNAPSHOT**:
+  - Make `--config` from buildx command string generation optional ([1673](https://github.com/fabric8io/docker-maven-plugin/pull/1673)) @robfrank
 
 * **0.43.1** (2023-07-28):
   - Resolve registry auth URL by registry ID ([1688](https://github.com/fabric8io/docker-maven-plugin/issues/1688)) @wajda

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -63,7 +63,7 @@ public class BuildXService {
         BuildDirs buildDirs = new BuildDirs(projectPaths, imageConfig.getName());
 
         Path configPath = getDockerStateDir(imageConfig.getBuildConfiguration(),  buildDirs);
-        List<String> buildX = Arrays.asList("docker", "--config", configPath.toString(), "buildx");
+        List<String> buildX = Arrays.asList("docker", "buildx");
 
         String builderName = createBuilder(configPath, buildX, imageConfig, buildDirs);
         Path configJson = configPath.resolve("config.json");
@@ -215,7 +215,7 @@ public class BuildXService {
         Path builderPath = configPath.resolve(Paths.get("buildx", "instances", builderName));
         if(Files.notExists(builderPath)) {
             List<String> cmds = new ArrayList<>(buildX);
-            append(cmds, "create", "--driver", "docker-container", "--name", builderName);
+            append(cmds, "create", "--driver", "docker-container", "--name", builderName, "--node", builderName + "0");
             String buildConfig = buildXConfiguration.getConfigFile();
             if(buildConfig != null) {
                 append(cmds, "--config",

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -63,7 +63,14 @@ public class BuildXService {
         BuildDirs buildDirs = new BuildDirs(projectPaths, imageConfig.getName());
 
         Path configPath = getDockerStateDir(imageConfig.getBuildConfiguration(),  buildDirs);
-        List<String> buildX = Arrays.asList("docker", "buildx");
+        File[] configDirFiles = configPath.toFile().listFiles();
+        List<String> buildX = new ArrayList<>();
+        buildX.add("docker");
+        if (configDirFiles != null && configDirFiles.length > 0) {
+            buildX.add("--config");
+            buildX.add(configPath.toString());
+        }
+        buildX.add("buildx");
 
         String builderName = createBuilder(configPath, buildX, imageConfig, buildDirs);
         Path configJson = configPath.resolve("config.json");

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -295,15 +295,15 @@ class BuildMojoTest extends MojoTestBase {
         String configFile = relativeConfigFile != null ? getOsDependentBuild(projectBaseDirectory.toPath(), relativeConfigFile) : null;
 
         List<String> cmds =
-            BuildXService.append(new ArrayList<>(), "docker", "--config", config, "buildx",
-                "create", "--driver", "docker-container", "--name", "maven");
+            BuildXService.append(new ArrayList<>(), "docker",  "buildx",
+                "create", "--driver", "docker-container", "--name", "maven" , "--node", "maven0");
         if (configFile != null) {
             BuildXService.append(cmds, "--config", configFile.replace('/', File.separatorChar));
         }
         Mockito.verify(exec).process(cmds);
 
         if (nativePlatformIncluded) {
-            List<String> buildXLine = BuildXService.append(new ArrayList<>(), "docker", "--config", config, "buildx",
+            List<String> buildXLine = BuildXService.append(new ArrayList<>(), "docker",  "buildx",
                     "build", "--progress=plain", "--builder", "maven",
                     "--platform", NATIVE_PLATFORM, "--tag", "example:latest", "--build-arg", "foo=bar");
 

--- a/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
@@ -437,11 +437,11 @@ class RegistryServiceTest {
         String builderName = providedBuilder != null ? providedBuilder : "maven";
 
         if (providedBuilder == null) {
-            Mockito.verify(exec).process(Arrays.asList("docker", "--config", config, "buildx", "create", "--driver", "docker-container", "--name", builderName));
+            Mockito.verify(exec).process(Arrays.asList("docker", "buildx", "create", "--driver", "docker-container", "--name", builderName, "--node",  builderName+"0"));
         }
 
         List<String> cmds =
-            BuildXService.append(new ArrayList<>(), "docker", "--config", config, "buildx", "build",
+            BuildXService.append(new ArrayList<>(), "docker", "buildx", "build",
                 "--progress=plain", "--builder", builderName, "--platform",
                 "linux/amd64,linux/arm64", "--tag",
                 new ImageName(imageConfiguration.getName()).getFullName(registry));


### PR DESCRIPTION
As per this comment: 

https://github.com/fabric8io/docker-maven-plugin/issues/1583#issuecomment-1537097053

removing the "--config" let the sample project "multi-architecture" to build fine