### PR TITLE
ci : Move Sonar analysis to Java 17

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - name: Setup Java 11 # Move Sonar analysis to Java 11
+      - name: Setup Java 17 # Move Sonar analysis to Java 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
       - name: Maven Sonar
         run: |

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - name: Setup Java 11 # Move Sonar analysis to Java 11
+      - name: Setup Java 17 # Move Sonar analysis to Java 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
       - name: Maven Sonar
         run: ./mvnw ${MAVEN_ARGS} -Pjacoco,sonar clean install


### PR DESCRIPTION
Sonar now requires Java 17 for doing analysis.  Read more about this here[0]

Bump Sonar workflow JDK to Java 17.

[0] https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597