### PR TITLE
Add support setting driverOpts for buildx

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
   - Add new option "useDefaultExclusion" for build configuration to handle exclusion of hidden files ([1708](https://github.com/fabric8io/docker-maven-plugin/issues/1708))
   - The <noCache> option is now propagated down to the buildx command, if it is set in the <build> section. ([1717](https://github.com/fabric8io/docker-maven-plugin/pull/1717))
   - Fix Buildx build with Dockerfile outside of the Docker build context directory ([1721](https://github.com/fabric8io/docker-maven-plugin/pull/1721))
+  - Add support setting driverOpts for buildx ([1704](https://github.com/fabric8io/docker-maven-plugin/pull/1704))
 
 * **0.43.4** (2023-08-18):
   - Always pass `--config` option for latest versions of Docker CLI ([1701](https://github.com/fabric8io/docker-maven-plugin/issues/1701))

--- a/it/buildx-driver-opt/pom.xml
+++ b/it/buildx-driver-opt/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.44-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>dmp-it-buildx-driver-opts</artifactId>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <images>
+            <image>
+              <name>hello/buildx-driver-opt:${project.version}</name>
+              <alias>hello-world-buildx-driver-opt</alias>
+              <build>
+                <from>azul/zulu-openjdk-alpine:17-jre</from>
+                <assembly>
+                  <descriptorRef>artifact</descriptorRef>
+                </assembly>
+                <cmd>java -jar maven/${project.name}-${project.version}.jar</cmd>
+                <buildx>
+                  <driverOpts>
+                    <network>host</network>
+                  </driverOpts>
+                  <platforms>
+                    <platform>linux/amd64</platform>
+                    <platform>linux/arm64</platform>
+                  </platforms>
+                </buildx>
+                <tags>
+                  <tag>${project.version}</tag>
+                </tags>
+              </build>
+              <run>
+                <log>
+                  <file>${project.build.directory}/docker.log</file>
+                </log>
+                <wait>
+                  <log>Hello World</log>
+                  <kill>5000</kill>
+                  <shutdown>1000</shutdown>
+                  <time>5000</time>
+                </wait>
+              </run>
+            </image>
+          </images>
+        </configuration>
+        <executions>
+          <execution>
+            <id>docker-build</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>start</goal>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>io.fabric8.dmp.sample.multiarch.helloworld.App</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/it/buildx-driver-opt/src/main/java/io/fabric8/dmp/sample/multiarch/helloworld/App.java
+++ b/it/buildx-driver-opt/src/main/java/io/fabric8/dmp/sample/multiarch/helloworld/App.java
@@ -1,0 +1,11 @@
+package io.fabric8.dmp.sample.multiarch.helloworld;
+
+/**
+ * Hello world!
+ */
+public class App {
+    public static void main(String[] args) throws InterruptedException {
+        System.out.println("Hello World from " + System.getProperty("os.arch"));
+        Thread.sleep(100000);
+    }
+}

--- a/src/main/asciidoc/inc/build/_buildx.adoc
+++ b/src/main/asciidoc/inc/build/_buildx.adoc
@@ -31,6 +31,9 @@ The `<buildx>` element within `<build>` defines how to build multi-architecture 
 | Name of builder to use with buildx.  If not supplied, the builder is named `maven`.  The builder is created as necessary.
 The builder manages the build cache.
 
+| *driverOpts*
+| Optional list of driverOpts to use with the builder. The driverOpts are passed to the builder when it is created.
+
 | *nodeName*
 | Specify the name of the node to be created or modified.
 

--- a/src/main/java/io/fabric8/maven/docker/config/BuildXConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildXConfiguration.java
@@ -6,6 +6,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 public class BuildXConfiguration implements Serializable {
 
@@ -54,6 +55,12 @@ public class BuildXConfiguration implements Serializable {
     @Parameter
     private String cacheTo;
 
+    /**
+     * Map of driver options
+     */
+    @Parameter
+    private Map<String, String> driverOpts;
+
     public String getBuilderName() {
         return builderName;
     }
@@ -89,6 +96,10 @@ public class BuildXConfiguration implements Serializable {
 
     public AttestationConfiguration getAttestations() {
         return attestations;
+    }
+
+    public Map<String, String> getDriverOpts() {
+        return driverOpts;
     }
 
     public static class Builder {
@@ -148,9 +159,18 @@ public class BuildXConfiguration implements Serializable {
             return this;
         }
 
+
         public Builder cacheFrom(String cacheFrom) {
             config.cacheFrom = cacheFrom;
             if (cacheFrom != null) {
+                isEmpty = false;
+            }
+            return this;
+        }
+
+        public Builder driverOpts(Map<String, String> driverOpts) {
+            config.driverOpts = driverOpts;
+            if (driverOpts != null) {
                 isEmpty = false;
             }
             return this;

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -268,6 +268,13 @@ public class BuildXService {
             if (nodeName != null) {
                 append(cmds, "--node", nodeName);
             }
+
+            if (buildXConfiguration.getDriverOpts() != null) {
+                buildXConfiguration.getDriverOpts().forEach((key, value) -> {
+                    append(cmds, "--driver-opt", key + '=' + value);
+                });
+            }
+
             String buildConfig = buildXConfiguration.getConfigFile();
             if(buildConfig != null) {
                 append(cmds, "--config",

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -269,10 +269,8 @@ public class BuildXService {
                 append(cmds, "--node", nodeName);
             }
 
-            if (buildXConfiguration.getDriverOpts() != null) {
-                buildXConfiguration.getDriverOpts().forEach((key, value) -> {
-                    append(cmds, "--driver-opt", key + '=' + value);
-                });
+            if (buildXConfiguration.getDriverOpts() != null && !buildXConfiguration.getDriverOpts().isEmpty()) {
+                buildXConfiguration.getDriverOpts().forEach((key, value) -> append(cmds, "--driver-opt", key + '=' + value));
             }
 
             String buildConfig = buildXConfiguration.getConfigFile();

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceCreateBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceCreateBuilderTest.java
@@ -1,0 +1,106 @@
+package io.fabric8.maven.docker.service;
+
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.assembly.BuildDirs;
+import io.fabric8.maven.docker.assembly.DockerAssemblyManager;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.BuildXConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.docker.util.ProjectPaths;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class BuildXServiceCreateBuilderTest {
+  private BuildXService buildXService;
+  private ImageConfiguration imageConfig;
+  private BuildXService.Exec exec;
+  private BuildDirs buildDirs;
+  private Path configPath;
+  private List<String> execArgs;
+
+  @TempDir
+  private File temporaryFolder;
+
+  @BeforeEach
+  void setUp() {
+    configPath = temporaryFolder.toPath().resolve(".docker").resolve("config.json");
+    buildDirs = new BuildDirs(new ProjectPaths(temporaryFolder, "target"), "foo/bar:latest");
+    DockerAssemblyManager dockerAssemblyManager = mock(DockerAssemblyManager.class);
+    DockerAccess dockerAccess = mock(DockerAccess.class);
+    Logger logger = mock(Logger.class);
+    exec = mock(BuildXService.Exec.class);
+    buildXService = new BuildXService(dockerAccess, dockerAssemblyManager, logger, exec);
+  }
+
+  @Test
+  void driverOptIsPresentIfProvided() throws Exception {
+    //Given
+    buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX.driverOpts(Collections.singletonMap("network", "foonet")));
+
+    // When
+    buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+    //Then
+    verifyBuildXArgumentContains("--driver-opt", "network=foonet");
+  }
+
+  @Test
+  void driverOptIsAbsentIfNotProvided() throws Exception {
+    //Given
+    buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> {});
+
+    // When
+    buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+    //Then
+    verifyBuildXArgumentDoesNotContain("--driver-opt", "network=foonet");
+  }
+
+  private void captureBuildXArguments() throws MojoExecutionException {
+    ArgumentCaptor<List<String>> buildXArgCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(exec).process(buildXArgCaptor.capture());
+    execArgs = buildXArgCaptor.getValue();
+  }
+
+  private void verifyBuildXArgumentContains(String... args) throws MojoExecutionException {
+    captureBuildXArguments();
+    assertTrue(execArgs.containsAll(Arrays.asList(args)));
+  }
+
+  private void verifyBuildXArgumentDoesNotContain(String... args) throws MojoExecutionException {
+    captureBuildXArguments();
+    assertFalse(execArgs.containsAll(Arrays.asList(args)));
+  }
+
+  private void buildConfigUsingBuildX(File temporaryFolder, BiConsumer<BuildXConfiguration.Builder, BuildImageConfiguration.Builder> spec) {
+    final BuildXConfiguration.Builder buildXConfigurationBuilder = new BuildXConfiguration.Builder()
+        .dockerStateDir(temporaryFolder.getAbsolutePath())
+        .platforms(Collections.singletonList("linux/amd64"));
+    final BuildImageConfiguration.Builder buildImageConfigBuilder = new BuildImageConfiguration.Builder();
+    spec.accept(buildXConfigurationBuilder, buildImageConfigBuilder);
+    final BuildXConfiguration buildXConfig = buildXConfigurationBuilder.build();
+    final BuildImageConfiguration buildImageConfig = buildImageConfigBuilder
+        .buildx(buildXConfig)
+        .build();
+    imageConfig = new ImageConfiguration.Builder()
+        .name("foo/bar:latest")
+        .buildConfig(buildImageConfig)
+        .build();
+  }
+}


### PR DESCRIPTION
I recently had a use case where I wanted to change the builder image name to use an image from our local Artifactory instance.

To do that with the builder, I needed to add support for driverOpts to set  `--driver-opt image=MY_IMAGE`. Tested locally, seems to work fine.

Regarding testing - I did not see any tests currently verifying the buildx create.

https://docs.docker.com/engine/reference/commandline/buildx_create/#driver-opt