### PR TITLE
GH-1527 allow 'host-gateway' as non-resolvable hostname in extraHosts

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,7 @@
 # ChangeLog
 * **0.44-SNAPSHOT**:
+  - Resolve registry auth URL by registry ID ([1688](https://github.com/fabric8io/docker-maven-plugin/issues/1688)) @wajda
+  - Allow 'host-gateway' as non-resolvable hostname in extraHosts ([1527](https://github.com/fabric8io/docker-maven-plugin/issues/1527)) @azaaiman
 
 * **0.43.0** (2023-05-20):
   - Make buildx build single non-native platform if requested ([1665](https://github.com/fabric8io/docker-maven-plugin/pull/1665)) @martyvona

--- a/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
@@ -16,6 +16,7 @@ import io.fabric8.maven.docker.util.JsonFactory;
 
 public class ContainerHostConfig {
 
+    private static final String HOST_GATEWAY = "host-gateway";
     final JsonObject startConfig = new JsonObject();
 
     public ContainerHostConfig() {}
@@ -98,11 +99,7 @@ public class ContainerHostConfig {
                     throw new IllegalArgumentException("extraHosts must be in the form <host:host|ip>");
                 }
 
-                try {
-                    mapped.add(i, parts[0] + ":" + InetAddress.getByName(parts[1]).getHostAddress());
-                } catch (UnknownHostException e) {
-                    throw new IllegalArgumentException("unable to resolve ip address for " + parts[1], e);
-                }
+                mapped.add(i, parts[0] + ":" + resolveHostAddress(parts[1]));
             }
             return addAsArray("ExtraHosts", mapped);
         }
@@ -230,6 +227,17 @@ public class ContainerHostConfig {
             startConfig.add(propKey, JsonFactory.newJsonArray(props));
         }
         return this;
+    }
+
+    private String resolveHostAddress(String host) {
+        if (HOST_GATEWAY.equalsIgnoreCase(host)) {
+            return host;
+        }
+        try {
+            return InetAddress.getByName(host).getHostAddress();
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("unable to resolve ip address for " + host, e);
+        }
     }
 
     private ContainerHostConfig add(String name, String value) {

--- a/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
@@ -41,6 +41,14 @@ class ContainerHostConfigTest {
     }
 
     @Test
+    void testExtraHostsAcceptsHostGateway() {
+        ContainerHostConfig hc = new ContainerHostConfig();
+        hc.extraHosts(Collections.singletonList("host.docker.internal:host-gateway"));
+
+        Assertions.assertEquals("{\"ExtraHosts\":[\"host.docker.internal:host-gateway\"]}", hc.toJson());
+    }
+
+    @Test
     void testUlimits() {
         Object data[] = {
             "{Ulimits: [{Name:bla, Hard:2048, Soft: 1024}]}", "bla", 2048, 1024,


### PR DESCRIPTION
Fixes #1527

On macOS and Windows docker provides out-of-the-box an alias `host.docker.internal`, however not on Linux.
`host.docker.internal` is easy in case a running container needs to talk back to a TCP/UDP socket on the docker host.
Since docker 20.10.x they have added the ability to add an extra host using a magic hostname `host-gateway`.

This PR detects this, and does not attempt to resolve the hostname, but passes it on to docker.

This also works on macOS and Windows, and gives even the opportunity to use another alias, instead of `host.docker.internal`.