### PR TITLE
Add no-cache functionality into Buildx.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 * **0.44-SNAPSHOT**:
   - Add new option "useDefaultExclusion" for build configuration to handle exclusion of hidden files ([1708](https://github.com/fabric8io/docker-maven-plugin/issues/1708))
+  - The <noCache> option is now propagated down to the buildx command, if it is set in the <build> section. ([1717](https://github.com/fabric8io/docker-maven-plugin/pull/1717))
 
 * **0.43.4** (2023-08-18):
   - Always pass `--config` option for latest versions of Docker CLI ([1701](https://github.com/fabric8io/docker-maven-plugin/issues/1701))

--- a/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
@@ -173,6 +173,19 @@ public class ConfigHelper {
         }
     }
 
+    public static boolean isNoCache(ImageConfiguration imageConfig) {
+        String noCache = System.getProperty("docker.noCache");
+        if (noCache == null) {
+            noCache = System.getProperty("docker.nocache");
+        }
+        if (noCache != null) {
+            return noCache.length() == 0 || Boolean.valueOf(noCache);
+        } else {
+            BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
+            return buildConfig.noCache();
+        }
+    }
+
 
     // =========================================================================
 

--- a/src/main/java/io/fabric8/maven/docker/service/BuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildService.java
@@ -10,6 +10,7 @@ import io.fabric8.maven.docker.assembly.DockerAssemblyManager;
 import io.fabric8.maven.docker.config.AssemblyConfiguration;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.CleanupMode;
+import io.fabric8.maven.docker.config.ConfigHelper;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.model.ImageArchiveManifest;
 import io.fabric8.maven.docker.model.ImageArchiveManifestEntry;
@@ -68,7 +69,7 @@ public class BuildService {
             autoPullCacheFromImage(imageConfig, imagePullManager, buildContext);
         }
 
-        buildImage(imageConfig, buildContext.getMojoParameters(), checkForNocache(imageConfig), checkForSquash(imageConfig), addBuildArgs(buildContext), buildArchiveFile);
+        buildImage(imageConfig, buildContext.getMojoParameters(), ConfigHelper.isNoCache(imageConfig), checkForSquash(imageConfig), addBuildArgs(buildContext), buildArchiveFile);
     }
 
     /**
@@ -478,18 +479,6 @@ public class BuildService {
         }
     }
 
-    private boolean checkForNocache(ImageConfiguration imageConfig) {
-        String noCache = System.getProperty("docker.noCache");
-        if (noCache == null) {
-            noCache = System.getProperty("docker.nocache");
-        }
-        if (noCache != null) {
-            return noCache.length() == 0 || Boolean.valueOf(noCache);
-        } else {
-            BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
-            return buildConfig.noCache();
-        }
-    }
 
     private boolean checkForSquash(ImageConfiguration imageConfig) {
         String squash = System.getProperty("docker.squash");

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -8,6 +8,7 @@ import io.fabric8.maven.docker.assembly.DockerAssemblyManager;
 import io.fabric8.maven.docker.config.AttestationConfiguration;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.BuildXConfiguration;
+import io.fabric8.maven.docker.config.ConfigHelper;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.ImageName;
@@ -170,7 +171,7 @@ public class BuildXService {
                 cmdLine.add(key + '=' + value);
             });
         }
-        if (checkForNocache(imageConfig)) {
+        if (ConfigHelper.isNoCache(imageConfig)) {
             cmdLine.add("--no-cache");
         }
 
@@ -244,18 +245,6 @@ public class BuildXService {
             Files.createDirectories(cachePath);
         } catch (IOException e) {
             throw new IllegalArgumentException("Cannot create " + cachePath);
-        }
-    }
-    private boolean checkForNocache(ImageConfiguration imageConfig) {
-        String noCache = System.getProperty("docker.noCache");
-        if (noCache == null) {
-            noCache = System.getProperty("docker.nocache");
-        }
-        if (noCache != null) {
-            return noCache.length() == 0 || Boolean.valueOf(noCache);
-        } else {
-            BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
-            return buildConfig.noCache();
         }
     }
 

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -170,6 +170,9 @@ public class BuildXService {
                 cmdLine.add(key + '=' + value);
             });
         }
+        if (checkForNocache(imageConfig)) {
+            cmdLine.add("--no-cache");
+        }
 
         AttestationConfiguration attestations = buildConfiguration.getBuildX().getAttestations();
         if (attestations != null) {
@@ -241,6 +244,18 @@ public class BuildXService {
             Files.createDirectories(cachePath);
         } catch (IOException e) {
             throw new IllegalArgumentException("Cannot create " + cachePath);
+        }
+    }
+    private boolean checkForNocache(ImageConfiguration imageConfig) {
+        String noCache = System.getProperty("docker.noCache");
+        if (noCache == null) {
+            noCache = System.getProperty("docker.nocache");
+        }
+        if (noCache != null) {
+            return noCache.length() == 0 || Boolean.valueOf(noCache);
+        } else {
+            BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
+            return buildConfig.noCache();
         }
     }
 


### PR DESCRIPTION
Heya, I noticed that running a multiplatform build (which uses buildx) ignores the configured no-cache directive. e.g. this pom.xml

```
						<configuration>

							<pullRegistry>docker.io</pullRegistry>
							<pushRegistry>${docker.registry}</pushRegistry>

							<images>
								<image>
									<name>blah</name>
									<build>
										<noCache>true</noCache>
										<buildx>
											<platforms>
												<platform>linux/arm64</platform>
												<platform>linux/amd64</platform>
											</platforms>
										</buildx>
										<contextDir>${project.basedir}/target/dockercontext</contextDir>
									</build>
								</image>
							</images>
						</configuration>
```

was not actually passing down `--no-cache` to the buildx command.

This PR causes the top-level build option to be passed down to buildx if buildx happens to be used. Note that the check for no-cache is copy-pasted from your existing implementation. I didn't want to do guesswork about where utility classes should live. If you'd like me to move it, please let me know where to move it to.  I would truly appreciate it if this  could be  merged and released, as I'm using a fork at my organization at the moment 😅 

Cheers,
 
--Gary