### PR TITLE
fix (buildx) : Do not use `--config` when registry credentials from local docker config

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.44-SNAPSHOT** :
+  - Only add `--config` to buildx command string when authentication credentials are coming from outside sources
 
 * **0.43.2** (2023-07-29):
   - Make `--config` from buildx command string generation optional ([1673](https://github.com/fabric8io/docker-maven-plugin/pull/1673)) @robfrank

--- a/it/buildx-push/Dockerfile
+++ b/it/buildx-push/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+
+EXPOSE 8080
+USER 1001

--- a/it/buildx-push/pom.xml
+++ b/it/buildx-push/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.44-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>dmp-it-buildx-push</artifactId>
+  <properties>
+    <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <images>
+            <image>
+              <name>ttl.sh/%a:1h</name>
+              <build>
+                <dockerFileDir>${project.basedir}</dockerFileDir>
+                <buildx>
+                  <platforms>
+                    <platform>${docker.platforms}</platform>
+                  </platforms>
+                  <attestations>
+                    <provenance>false</provenance>
+                  </attestations>
+                </buildx>
+              </build>
+            </image>
+          </images>
+        </configuration>
+        <executions>
+          <execution>
+            <id>docker-build</id>
+            <goals>
+              <goal>build</goal>
+              <goal>push</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -25,6 +25,7 @@
     <module>buildx-contextdir</module>
     <module>buildx-dependencyset</module>
     <module>buildx-dockerfile</module>
+    <module>buildx-push</module>
     <module>docker-compose</module>
     <module>dockerfile</module>
     <module>dockerignore</module>

--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -29,6 +29,7 @@ import io.fabric8.maven.docker.util.ImageName;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.MojoParameters;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -139,12 +140,14 @@ public class BuildMojo extends AbstractBuildSupportMojo {
         BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
         Set<String> fromRegistries = getRegistriesForPull(buildConfig);
         for (String fromRegistry : fromRegistries) {
-            if (configuredRegistry.equalsIgnoreCase(fromRegistry)) {
+            if (StringUtils.isNotBlank(configuredRegistry) && configuredRegistry.equalsIgnoreCase(fromRegistry)) {
                 continue;
             }
             registryConfig = getRegistryConfig(fromRegistry);
             AuthConfig additionalAuth = registryConfig.createAuthConfig(false, imageName.getUser(), fromRegistry);
-            authConfigList.addAuthConfig(additionalAuth);
+            if (additionalAuth != null) {
+                authConfigList.addAuthConfig(additionalAuth);
+            }
         }
 
         return authConfigList;

--- a/src/main/java/io/fabric8/maven/docker/access/AuthConfigList.java
+++ b/src/main/java/io/fabric8/maven/docker/access/AuthConfigList.java
@@ -20,7 +20,9 @@ public class AuthConfigList {
 
     public AuthConfigList(AuthConfig authConfig) {
         this();
-        authConfigs.add(authConfig);
+        if (authConfig != null) {
+            authConfigs.add(authConfig);
+        }
     }
 
     public void addAuthConfig(AuthConfig authConfig) {
@@ -42,5 +44,13 @@ public class AuthConfigList {
         }
 
         return root.toString();
+    }
+
+    public boolean isEmpty() {
+        return authConfigs.isEmpty();
+    }
+
+    public int size() {
+        return authConfigs.size();
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static io.fabric8.maven.docker.util.AuthConfigFactory.hasAuthForRegistryInDockerConfig;
+
 public class BuildXService {
     private final DockerAccess dockerAccess;
     private final DockerAssemblyManager dockerAssemblyManager;
@@ -63,10 +65,10 @@ public class BuildXService {
         BuildDirs buildDirs = new BuildDirs(projectPaths, imageConfig.getName());
 
         Path configPath = getDockerStateDir(imageConfig.getBuildConfiguration(),  buildDirs);
-        File[] configDirFiles = configPath.toFile().listFiles();
         List<String> buildX = new ArrayList<>();
         buildX.add("docker");
-        if (configDirFiles != null && configDirFiles.length > 0) {
+        if (authConfig != null && !authConfig.isEmpty() &&
+            !hasAuthForRegistryInDockerConfig(logger, configuredRegistry, authConfig)) {
             buildX.add("--config");
             buildX.add(configPath.toString());
         }

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -291,7 +291,6 @@ class BuildMojoTest extends MojoTestBase {
     private void thenBuildxRun(String relativeConfigFile, String contextDir,
         boolean nativePlatformIncluded, String attestation) throws MojoExecutionException {
         Path buildPath = projectBaseDirectory.toPath().resolve("target/docker/example/latest");
-        String config = getOsDependentBuild(buildPath, "docker");
         String configFile = relativeConfigFile != null ? getOsDependentBuild(projectBaseDirectory.toPath(), relativeConfigFile) : null;
 
         List<String> cmds =

--- a/src/test/java/io/fabric8/maven/docker/PushMojoBuildXTest.java
+++ b/src/test/java/io/fabric8/maven/docker/PushMojoBuildXTest.java
@@ -1,0 +1,210 @@
+package io.fabric8.maven.docker;
+
+import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.BuildXConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.config.handler.ImageConfigResolver;
+import io.fabric8.maven.docker.service.BuildXService;
+import io.fabric8.maven.docker.service.DockerAccessFactory;
+import io.fabric8.maven.docker.service.ServiceHubFactory;
+import io.fabric8.maven.docker.util.AuthConfigFactory;
+import io.fabric8.maven.docker.util.DockerFileUtil;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PushMojoBuildXTest {
+  private PushMojo pushMojo;
+  @TempDir
+  private File temporaryFolder;
+
+  private Path expectedDockerStateDir;
+  private File expectedDockerStateConfigDir;
+  private Settings mockedMavenSettings;
+  private MockedConstruction<BuildXService.DefaultExec> defaultExecMockedConstruction;
+
+  @BeforeEach
+  void setup() throws MojoExecutionException, MojoFailureException, IOException, ComponentLookupException, SecDispatcherException {
+    mockedMavenSettings = mock(Settings.class);
+    MavenProject mavenProject = mock(MavenProject.class, RETURNS_DEEP_STUBS);
+    DockerAccessFactory dockerAccessFactory = mock(DockerAccessFactory.class);
+    DockerAccess dockerAccess = mock(DockerAccess.class);
+    PlexusContainer mockedPlexusContainer = mock(PlexusContainer.class);
+    SecDispatcher mockedSecDispatcher = mock(SecDispatcher.class);
+    ServiceHubFactory serviceHubFactory = new ServiceHubFactory();
+    when(mockedMavenSettings.getInteractiveMode()).thenReturn(false);
+    Properties properties = new Properties();
+    when(mavenProject.getProperties()).thenReturn(properties);
+    File targetDir = temporaryFolder.toPath().resolve("target").toFile();
+    expectedDockerStateDir = targetDir.toPath().resolve("docker")
+        .resolve("test.example.org").resolve("testuser").resolve("sample-test-image")
+        .resolve("latest");
+    expectedDockerStateConfigDir = expectedDockerStateDir.resolve("docker").toFile();
+    Files.createDirectory(targetDir.toPath());
+    when(mavenProject.getBuild().getDirectory()).thenReturn(targetDir.getAbsolutePath());
+    when(mavenProject.getBuild().getOutputDirectory()).thenReturn(targetDir.getAbsolutePath());
+    when(mavenProject.getBasedir()).thenReturn(temporaryFolder);
+    when(dockerAccessFactory.createDockerAccess(any())).thenReturn(dockerAccess);
+    when(mockedPlexusContainer.lookup(SecDispatcher.ROLE, "maven")).thenReturn(mockedSecDispatcher);
+    when(mockedSecDispatcher.decrypt(anyString())).thenReturn("testpassword");
+    Map<String, Object> pluginContext = new HashMap<>();
+    defaultExecMockedConstruction = mockConstruction(BuildXService.DefaultExec.class);
+    this.pushMojo = new PushMojo();
+    this.pushMojo.setPluginContext(pluginContext);
+    pushMojo.verbose = "true";
+    pushMojo.settings = mockedMavenSettings;
+    pushMojo.project = mavenProject;
+    pushMojo.authConfigFactory = new AuthConfigFactory(mockedPlexusContainer);
+    pushMojo.imageConfigResolver = new ImageConfigResolver();
+    pushMojo.dockerAccessFactory = dockerAccessFactory;
+    pushMojo.serviceHubFactory = serviceHubFactory;
+    pushMojo.outputDirectory = "target/docker";
+    pushMojo.images = Collections.singletonList(createImageConfiguration());
+  }
+
+  @AfterEach
+  void tearDown() {
+    defaultExecMockedConstruction.close();
+  }
+
+  @Test
+  @DisplayName("docker:push buildx, no auth, then don't add --config option to buildx")
+  void execute_whenNoAuthConfig_thenRunBuildXCommandWithAddedConfig() throws MojoExecutionException, MojoFailureException {
+    // Given
+    // When
+    pushMojo.execute();
+
+    // Then
+    assertEquals(1, defaultExecMockedConstruction.constructed().size());
+    BuildXService.DefaultExec defaultExec = defaultExecMockedConstruction.constructed().get(0);
+    verify(defaultExec).process(Arrays.asList("docker", "buildx", "create",
+        "--driver", "docker-container", "--name", "testbuilder", "--node", "testbuilder0"));
+    verify(defaultExec).process(Arrays.asList("docker", "buildx", "build",
+        "--progress=plain", "--builder", "testbuilder", "--platform", "linux/amd64,linux/arm64",
+        "--tag", "test.example.org/testuser/sample-test-image:latest",
+        expectedDockerStateDir.resolve("build").toFile().getAbsolutePath(), "--push"));
+  }
+
+  @Test
+  @DisplayName("docker:push buildx, auth from ~/.docker/config.json, then don't add --config option to buildx")
+  void execute_whenAuthConfigFromLocalDockerConfig_thenDoNotAddConfigToDockerBuildXCommand() throws MojoExecutionException, MojoFailureException {
+    try (MockedStatic<DockerFileUtil> dockerFileUtilMockedStatic = mockStatic(DockerFileUtil.class)) {
+      // Given
+      AuthConfig authConfig = new AuthConfig("testuser", "testpassword", null, null, null);
+      authConfig.setRegistry("test.example.org");
+      dockerFileUtilMockedStatic.when(DockerFileUtil::readDockerConfig)
+          .thenReturn(authConfig.toJsonObject());
+
+      // When
+      pushMojo.execute();
+
+      // Then
+      assertEquals(1, defaultExecMockedConstruction.constructed().size());
+      BuildXService.DefaultExec defaultExec = defaultExecMockedConstruction.constructed().get(0);
+      verify(defaultExec).process(Arrays.asList("docker", "buildx", "create",
+          "--driver", "docker-container", "--name", "testbuilder", "--node", "testbuilder0"));
+      verify(defaultExec).process(Arrays.asList("docker", "buildx", "build",
+          "--progress=plain", "--builder", "testbuilder", "--platform", "linux/amd64,linux/arm64",
+          "--tag", "test.example.org/testuser/sample-test-image:latest",
+          expectedDockerStateDir.resolve("build").toFile().getAbsolutePath(), "--push"));
+    }
+  }
+
+  @Test
+  @DisplayName("docker:push buildx, auth from ~/.m2/settings.xml, then add --config option to buildx")
+  void execute_whenAuthConfigFromMavenSettings_thenAddConfigToDockerBuildXCommand() throws MojoExecutionException, MojoFailureException {
+    // Given
+    Server server = new Server();
+    server.setId("test.example.org");
+    server.setUsername("testuser");
+    server.setPassword("testpassword");
+    when(mockedMavenSettings.getServers()).thenReturn(Collections.singletonList(server));
+
+    // When
+    pushMojo.execute();
+
+    // Then
+    assertEquals(1, defaultExecMockedConstruction.constructed().size());
+    BuildXService.DefaultExec defaultExec = defaultExecMockedConstruction.constructed().get(0);
+    verify(defaultExec).process(Arrays.asList("docker", "--config", expectedDockerStateConfigDir.getAbsolutePath(), "buildx", "create",
+        "--driver", "docker-container", "--name", "testbuilder", "--node", "testbuilder0"));
+    verify(defaultExec).process(Arrays.asList("docker", "--config", expectedDockerStateConfigDir.getAbsolutePath(), "buildx", "build",
+        "--progress=plain", "--builder", "testbuilder", "--platform", "linux/amd64,linux/arm64",
+        "--tag", "test.example.org/testuser/sample-test-image:latest",
+        expectedDockerStateDir.resolve("build").toFile().getAbsolutePath(), "--push"));
+  }
+
+  @Test
+  @DisplayName("docker:push buildx, auth from properties, then add --config option to buildx")
+  void execute_whenAuthConfigFromProperties_thenAddConfigOptionToBuildXCommand() throws MojoExecutionException, MojoFailureException {
+    try {
+      // Given
+      System.setProperty("docker.push.username", "testuser");
+      System.setProperty("docker.push.password", "testpassword");
+
+      // When
+      pushMojo.execute();
+
+      // Then
+      assertEquals(1, defaultExecMockedConstruction.constructed().size());
+      BuildXService.DefaultExec defaultExec = defaultExecMockedConstruction.constructed().get(0);
+      verify(defaultExec).process(Arrays.asList("docker", "--config", expectedDockerStateConfigDir.getAbsolutePath(), "buildx", "create",
+          "--driver", "docker-container", "--name", "testbuilder", "--node", "testbuilder0"));
+      verify(defaultExec).process(Arrays.asList("docker", "--config", expectedDockerStateConfigDir.getAbsolutePath(), "buildx", "build",
+          "--progress=plain", "--builder", "testbuilder", "--platform", "linux/amd64,linux/arm64",
+          "--tag", "test.example.org/testuser/sample-test-image:latest",
+          expectedDockerStateDir.resolve("build").toFile().getAbsolutePath(), "--push"));
+    } finally {
+      System.clearProperty("docker.push.username");
+      System.clearProperty("docker.push.password");
+    }
+  }
+
+  private ImageConfiguration createImageConfiguration() {
+    return new ImageConfiguration.Builder()
+        .name("test.example.org/testuser/sample-test-image:latest")
+        .buildConfig(new BuildImageConfiguration.Builder()
+            .from("test.example.org/base/builder:latest")
+            .buildx(new BuildXConfiguration.Builder()
+                .platforms(Arrays.asList("linux/amd64", "linux/arm64"))
+                .builderName("testbuilder")
+                .build())
+            .build())
+        .build();
+  }
+}

--- a/src/test/java/io/fabric8/maven/docker/access/AuthConfigListTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/AuthConfigListTest.java
@@ -18,6 +18,24 @@ class AuthConfigListTest {
     }
 
     @Test
+    void authConfigConstructor() {
+        // Given
+        AuthConfig a1 = getAuthConfig();
+        // When
+        AuthConfigList authConfigList = new AuthConfigList(a1);
+        // Then
+        assertEquals(1, authConfigList.size());
+    }
+
+    @Test
+    void authConfigConstructorWithNullArg() {
+        // Given + When
+        AuthConfigList authConfigList = new AuthConfigList(null);
+        // Then
+        assertTrue(authConfigList.isEmpty());
+    }
+
+    @Test
     void emptyList() {
         AuthConfigList authConfigList = new AuthConfigList();
 


### PR DESCRIPTION
Related to #1698
+ Add null checks for authConfig and fromRegistry in BuildMojo
+ Change condition for adding --config option to docker buildx. Temporary config.json file seems to be getting created after we already add config flag. Since this option seems to be useful only when credentials are coming from outside sources (settings, properties, etc); don't add --config when it's coming from local docker config.json
+ Add integration test for docker buildx push that uses `ttl.sh` anonymous registry