### PR TITLE
fix (buildx) : Always pass --config option for latest versions of Docker CLI (#1701)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,6 @@
 # ChangeLog
 * **0.44-SNAPSHOT**:
+  - Always pass `--config` option for latest versions of Docker CLI ([1701](https://github.com/fabric8io/docker-maven-plugin/issues/1701))
 
 * **0.43.3** (2023-08-13):
   - Only add `--config` to buildx command string when authentication credentials are coming from outside sources

--- a/src/main/asciidoc/inc/build/_buildx.adoc
+++ b/src/main/asciidoc/inc/build/_buildx.adoc
@@ -32,7 +32,7 @@ The `<buildx>` element within `<build>` defines how to build multi-architecture 
 The builder manages the build cache.
 
 | *nodeName*
-| Specify the name of the node to be created or modified. If none is specified, it is the name of the builder it belongs to, with an index `0` number suffix.
+| Specify the name of the node to be created or modified.
 
 | *configFile*
 | Configuration file for builder.  Non-absolute files are relative to the maven project directory.  If configFile starts with

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -12,13 +12,16 @@ import io.fabric8.maven.docker.service.BuildService;
 import io.fabric8.maven.docker.service.BuildXService;
 import io.fabric8.maven.docker.service.ImagePullManager;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -51,9 +54,20 @@ class BuildMojoTest extends MojoTestBase {
 
     @Mock
     private BuildXService.Exec exec;
+    private MockedConstruction<BuildXService.DockerVersionExternalCommand> dockerVersionExternalCommandMockedConstruction;
 
     private static String getOsDependentBuild(Path buildPath, String docker) {
         return buildPath.resolve(docker).toString().replace('/', File.separatorChar);
+    }
+
+    @BeforeEach
+    void setUp() {
+        dockerVersionExternalCommandMockedConstruction = Mockito.mockConstruction(BuildXService.DockerVersionExternalCommand.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dockerVersionExternalCommandMockedConstruction.close();
     }
 
     @Test
@@ -336,6 +350,7 @@ class BuildMojoTest extends MojoTestBase {
 
     private BuildXConfiguration.Builder getBuildXPlatforms(String... platforms) {
         return new BuildXConfiguration.Builder()
+            .nodeName("maven0")
             .platforms(Arrays.asList(platforms));
     }
 

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceDockerVersionExternalCommandTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceDockerVersionExternalCommandTest.java
@@ -1,0 +1,34 @@
+package io.fabric8.maven.docker.service;
+
+import io.fabric8.maven.docker.util.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class BuildXServiceDockerVersionExternalCommandTest {
+  private BuildXService.DockerVersionExternalCommand dockerVersionExternalCommand;
+
+  @BeforeEach
+  void setUp() {
+    Logger logger = mock(Logger.class);
+    dockerVersionExternalCommand = new BuildXService.DockerVersionExternalCommand(logger);
+  }
+
+  @Test
+  void getArgs() {
+    assertArrayEquals(new String[] {"docker", "version", "--format", "'{{.Client.Version}}'"}, dockerVersionExternalCommand.getArgs());
+  }
+
+  @Test
+  void getVersion() {
+    // Given
+    dockerVersionExternalCommand.processLine("'24.0.6+azure-2'");
+    // When
+    String version = dockerVersionExternalCommand.getVersion();
+    // Then
+    assertEquals("'24.0.6+azure-2'", version);
+  }
+}

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import io.fabric8.maven.docker.access.AuthConfig;
 import io.fabric8.maven.docker.util.DockerFileUtil;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Spy;
 import org.mockito.Mockito;
@@ -37,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,6 +72,7 @@ class BuildXServiceTest {
     private final String configuredRegistry = "configured-registry";
     private final File buildArchive = new File("build-archive");
     private AuthConfigList authConfigList;
+    private MockedConstruction<BuildXService.DockerVersionExternalCommand> dockerVersionExternalCommandMockedConstruction;
 
     @BeforeEach
     void setup() throws Exception {
@@ -81,6 +85,12 @@ class BuildXServiceTest {
         Mockito.doReturn(Paths.get("docker-state-dir")).when(buildx).getDockerStateDir(Mockito.any(), Mockito.any());
         Mockito.doReturn("maven").when(buildx).createBuilder(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
         authConfigList = null;
+        dockerVersionExternalCommandMockedConstruction = mockConstruction(BuildXService.DockerVersionExternalCommand.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dockerVersionExternalCommandMockedConstruction.close();
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 
 /**
@@ -62,6 +64,7 @@ class RegistryServiceTest {
     private boolean hasImage;
     private Map<String, String> authConfig;
     private MockedStatic<DockerFileUtil> dockerFileUtilMockedStatic;
+    private MockedConstruction<BuildXService.DockerVersionExternalCommand> dockerVersionExternalCommandMockedConstruction;
 
     @TempDir
     private File projectBaseDir;
@@ -102,11 +105,13 @@ class RegistryServiceTest {
         registry = null;
         imageConfiguration = null;
         dockerFileUtilMockedStatic = mockStatic(DockerFileUtil.class);
+        dockerVersionExternalCommandMockedConstruction = mockConstruction(BuildXService.DockerVersionExternalCommand.class);
     }
 
     @AfterEach
     void tearDown() {
         dockerFileUtilMockedStatic.close();
+        dockerVersionExternalCommandMockedConstruction.close();
     }
 
     @ParameterizedTest
@@ -576,6 +581,7 @@ class RegistryServiceTest {
         BuildXConfiguration buildx = new BuildXConfiguration.Builder()
             .platforms(Arrays.asList("linux/amd64", "linux/arm64"))
             .builderName(builderName)
+            .nodeName("maven0")
             .build();
         givenImageNameAndBuildX(imageName, buildx, dockerFile, tag);
     }


### PR DESCRIPTION
## Description

+ Always pass --config option in case of latest docker CLI (>= 23.0.x)
+ Change default value of `--node` parameter to null