### PR TITLE
Add new build parameter: "defaultExclusion"

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,6 @@
 # ChangeLog
 * **0.44-SNAPSHOT**:
+  - Add new option "useDefaultExclusion" for build configuration to handle exclusion of hidden files ([1708](https://github.com/fabric8io/docker-maven-plugin/issues/1708))
 
 * **0.43.4** (2023-08-18):
   - Always pass `--config` option for latest versions of Docker CLI ([1701](https://github.com/fabric8io/docker-maven-plugin/issues/1701))

--- a/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/src/main/asciidoc/inc/build/_configuration.adoc
@@ -143,6 +143,9 @@ a| Scan the archive specified in `dockerArchive` and find the actual repository 
 
 | *workdir*
 | Directory to change to when starting the container.
+
+| *useDefaultExcludes*
+| If set to true this plugin won't include any hidden files in the docker image.
 |===
 
 From this configuration this Plugin creates an in-memory Dockerfile,

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -176,7 +176,7 @@ public class DockerAssemblyManager {
                         // Interpolated Dockerfile is already added as it was created into the output directory when
                         // using dir dir mode
                         excludeDockerfile(fileSet, dockerFile);
-
+                        fileSet.setUsingDefaultExcludes(buildConfig.useDefaultExcludes());
                         // If the content is added as archive, then we need to add the Dockerfile from the builddir
                         // directly to docker.tar (as the output builddir is not picked up in archive mode)
                         if (isArchive(assemblyConfigurations)) {

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -196,6 +196,10 @@ public class BuildImageConfiguration implements Serializable {
     @Parameter
     private Map<String,String> buildOptions;
 
+    //Default file exclusions
+    @Parameter
+    private Boolean useDefaultExcludes;
+
     /**
      * Map specifying the create image options to provide to the docker daemon when pulling or importing an image.
      *
@@ -407,6 +411,11 @@ public class BuildImageConfiguration implements Serializable {
         return skipPush != null ? skipPush : false;
     }
 
+    public boolean useDefaultExcludes() {
+
+        return useDefaultExcludes != null ? useDefaultExcludes : true;
+    }
+
     public Boolean getNoCache() {
         return noCache != null ? noCache : nocache;
     }
@@ -425,6 +434,11 @@ public class BuildImageConfiguration implements Serializable {
 
     public Boolean getSkipPush() {
         return skipPush;
+    }
+
+    public Boolean getUseDefaultExcludes() {
+
+        return useDefaultExcludes;
     }
 
     public ArchiveCompression getCompression() {
@@ -726,6 +740,12 @@ public class BuildImageConfiguration implements Serializable {
 
         public Builder createImageOptions(Map<String, String> createImageOptions) {
             config.createImageOptions = createImageOptions;
+            return this;
+        }
+
+        public Builder useDefaultExcludes(Boolean useDefaultExcludes) {
+
+            config.useDefaultExcludes = useDefaultExcludes;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -128,6 +128,7 @@ public enum ConfigKey {
     STOP_NAME_PATTERN,
     COPY_NAME_PATTERN,
     TAGS(ValueCombinePolicy.Merge),
+    USE_DEFAULT_EXCLUDES,
     TMPFS,
     ULIMITS,
     USER,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -181,6 +181,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .dockerFile(valueProvider.getString(DOCKER_FILE, config.getDockerFileRaw()))
             .dockerFileDir(valueProvider.getString(DOCKER_FILE_DIR, config.getDockerFileDirRaw()))
             .buildOptions(valueProvider.getMap(BUILD_OPTIONS, config.getBuildOptions()))
+            .useDefaultExcludes(valueProvider.getBoolean(USE_DEFAULT_EXCLUDES, config.getUseDefaultExcludes()))
             .filter(valueProvider.getString(FILTER, config.getFilterRaw()))
             .user(valueProvider.getString(USER, config.getUser()))
             .healthCheck(extractHealthCheck(config.getHealthCheck(), valueProvider))


### PR DESCRIPTION
This commit introduces a new build parameter, "defaultExclusion," within the build properties of the plugin. The current behavior of the plugin is to build a Docker archive with default exclusion rules, which exclude hidden files. However, the Docker CLI includes hidden files by default.

With the addition of the "defaultExclusion" parameter, users can now control whether hidden files should be excluded during the Docker archive build process. This parameter provides flexibility and allows users to align the plugin's behavior with their specific requirements.

Fixes: https://github.com/fabric8io/docker-maven-plugin/issues/1708