### PR TITLE
ci : Run E2E tests against multiple versions of Docker

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,23 +18,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Linux Java ${{ matrix.java }} Maven
+  buildWithoutTests:
+    name: BuildWithoutTests
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache .m2 registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Install DMP
+        run: mvn ${MAVEN_ARGS} clean install -DskipTests -Djacoco.skip=true
+
+  build:
+    name: Docker ${{ matrix.docker }} on Linux
+    runs-on: ubuntu-latest
+    needs: buildWithoutTests
     strategy:
+      fail-fast: false
       matrix:
-        java: [11]
+        docker: [v25.0.2, v24.0.9, v23.0.6]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Install Docker Maven Plugin
-        run: mvn ${MAVEN_ARGS} clean install -DskipTests -Djacoco.skip=true
+          java-version: '11'
+      - name: Cache .m2 registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
+      - name: Set up Docker
+        uses: crazy-max/ghaction-setup-docker@v2
+        with:
+          version: ${{ matrix.docker }}
       - name: Run Integration tests
         run: |
           cd it/

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+
+env:
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '0 1 * * *' # Every day at 1
+
+jobs:
+  windows-build:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - name: Get Windows Version > Used to retrieve specific Docker Image
+        shell: cmd
+        run: |
+          ver
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Install DMP
+        run: mvn ${MAVEN_ARGS} clean install -DskipTests
+      - name: Run Integration tests
+        run: |
+          cd it/windows-build
+          mvn clean install -Pwindows

--- a/.github/workflows/macos-mavenwrapper-build.yml
+++ b/.github/workflows/macos-mavenwrapper-build.yml
@@ -1,0 +1,24 @@
+name: Mac OS Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Java ${{ matrix.java }} Maven Wrapper
+    runs-on: macos-13
+    strategy:
+      matrix:
+        java: [11]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build Project
+        run: ./mvnw -B -C -V -ntp clean install

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -44,5 +44,6 @@
     <module>spring-boot-with-jib</module>
     <module>volume</module>
     <module>zero-config</module>
+    <module>windows-build</module>
   </modules>
 </project>

--- a/it/windows-build/pom.xml
+++ b/it/windows-build/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.44-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>fabric8io</groupId>
+  <artifactId>dmp-it-windows-build</artifactId>
+  <version>0.44-SNAPSHOT</version>
+
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <name>%g/%a:${project.version}</name>
+                  <build>
+                    <from>mcr.microsoft.com/windows/nanoserver:ltsc2022</from>
+                    <assembly>
+                      <descriptorRef>artifact</descriptorRef>
+                    </assembly>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+
+            <executions>
+              <execution>
+                <id>build</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <phase>pre-integration-test</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>


### PR DESCRIPTION
+ Use `crazy-max/ghaction-setup-docker` GitHub action to run E2E tests tied to a specific version of Docker
+ Add a minimal E2E test for windows that would just verify that DMP is able to build image with docker on windows
+ Add build job for verifying project compiles on Mac OS