### PR TITLE
Fix: SourceMojo: Use `isEmpty()` to check whether collection is empty or not issue1746

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/SourceMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/SourceMojo.java
@@ -78,7 +78,7 @@ public class SourceMojo extends AbstractBuildSupportMojo {
                 }
             }
         }
-        if (sourceMode == BuildImageSelectMode.first && imageConfigs.size() > 0) {
+        if (sourceMode == BuildImageSelectMode.first && !imageConfigs.isEmpty()) {
             ImageConfiguration imageConfig = imageConfigs.get(0);
             File dockerTar = hub.getArchiveService().createDockerBuildArchive(imageConfig, params);
             projectHelper.attachArtifact(project, getArchiveType(imageConfig),


### PR DESCRIPTION
Hello Maintainers,

I just wanted to let you know that I have modified the code. I have changed the `imageConfigs>0` to `!imageConfigs.isEmpty()` to check whether the Collection is empty. After making these changes, I have used the `mvn clean install` command.

Best Regards,
@mdxabu 
