### PR TITLE
Add support for using maven/system properties for an ARG used as the FROM image in a dockerfile

### DIFF
--- a/it/dockerfile-base-as-arg/README.md
+++ b/it/dockerfile-base-as-arg/README.md
@@ -1,0 +1,13 @@
+## d-m-p sample using a Dockerfile
+
+This example shows how to use docker-maven-plugin together with a Dockerfile. 
+It is a simple `HelloWorld` servlet running on top of Jetty at the root context.
+ 
+The [Dockerfile](src/main/docker/Dockerfile) is located is `src/main/docker`. 
+Please note how the assembly is added using the directory `maven` which will be created on the fly by this plugin when an `<assembly>` is specified. 
+ 
+To build and start a Jetty container with a mapped port at 8080 on the Docker host use
+
+```
+mvn package docker:build docker:run
+```

--- a/it/dockerfile-base-as-arg/pom.xml
+++ b/it/dockerfile-base-as-arg/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!--
+  Simple sample program including Java code.
+
+  This helloworld exactly has been taken over mostly from https://github.com/arun-gupta/docker-java-sample.git
+-->
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.44-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>dmp-it-dockerfile-base-as-arg</artifactId>
+  <version>0.44-SNAPSHOT</version>
+  <packaging>war</packaging>
+  <name>dmp-it-dockerfile</name>
+
+  <properties>
+    <docker.buildArg.baseImage>jetty</docker.buildArg.baseImage>
+    <file>welcome.txt</file>
+    <project.artifactId>${project.artifactId}</project.artifactId>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.7</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <images>
+            <image>
+              <name>fabric8:dmp-it-dockerfile</name>
+              <alias>dockerfile</alias>
+              <build>
+                <!-- filter>@</filter-->
+                <contextDir>${project.basedir}/src/main/docker</contextDir>
+                <assembly>
+                  <descriptorRef>rootWar</descriptorRef>
+                </assembly>
+              </build>
+              <run>
+                <ports>
+                  <port>8080:8080</port>
+                </ports>
+              </run>
+            </image>
+          </images>
+        </configuration>
+        <executions>
+          <execution>
+            <id>build</id>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <phase>install</phase>
+          </execution>
+          <execution>
+            <id>start</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <phase>install</phase>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+            <phase>install</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/it/dockerfile-base-as-arg/src/main/docker/Dockerfile
+++ b/it/dockerfile-base-as-arg/src/main/docker/Dockerfile
@@ -1,0 +1,16 @@
+# Sample Dockerfile for use with the Docker file mode
+ARG baseImage
+FROM ${baseImage}
+
+ENV SAMPLE_BUILD_MODE=dockerfile
+LABEL PROJECT_NAME=hello-world \
+      PROJECT=${project.artifactId}
+
+# Arbitrary files can be added
+ADD ${file} /
+
+# In maven/ the files as specified in the <assembly> section is stored
+# and need to be added manually
+COPY maven/ /var/lib/jetty/webapps/
+
+EXPOSE 8080

--- a/it/dockerfile-base-as-arg/src/main/docker/welcome.txt
+++ b/it/dockerfile-base-as-arg/src/main/docker/welcome.txt
@@ -1,0 +1,1 @@
+Hello World !!!

--- a/it/dockerfile-base-as-arg/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
+++ b/it/dockerfile-base-as-arg/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
@@ -1,0 +1,26 @@
+package io.fabric8.dmp.itests.dockerfile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.FileUtils;
+
+/**
+ * @author roland
+ * @since 18.04.17
+ */
+public class HelloWorldServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String txt = FileUtils.readFileToString(new File("/welcome.txt"), Charset.defaultCharset());
+        resp.getWriter().append(txt).flush();
+        resp.setHeader("Content-Type", "plain/text");
+    }
+}

--- a/it/dockerfile-base-as-arg/src/main/webapp/WEB-INF/web.xml
+++ b/it/dockerfile-base-as-arg/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+
+  <servlet>
+    <display-name>HelloWold</display-name>
+    <servlet-name>hello-world</servlet-name>
+    <servlet-class>io.fabric8.dmp.itests.dockerfile.HelloWorldServlet</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>hello-world</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+</web-app>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -30,6 +30,7 @@
     <module>docker-compose</module>
     <module>docker-compose-dependon</module>
     <module>dockerfile</module>
+    <module>dockerfile-base-as-arg</module>
     <module>dockerignore</module>
     <module>healthcheck</module>
     <module>helloworld</module>


### PR DESCRIPTION
Scenario: build using a Dockerfile, I'm trying to configure the base image using an ARG, as in:

```
ARG baseImage=some/project:version
FROM $baseImage
...
```
This works as long as I don't want a different base image, or if I configure it in the image settings. In theory `docker.buildArg.baseImage=ghcr.io/some/otherProject:otherVersion` should allow changing that value, but that doesn't work since the `autoPullBaseImage` code only looks in the image buildArg configuration.

This PR adds support for looking at all the arg configurations, no matter where they're coming from.