### PR TITLE
Fix unauthorized error with buildx needing multiple credentials

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/AuthConfig.java
@@ -106,13 +106,17 @@ public class AuthConfig {
     }
 
     public String toJson() {
+        return toJsonObject().toString();
+    }
+
+    public JsonObject toJsonObject() {
         JsonObject creds = new JsonObject();
         creds.addProperty("auth", encodeBase64(username + ":" + password));
         JsonObject auths = new JsonObject();
         auths.add(registry != null ? registry : "https://index.docker.io/v1/", creds);
         JsonObject root = new JsonObject();
         root.add("auths", auths);
-        return root.toString();
+        return root;
     }
 
     // ======================================================================================================

--- a/src/main/java/io/fabric8/maven/docker/access/AuthConfigList.java
+++ b/src/main/java/io/fabric8/maven/docker/access/AuthConfigList.java
@@ -1,0 +1,46 @@
+package io.fabric8.maven.docker.access;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Container for multiple {@link AuthConfig} objects
+ */
+public class AuthConfigList {
+    private final List<AuthConfig> authConfigs;
+
+    public AuthConfigList() {
+        authConfigs = new ArrayList<>();
+    }
+
+    public AuthConfigList(AuthConfig authConfig) {
+        this();
+        authConfigs.add(authConfig);
+    }
+
+    public void addAuthConfig(AuthConfig authConfig) {
+        Objects.requireNonNull(authConfig);
+        authConfigs.add(authConfig);
+    }
+
+    public String toJson() {
+        JsonObject auths = new JsonObject();
+        for (AuthConfig authConfig: authConfigs) {
+            JsonObject auth = authConfig.toJsonObject().getAsJsonObject("auths");
+            for (Map.Entry<String, JsonElement> entry : auth.entrySet()) {
+                auths.add(entry.getKey(), entry.getValue());
+            }
+        }
+        JsonObject root = new JsonObject();
+        if (auths.size() > 0) {
+            root.add("auths", auths);
+        }
+
+        return root.toString();
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -1,6 +1,6 @@
 package io.fabric8.maven.docker.service;
 
-import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.access.AuthConfigList;
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.assembly.BuildDirs;
 import io.fabric8.maven.docker.assembly.DockerAssemblyManager;
@@ -49,17 +49,17 @@ public class BuildXService {
         this.exec = exec;
     }
 
-    public void build(ProjectPaths projectPaths, ImageConfiguration imageConfig, String  configuredRegistry, AuthConfig authConfig, File buildArchive) throws MojoExecutionException {
+    public void build(ProjectPaths projectPaths, ImageConfiguration imageConfig, String  configuredRegistry, AuthConfigList authConfig, File buildArchive) throws MojoExecutionException {
         useBuilder(projectPaths, imageConfig,  configuredRegistry, authConfig, buildArchive, this::buildAndLoadSinglePlatform);
     }
 
-    public void push(ProjectPaths projectPaths, ImageConfiguration imageConfig, String configuredRegistry, AuthConfig authConfig) throws MojoExecutionException {
+    public void push(ProjectPaths projectPaths, ImageConfiguration imageConfig, String configuredRegistry, AuthConfigList authConfig) throws MojoExecutionException {
         BuildDirs buildDirs = new BuildDirs(projectPaths, imageConfig.getName());
         File archive = new File(buildDirs.getTemporaryRootDirectory(), "docker-build.tar");
         useBuilder(projectPaths, imageConfig, configuredRegistry, authConfig, archive, this::pushMultiPlatform);
     }
 
-    protected <C> void useBuilder(ProjectPaths projectPaths, ImageConfiguration imageConfig, String configuredRegistry, AuthConfig authConfig, C context, Builder<C> builder) throws MojoExecutionException {
+    protected <C> void useBuilder(ProjectPaths projectPaths, ImageConfiguration imageConfig, String configuredRegistry, AuthConfigList authConfig, C context, Builder<C> builder) throws MojoExecutionException {
         BuildDirs buildDirs = new BuildDirs(projectPaths, imageConfig.getName());
 
         Path configPath = getDockerStateDir(imageConfig.getBuildConfiguration(),  buildDirs);
@@ -75,7 +75,7 @@ public class BuildXService {
         }
     }
 
-    protected void createConfigJson(Path configJson, AuthConfig authConfig) throws MojoExecutionException {
+    protected void createConfigJson(Path configJson, AuthConfigList authConfig) throws MojoExecutionException {
         try (BufferedWriter bufferedWriter = Files.newBufferedWriter(configJson, StandardCharsets.UTF_8,
             StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
         ) {

--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.access.AuthConfigList;
 import io.fabric8.maven.docker.access.CreateImageOptions;
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.DockerAccessException;
@@ -68,7 +69,7 @@ public class RegistryService {
 
             AuthConfig authConfig = createAuthConfig(true, imageName.getUser(), configuredRegistry, registryConfig);
             if (imageConfig.isBuildX()) {
-                buildXService.push(projectPaths, imageConfig, configuredRegistry, authConfig);
+                buildXService.push(projectPaths, imageConfig, configuredRegistry, new AuthConfigList(authConfig));
             } else {
                 dockerPush(retries, skipTag, buildConfig, name, configuredRegistry, authConfig);
             }

--- a/src/test/java/io/fabric8/maven/docker/MojoTestBase.java
+++ b/src/test/java/io/fabric8/maven/docker/MojoTestBase.java
@@ -17,6 +17,7 @@ import io.fabric8.maven.docker.service.ServiceHub;
 import io.fabric8.maven.docker.util.AnsiLogger;
 import io.fabric8.maven.docker.util.AuthConfigFactory;
 import io.fabric8.maven.docker.util.GavLabel;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.monitor.logging.DefaultLog;
 import org.apache.maven.project.MavenProject;
@@ -81,6 +82,9 @@ abstract class MojoTestBase {
 
     @Mock
     protected AuthConfigFactory authConfigFactory;
+
+    @Mock
+    protected MavenSession session;
 
     protected String projectGroupId;
     protected String projectArtifactId;
@@ -240,6 +244,7 @@ abstract class MojoTestBase {
         mojo.log = ansiLogger;
         mojo.outputDirectory= "target/docker";
         mojo.authConfigFactory= authConfigFactory;
+        mojo.session = session;
 
         mojo.setPluginContext(new HashMap<>());
         mojo.getPluginContext().put(CONTEXT_KEY_LOG_DISPATCHER, logDispatcher);

--- a/src/test/java/io/fabric8/maven/docker/access/AuthConfigListTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/AuthConfigListTest.java
@@ -1,0 +1,60 @@
+package io.fabric8.maven.docker.access;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthConfigListTest {
+    @Test
+    void simpleConstructor() {
+        AuthConfig config = getAuthConfig();
+        AuthConfigList authConfigList = new AuthConfigList(config);
+
+        assertEquals(config.toJson(), authConfigList.toJson());
+    }
+
+    @Test
+    void emptyList() {
+        AuthConfigList authConfigList = new AuthConfigList();
+
+        assertEquals("{}", authConfigList.toJson());
+    }
+
+    @Test
+    void addingToList() {
+        AuthConfig config = getAuthConfig();
+
+        AuthConfigList authConfigList = new AuthConfigList();
+        authConfigList.addAuthConfig(config);
+
+        assertEquals(config.toJson(), authConfigList.toJson());
+    }
+
+    @Test
+    void multipleRegistries() {
+        AuthConfig config1 = getAuthConfig();
+        AuthConfig config2 = getAuthConfig();
+
+        config1.setRegistry("registry-one.org");
+        config2.setRegistry("registry-two.org");
+
+        AuthConfigList authConfigList = new AuthConfigList();
+        authConfigList.addAuthConfig(config1);
+        authConfigList.addAuthConfig(config2);
+
+        assertTrue(authConfigList.toJson().contains("registry-one.org"));
+        assertTrue(authConfigList.toJson().contains("registry-two.org"));
+    }
+
+    private AuthConfig getAuthConfig() {
+        Map<String,String> map = new HashMap<>();
+        map.put(AuthConfig.AUTH_USERNAME,"username");
+        map.put(AuthConfig.AUTH_PASSWORD,"#>secrets??");
+        map.put(AuthConfig.AUTH_EMAIL,"username@email.org");
+        return new AuthConfig(map);
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/assembly/TrackArchiverCollectionTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/TrackArchiverCollectionTest.java
@@ -52,6 +52,7 @@ class TrackArchiverCollectionTest {
         Assertions.assertNotNull(files);
         List<AssemblyFiles.Entry> entries = files.getUpdatedEntriesAndRefresh();
         Assertions.assertEquals(0, entries.size());
+        Thread.sleep(1000); // Wait before touching the file so the modified time is different
         FileUtils.touch(tempFile);
         entries = files.getUpdatedEntriesAndRefresh();
         Assertions.assertEquals(1, entries.size());
@@ -64,6 +65,7 @@ class TrackArchiverCollectionTest {
         Assertions.assertNotNull(deps);
         entries = deps.getUpdatedEntriesAndRefresh();
         Assertions.assertEquals(0, entries.size());
+        Thread.sleep(1000); // Wait before touching the file so the modified time is different
         FileUtils.touch(tempFile2);
         entries = deps.getUpdatedEntriesAndRefresh();
         Assertions.assertEquals(1, entries.size());

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
@@ -20,7 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 
 import io.fabric8.maven.docker.access.DockerAccess;
-import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.access.AuthConfigList;
 import io.fabric8.maven.docker.assembly.DockerAssemblyManager;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.docker.util.ProjectPaths;
@@ -57,7 +57,7 @@ class BuildXServiceTest {
     private final ProjectPaths projectPaths = new ProjectPaths(new File("project-base-dir"), "output-dir");
     private final String configuredRegistry = "configured-registry";
     private final File buildArchive = new File("build-archive");
-    private final AuthConfig authConfig = null;
+    private final AuthConfigList authConfig = null;
 
     @BeforeEach
     void setup() throws Exception {

--- a/src/test/resources/docker/Dockerfile.custom_registry.test
+++ b/src/test/resources/docker/Dockerfile.custom_registry.test
@@ -1,0 +1,12 @@
+FROM custom-registry.org/library/image
+MAINTAINER maintainer@example.com
+ENV foo=bar
+LABEL com.acme.foobar="How are \"you\" ?"
+EXPOSE 8080
+COPY /src /export/dest
+WORKDIR /tmp
+SHELL ["/bin/sh","-c"]
+RUN echo something
+RUN echo second
+VOLUME ["/vol1"]
+CMD ["c1","c2"]


### PR DESCRIPTION
This addresses a `401 Unauthorized` error when building for multi-platform and multiple credentials are needed for different registries. For example, if the image name is `registry-one.org/library/example` and the base (`FROM`) image is in another registry (e.g. `registry-two.org`), two credentials are needed: one for each registry.

I believe this would also fix https://github.com/fabric8io/docker-maven-plugin/issues/1583 .

