### PR TITLE
Runtime healthcheck definition support

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
@@ -138,6 +138,10 @@ public class ContainerCreateConfig {
     public ContainerCreateConfig networkingConfig(ContainerNetworkingConfig networkingConfig) {
         return add("NetworkingConfig", networkingConfig.toJsonObject());
     }
+    
+    public ContainerCreateConfig healthCheck(ContainerHealthCheckConfig healthCheckConfig) {
+        return add("Healthcheck", healthCheckConfig.toJsonObject());
+    }
 
     /**
      * Get JSON which is used for <em>creating</em> a container

--- a/src/main/java/io/fabric8/maven/docker/access/ContainerHealthCheckConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerHealthCheckConfig.java
@@ -1,0 +1,52 @@
+package io.fabric8.maven.docker.access;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.fabric8.maven.docker.config.HealthCheckConfiguration;
+import io.fabric8.maven.docker.config.HealthCheckConfiguration.DurationParser;
+
+public class ContainerHealthCheckConfig {
+    
+    private final JsonObject healthcheck = new JsonObject();
+    
+    public ContainerHealthCheckConfig(HealthCheckConfiguration configuration) {
+        JsonArray test = new JsonArray();
+        switch (configuration.getMode()) {
+            case none:
+                test.add("NONE");
+                break;
+            case cmd:
+                test.add("CMD");
+                for (String arg : configuration.getCmd().asStrings()) {
+                    test.add(arg);
+                }
+                break;
+            case shell:
+                test.add("CMD-SHELL");
+                test.add(configuration.getCmd().getShell());
+                break;
+        }
+        this.healthcheck.add("Test", test);
+        
+        if (configuration.getInterval() != null) {
+            this.healthcheck.addProperty("Interval", DurationParser.parseDuration(configuration.getInterval()).toNanos());
+        }
+        if (configuration.getTimeout() != null) {
+            this.healthcheck.addProperty("Timeout", DurationParser.parseDuration(configuration.getTimeout()).toNanos());
+        }
+        if (configuration.getStartPeriod() != null) {
+            this.healthcheck.addProperty("StartPeriod", DurationParser.parseDuration(configuration.getStartPeriod()).toNanos());
+        }
+        if (configuration.getRetries() != null) {
+            this.healthcheck.addProperty("Retries", configuration.getRetries());
+        }
+    }
+
+    public String toJson() {
+        return healthcheck.toString();
+    }
+
+    public JsonObject toJsonObject() {
+        return healthcheck;
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerFileBuilder.java
@@ -146,8 +146,10 @@ public class DockerFileBuilder {
             case none:
                 DockerFileKeyword.NONE.addTo(healthString, false);
                 break;
+            case shell:
+                throw new IllegalArgumentException("Runtime-only mode 'shell' is not supported during builds, please use 'cmd' instead");
             default:
-                throw new IllegalArgumentException("Unsupported health check mode: " + healthCheck.getMode());
+                throw new IllegalArgumentException("Unsupported build time health check mode: " + healthCheck.getMode());
             }
 
             DockerFileKeyword.HEALTHCHECK.addTo(b, healthString.toString());

--- a/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
@@ -74,6 +74,18 @@ public class HealthCheckConfiguration implements Serializable {
                 if (cmd == null) {
                     throw new IllegalArgumentException("HealthCheck: the parameter 'cmd' is mandatory when the health check mode is set to 'cmd' (default) or 'shell'");
                 }
+                if (retries != null && retries < 0) {
+                    throw new IllegalArgumentException("HealthCheck: the parameter 'retries' may not be negative");
+                }
+                if (interval != null && ! DurationParser.matchesDuration(interval)) {
+                    throw new IllegalArgumentException("HealthCheck: illegal duration specified for interval");
+                }
+                if (timeout != null && ! DurationParser.matchesDuration(timeout)) {
+                    throw new IllegalArgumentException("HealthCheck: illegal duration specified for timeout");
+                }
+                if (startPeriod != null && ! DurationParser.matchesDuration(startPeriod)) {
+                    throw new IllegalArgumentException("HealthCheck: illegal duration specified for start period");
+                }
                 break;
         }
     }

--- a/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
@@ -59,23 +59,36 @@ public class HealthCheckConfiguration implements Serializable {
         }
 
         switch(mode) {
-        case none:
-            if (interval != null || timeout != null || startPeriod != null || retries != null || cmd != null) {
-                throw new IllegalArgumentException("HealthCheck: no parameters are allowed when the health check mode is set to 'none'");
-            }
-            break;
-        case cmd:
-            if (cmd == null) {
-                throw new IllegalArgumentException("HealthCheck: the parameter 'cmd' is mandatory when the health check mode is set to 'cmd' (default)");
-            }
+            case none:
+                if (interval != null || timeout != null || startPeriod != null || retries != null || cmd != null) {
+                    throw new IllegalArgumentException("HealthCheck: no parameters are allowed when the health check mode is set to 'none'");
+                }
+                break;
+            case cmd:
+                if (cmd == null) {
+                    throw new IllegalArgumentException("HealthCheck: the parameter 'cmd' is mandatory when the health check mode is set to 'cmd' (default) or 'shell'");
+                }
+                break;
         }
     }
-
+    
+    @Override
+    public String toString() {
+        return "HealthCheckConfiguration{" +
+            "mode=" + mode +
+            ", interval='" + interval + '\'' +
+            ", timeout='" + timeout + '\'' +
+            ", startPeriod='" + startPeriod + '\'' +
+            ", retries=" + retries +
+            ", cmd=" + cmd +
+            '}';
+    }
+    
     // ===========================================
 
     public static class Builder {
 
-        private HealthCheckConfiguration config = new HealthCheckConfiguration();
+        private final HealthCheckConfiguration config;
 
         public Builder() {
             this.config = new HealthCheckConfiguration();
@@ -109,7 +122,7 @@ public class HealthCheckConfiguration implements Serializable {
         }
 
         public Builder mode(String mode) {
-            return this.mode(mode != null ? HealthCheckMode.valueOf(mode) : (HealthCheckMode) null);
+            return this.mode(mode != null ? HealthCheckMode.valueOf(mode) : null);
         }
 
         public Builder mode(HealthCheckMode mode) {

--- a/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
@@ -70,6 +70,7 @@ public class HealthCheckConfiguration implements Serializable {
                 }
                 break;
             case cmd:
+            case shell:
                 if (cmd == null) {
                     throw new IllegalArgumentException("HealthCheck: the parameter 'cmd' is mandatory when the health check mode is set to 'cmd' (default) or 'shell'");
                 }

--- a/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/HealthCheckConfiguration.java
@@ -1,6 +1,11 @@
 package io.fabric8.maven.docker.config;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.Serializable;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Build configuration for health checks.
@@ -132,6 +137,74 @@ public class HealthCheckConfiguration implements Serializable {
 
         public HealthCheckConfiguration build() {
             return config;
+        }
+    }
+    
+    public static final class DurationParser {
+        
+        // No instances allowed
+        private DurationParser() {}
+        
+        /**
+         * This complex regex allows duration in the special Docker format,
+         * which is not ISO-8601 compatible, and thus not parseable directly.
+         * (For example, it does not allow using days or even longer periods)
+         * @implSpec See <a href="https://docs.docker.com/compose/compose-file/compose-file-v2/#specifying-durations">Docker Compose durations</a> for supported duration formats.
+         *           <a href="https://docs.docker.com/engine/reference/builder/#healthcheck">Dockerfile HEALTHCHECK</a> has only very limited specification about allowed duration formatting.
+         * @implNote Note that the Docker API requires nanosecond precision (int64/long).
+         *           A conversion is easily done using {@link Duration#toNanos()}.
+         *           Examples of allowed values: 23h17m1s, 10ms, 1s, 0h10ms, 1h2m1.3432s
+         */
+        private static final String durationRegex = "^((?<hours>0[1-9]|1[1-9]|2[1-3]|[0-9])h)?((?<mins>[0-5]?[0-9])m)?(((?<secs>[0-5]?[0-9])s)?((?<msecs>\\d{1,3})ms)?((?<usecs>\\d{1,3})us)?|(?<fsecs>[0-5]?[0-9])\\.(?<fraction>\\d{1,9})s)$";
+        private static final Matcher durationMatcher = Pattern.compile(durationRegex).matcher("");
+        
+        public static boolean matchesDuration(String durationString) {
+            if (durationString == null || durationString.isEmpty()) {
+                return false;
+            }
+            return durationMatcher.reset(durationString).matches();
+        }
+        
+        public static Duration parseDuration(String durationString) {
+            if (durationString == null || durationString.isEmpty()) {
+                return null;
+            }
+            
+            if (durationMatcher.reset(durationString).matches()) {
+                Duration duration = Duration.ZERO;
+                // Add hours
+                if (durationMatcher.group("hours") != null) {
+                    duration = duration.plusHours(Long.parseLong(durationMatcher.group("hours")));
+                }
+                // Add minutes
+                if (durationMatcher.group("mins") != null) {
+                    duration = duration.plusMinutes(Long.parseLong(durationMatcher.group("mins")));
+                }
+                // When seconds are given with an optional fracture
+                if (durationMatcher.group("fsecs") != null) {
+                    duration = duration.plusSeconds(Long.parseLong(durationMatcher.group("fsecs")));
+                    
+                    String fraction = durationMatcher.group("fraction");
+                    // Append enough zeros to make it a nanosecond precision, then tune the duration
+                    fraction += StringUtils.repeat("0", 9 - fraction.length());
+                    duration = duration.plusNanos(Long.parseLong(fraction));
+                } else {
+                    // Add seconds
+                    if (durationMatcher.group("secs") != null) {
+                        duration = duration.plusSeconds(Long.parseLong(durationMatcher.group("secs")));
+                    }
+                    // Add milliseconds
+                    if (durationMatcher.group("msecs") != null) {
+                        duration = duration.plusMillis(Long.parseLong(durationMatcher.group("msecs")));
+                    }
+                    // Add microseconds (make them fake nanoseconds first, as Duration does not support adding micros)
+                    if (durationMatcher.group("usecs") != null) {
+                        duration = duration.plusNanos(Long.parseLong(durationMatcher.group("usecs") + "000"));
+                    }
+                }
+                return duration;
+            }
+            return null;
         }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/config/HealthCheckMode.java
+++ b/src/main/java/io/fabric8/maven/docker/config/HealthCheckMode.java
@@ -5,12 +5,20 @@ public enum HealthCheckMode {
 
     /**
      * Mainly used to disable any health check provided by the base image.
+     * This mode is supported at build and run time.
      */
     none,
 
     /**
-     * A command based health check.
+     * A command-based health check.
+     * This mode is supported at build and run time.
      */
-    cmd;
+    cmd,
+    
+    /**
+     * A shell-wrapped command-based health check.
+     * This mode is supported at runtime only.
+     */
+    shell
 
 }

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -228,6 +228,11 @@ public class RunImageConfiguration implements Serializable {
         if (cmd != null) {
             cmd.validate();
         }
+        if (healthCheck != null) {
+            healthCheck.validate();
+        }
+        
+        String minimalApiVersion = null;
 
         // Custom networks are available since API 1.21 (Docker 1.9)
         NetworkConfig config = getNetworkingConfig();

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -237,10 +237,15 @@ public class RunImageConfiguration implements Serializable {
         // Custom networks are available since API 1.21 (Docker 1.9)
         NetworkConfig config = getNetworkingConfig();
         if (config != null && config.isCustomNetwork()) {
-            return "1.21";
+            minimalApiVersion = "1.21";
+        }
+        
+        // Runtime provided healthchecks are available since API 1.24 (Docker 1.12)
+        if (healthCheck != null) {
+            minimalApiVersion = "1.24";
         }
 
-        return null;
+        return minimalApiVersion;
     }
 
     public Map<String, String> getEnv() {

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -208,6 +208,12 @@ public class RunImageConfiguration implements Serializable {
     // How to stop a container
     @Parameter
     private StopMode stopMode;
+    
+    /**
+     * Add new or override build time provided healthcheck
+     */
+    @Parameter
+    private HealthCheckConfiguration healthCheck;
 
     public RunImageConfiguration() {
     }
@@ -446,6 +452,10 @@ public class RunImageConfiguration implements Serializable {
             return StopMode.graceful;
         }
         return stopMode;
+    }
+    
+    public HealthCheckConfiguration getHealthCheck() {
+        return this.healthCheck;
     }
 
     /**
@@ -723,6 +733,11 @@ public class RunImageConfiguration implements Serializable {
 
         public Builder autoRemove(Boolean autoRemove) {
             config.autoRemove = autoRemove;
+            return this;
+        }
+        
+        public Builder healthCheck(HealthCheckConfiguration configuration) {
+            config.healthCheck = configuration;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import io.fabric8.maven.docker.access.ContainerCreateConfig;
+import io.fabric8.maven.docker.access.ContainerHealthCheckConfig;
 import io.fabric8.maven.docker.access.ContainerHostConfig;
 import io.fabric8.maven.docker.access.ContainerNetworkingConfig;
 import io.fabric8.maven.docker.access.DockerAccess;
@@ -44,6 +45,7 @@ import io.fabric8.maven.docker.access.ExecException;
 import io.fabric8.maven.docker.access.NetworkCreateConfig;
 import io.fabric8.maven.docker.access.PortMapping;
 import io.fabric8.maven.docker.config.Arguments;
+import io.fabric8.maven.docker.config.HealthCheckConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.NetworkConfig;
 import io.fabric8.maven.docker.config.RestartPolicy;
@@ -389,6 +391,11 @@ public class RunService {
                     new ContainerNetworkingConfig()
                         .aliases(networkConfig);
                 config.networkingConfig(networkingConfig);
+            }
+            
+            HealthCheckConfiguration healthCheckConfiguration = runConfig.getHealthCheck();
+            if (healthCheckConfiguration != null) {
+                config.healthCheck(new ContainerHealthCheckConfig(healthCheckConfiguration));
             }
 
             return config;

--- a/src/test/java/io/fabric8/maven/docker/access/ContainerHealthCheckConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ContainerHealthCheckConfigTest.java
@@ -1,0 +1,72 @@
+package io.fabric8.maven.docker.access;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.fabric8.maven.docker.config.Arguments;
+import io.fabric8.maven.docker.config.HealthCheckConfiguration;
+import io.fabric8.maven.docker.config.HealthCheckMode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ContainerHealthCheckConfigTest {
+    
+    @Test
+    void testNanoSecondTransition() {
+        HealthCheckConfiguration hcc = new HealthCheckConfiguration.Builder()
+            .mode(HealthCheckMode.cmd)
+            .cmd(Arguments.Builder.get().withShell("test").build())
+            .timeout("3s")
+            .interval("2s")
+            .startPeriod("1s")
+            .build();
+        
+        ContainerHealthCheckConfig chcc = new ContainerHealthCheckConfig(hcc);
+        JsonObject sut = chcc.toJsonObject();
+        
+        Assertions.assertEquals(3000000000L, sut.get("Timeout").getAsLong());
+        Assertions.assertEquals(2000000000L, sut.get("Interval").getAsLong());
+        Assertions.assertEquals(1000000000L, sut.get("StartPeriod").getAsLong());
+    }
+    
+    
+    // Zero as duration option means "inherit" the options from the image / base image options
+    // See also https://docs.docker.com/engine/api/latest/#tag/Container/operation/ContainerCreate
+    @Test
+    void testZeroAsDuration() {
+        HealthCheckConfiguration hcc = new HealthCheckConfiguration.Builder()
+            .mode(HealthCheckMode.cmd)
+            .cmd(Arguments.Builder.get().withShell("test").build())
+            .timeout("0")
+            .interval("0")
+            .startPeriod("0")
+            .build();
+        
+        ContainerHealthCheckConfig chcc = new ContainerHealthCheckConfig(hcc);
+        JsonObject sut = chcc.toJsonObject();
+        
+        Assertions.assertEquals(0, sut.get("Timeout").getAsLong());
+        Assertions.assertEquals(0, sut.get("Interval").getAsLong());
+        Assertions.assertEquals(0, sut.get("StartPeriod").getAsLong());
+    }
+    
+    @Test
+    void testCmdSplitting() {
+        HealthCheckConfiguration hcc = new HealthCheckConfiguration.Builder()
+            .mode(HealthCheckMode.cmd)
+            .cmd(Arguments.Builder.get().withShell("test -f /bin/bash").build())
+            .build();
+        
+        ContainerHealthCheckConfig chcc = new ContainerHealthCheckConfig(hcc);
+        JsonObject sut = chcc.toJsonObject();
+        
+        JsonArray expected = new JsonArray();
+        expected.add("CMD");
+        expected.add("test");
+        expected.add("-f");
+        expected.add("/bin/bash");
+        
+        Assertions.assertEquals(expected, sut.get("Test").getAsJsonArray());
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerFileBuilderTest.java
@@ -195,6 +195,13 @@ import org.junit.jupiter.api.Assertions;
         String dockerfileContent = new DockerFileBuilder().healthCheck(hc).content();
         Assertions.assertEquals("NONE", dockerfileToMap(dockerfileContent).get("HEALTHCHECK"));
     }
+     
+     @Test
+     void testHealthCheckShell() {
+         HealthCheckConfiguration hc = new HealthCheckConfiguration.Builder().mode(HealthCheckMode.shell).build();
+         DockerFileBuilder dfb = new DockerFileBuilder().healthCheck(hc);
+         Assertions.assertThrows(IllegalArgumentException.class, dfb::content);
+     }
 
     @Test
     void testNoRootExport() {

--- a/src/test/java/io/fabric8/maven/docker/config/HealthCheckConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/HealthCheckConfigTest.java
@@ -24,7 +24,9 @@ class HealthCheckConfigTest {
             new HealthCheckConfiguration.Builder().cmd(new Arguments("exit 0")).retries(1).build(),
             new HealthCheckConfiguration.Builder().cmd(new Arguments("exit 0")).retries(1).interval("2s").build(),
             new HealthCheckConfiguration.Builder().cmd(new Arguments("exit 0")).retries(1).interval("2s").timeout("3s").build(),
-            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.shell).cmd(new Arguments("exit 0")).retries(1).interval("2s").timeout("3s").startPeriod("30s").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.shell).cmd(new Arguments("exit 0")).retries(1).interval("2s").timeout("3s").startPeriod("4s").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).build()
         );
     }
     
@@ -46,17 +48,21 @@ class HealthCheckConfigTest {
             new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).startPeriod("30s").cmd(new Arguments("echo a")).build(),
             new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).cmd(new Arguments("echo a")).build(),
             
-            
             // No empty command when cmd or shell mode
             new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.shell).build(),
             
             // No invalid durations
             new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).cmd(new Arguments("echo a")).interval("1m2h").build(),
             new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).cmd(new Arguments("echo a")).timeout("1m2h").build(),
             new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).cmd(new Arguments("echo a")).startPeriod("1m2h").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.shell).cmd(new Arguments("echo a")).interval("1m2h").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.shell).cmd(new Arguments("echo a")).timeout("1m2h").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.shell).cmd(new Arguments("echo a")).startPeriod("1m2h").build(),
             
             // No invalid retries
             new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).cmd(new Arguments("echo a")).retries(-1).build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.shell).cmd(new Arguments("echo a")).retries(-1).build()
         );
     }
     

--- a/src/test/java/io/fabric8/maven/docker/config/HealthCheckConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/HealthCheckConfigTest.java
@@ -2,144 +2,63 @@ package io.fabric8.maven.docker.config;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.stream.Stream;
 
 /**
  * Tests the health check configuration
  */
 class HealthCheckConfigTest {
-
-    @Test
-    void testGoodHealthCheck1() {
-        new HealthCheckConfiguration.Builder()
-            .cmd(new Arguments("exit 0"))
-            .build()
-            .validate();
+    
+    static Stream<Object> goodExamples() {
+        return Stream.of(
+            // Defaulting to cmd mode
+            new HealthCheckConfiguration.Builder().cmd(new Arguments("exit 0")).build(),
+            new HealthCheckConfiguration.Builder().cmd(new Arguments("exit 0")).retries(1).build(),
+            new HealthCheckConfiguration.Builder().cmd(new Arguments("exit 0")).retries(1).interval("2s").build(),
+            new HealthCheckConfiguration.Builder().cmd(new Arguments("exit 0")).retries(1).interval("2s").timeout("3s").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).build(),
+        );
     }
-
-    @Test
-    void testGoodHealthCheck2() {
-        new HealthCheckConfiguration.Builder()
-            .cmd(new Arguments("exit 0"))
-            .retries(1)
-            .build()
-            .validate();
+    
+    @ParameterizedTest
+    @MethodSource("goodExamples")
+    void goodHealthCheck(HealthCheckConfiguration sut) {
+        Assertions.assertDoesNotThrow(sut::validate);
     }
-
-    @Test
-    void testGoodHealthCheck3() {
-        new HealthCheckConfiguration.Builder()
-            .cmd(new Arguments("exit 0"))
-            .retries(1)
-            .interval("2s")
-            .build()
-            .validate();
+    
+    static Stream<Object> badExamples() {
+        return Stream.of(
+            // No completely empty config is valid
+            new HealthCheckConfiguration.Builder().build(),
+            
+            // When mode is "none" there should be no options nor commands
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).interval("2s").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).retries(1).build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).timeout("3s").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).startPeriod("30s").cmd(new Arguments("echo a")).build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.none).cmd(new Arguments("echo a")).build(),
+            
+            
+            // No empty command when cmd or shell mode
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).build(),
+            
+            // No invalid durations
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).cmd(new Arguments("echo a")).interval("1m2h").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).cmd(new Arguments("echo a")).timeout("1m2h").build(),
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).cmd(new Arguments("echo a")).startPeriod("1m2h").build(),
+            
+            // No invalid retries
+            new HealthCheckConfiguration.Builder().mode(HealthCheckMode.cmd).cmd(new Arguments("echo a")).retries(-1).build(),
+        );
     }
-
-    @Test
-    void testGoodHealthCheck4() {
-        new HealthCheckConfiguration.Builder()
-            .cmd(new Arguments("exit 0"))
-            .retries(1)
-            .interval("2s")
-            .timeout("3s")
-            .build()
-            .validate();
+    
+    @ParameterizedTest
+    @MethodSource("badExamples")
+    void badHealthCheck(HealthCheckConfiguration sut) {
+        Assertions.assertThrows(IllegalArgumentException.class, sut::validate);
     }
-
-    @Test
-    void testGoodHealthCheck5() {
-        new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.cmd)
-            .cmd(new Arguments("exit 0"))
-            .retries(1)
-            .interval("2s")
-            .timeout("3s")
-            .startPeriod("30s")
-            .build()
-            .validate();
-    }
-
-    @Test
-    void testGoodHealthCheck6() {
-        new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.cmd)
-            .cmd(new Arguments("exit 0"))
-            .retries(1)
-            .interval("2s")
-            .timeout("3s")
-            .startPeriod("4s")
-            .build()
-            .validate();
-    }
-
-    @Test
-    void testGoodHealthCheck7() {
-        new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.none)
-            .build()
-            .validate();
-    }
-
-    @Test
-    void testBadHealthCheck1() {
-        HealthCheckConfiguration healthCheckConfiguration = new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.none)
-            .interval("2s")
-            .build();
-        Assertions.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
-    }
-
-    @Test
-    void testBadHealthCheck2() {
-        HealthCheckConfiguration healthCheckConfiguration = new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.none)
-            .retries(1)
-            .build();
-        Assertions.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
-
-    }
-
-    @Test
-    void testBadHealthCheck3() {
-        HealthCheckConfiguration healthCheckConfiguration = new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.none)
-            .timeout("3s")
-            .build();
-        Assertions.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
-    }
-
-    @Test
-    void testBadHealthCheck4() {
-        HealthCheckConfiguration healthCheckConfiguration = new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.none)
-            .startPeriod("30s")
-            .cmd(new Arguments("echo a"))
-            .build();
-        Assertions.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
-    }
-
-    @Test
-    void testBadHealthCheck5() {
-        HealthCheckConfiguration healthCheckConfiguration = new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.none)
-            .cmd(new Arguments("echo a"))
-            .build();
-        Assertions.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
-    }
-
-    @Test
-    void testBadHealthCheck6() {
-        HealthCheckConfiguration healthCheckConfiguration = new HealthCheckConfiguration.Builder()
-            .build();
-        Assertions.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
-    }
-
-    @Test
-    void testBadHealthCheck7() {
-        HealthCheckConfiguration healthCheckConfiguration = new HealthCheckConfiguration.Builder()
-            .mode(HealthCheckMode.cmd)
-            .build();
-        Assertions.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
     }
 
 }


### PR DESCRIPTION
This PR will add support to add a healthcheck to a container when it is created, not just when its image is built.

- Add `<healthCheck>` to `<run>` as known from `<build>`
- Add `healthcheck` to a compose file service definition

Closes #1733
Closes #1580 

## TODOs

- [ ] More tests?
- [ ] Add Compose support and tests
- [ ] Extend docs to explain the differences in both places on adding a check
- [ ] Add integration tests
- [ ] Fix integration tests and examples for build-time healthchecks