### PR TITLE
Fix Buildx build with Dockerfile outside of Docker build context

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,7 @@
 * **0.44-SNAPSHOT**:
   - Add new option "useDefaultExclusion" for build configuration to handle exclusion of hidden files ([1708](https://github.com/fabric8io/docker-maven-plugin/issues/1708))
   - The <noCache> option is now propagated down to the buildx command, if it is set in the <build> section. ([1717](https://github.com/fabric8io/docker-maven-plugin/pull/1717))
+  - Fix Buildx build with Dockerfile outside of the Docker build context directory ([1721](https://github.com/fabric8io/docker-maven-plugin/pull/1721))
 
 * **0.43.4** (2023-08-18):
   - Always pass `--config` option for latest versions of Docker CLI ([1701](https://github.com/fabric8io/docker-maven-plugin/issues/1701))

--- a/it/buildx-dockerfile_and_contextdir/Dockerfile
+++ b/it/buildx-dockerfile_and_contextdir/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:bullseye-slim
+
+COPY resource.properties /
+CMD [ "echo", "Hello World" ]

--- a/it/buildx-dockerfile_and_contextdir/pom.xml
+++ b/it/buildx-dockerfile_and_contextdir/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.44-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>dmp-it-buildx-dockerfile_and_contextdir</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <outputDirectory>target/docker-build</outputDirectory>
+          <useColor>false</useColor>
+          <verbose>all</verbose>
+          <images>
+            <image>
+              <name>${project.artifactId}:${project.version}</name>
+              <build>
+                <dockerFile>${project.basedir}/Dockerfile</dockerFile>
+                <contextDir>${project.basedir}/src/docker</contextDir>
+                <buildx>
+                  <platforms>
+                    <platform>linux/amd64</platform>
+                    <platform>linux/arm64</platform>
+                  </platforms>
+                </buildx>
+              </build>
+            </image>
+          </images>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/it/buildx-dockerfile_and_contextdir/src/docker/resource.properties
+++ b/it/buildx-dockerfile_and_contextdir/src/docker/resource.properties
@@ -1,0 +1,2 @@
+name=value1
+key=value2

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -25,6 +25,7 @@
     <module>buildx-contextdir</module>
     <module>buildx-dependencyset</module>
     <module>buildx-dockerfile</module>
+    <module>buildx-dockerfile_and_contextdir</module>
     <module>buildx-push</module>
     <module>docker-compose</module>
     <module>dockerfile</module>

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -204,8 +204,8 @@ public class BuildXService {
         File contextDir = buildConfiguration.getContextDir();
         if (contextDir != null) {
             Path destinationPath = getContextPath(buildArchive);
-            Path dockerFileRelativePath = contextDir.toPath().relativize(buildConfiguration.getDockerFile().toPath());
-            append(cmdLine, "--file=" + destinationPath.resolve(dockerFileRelativePath), destinationPath.toString());
+            String dockerFileName = buildConfiguration.getDockerFile().getName();
+            append(cmdLine, "--file=" + destinationPath.resolve(dockerFileName), destinationPath.toString());
         } else {
             cmdLine.add(buildDirs.getOutputDirectory().getAbsolutePath());
         }


### PR DESCRIPTION
Fixes a Buildx build failure when an external Dockerfile outside of the Docker build context directory is specified.
The Dockerfile (be it an external one or the generated one) is always stored at the root of the build archive created by  `DockerAssemblyManager.createDockerTarArchive()`.
Before this patch the code which constructs the full path of the Dockerfile to pass to Buildx didn't take that into account.