### PR TITLE
fix : AuthConfigList is populated with from images during buildx push as well

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
   - The <noCache> option is now propagated down to the buildx command, if it is set in the <build> section. ([1717](https://github.com/fabric8io/docker-maven-plugin/pull/1717))
   - Fix Buildx build with Dockerfile outside of the Docker build context directory ([1721](https://github.com/fabric8io/docker-maven-plugin/pull/1721))
   - Add support setting driverOpts for buildx ([1704](https://github.com/fabric8io/docker-maven-plugin/pull/1704))
+  - Multi-Architecture push is not sending pull registry auth credentials ([1709](https://github.com/fabric8io/docker-maven-plugin/issues/1709))
 
 * **0.43.4** (2023-08-18):
   - Always pass `--config` option for latest versions of Docker CLI ([1701](https://github.com/fabric8io/docker-maven-plugin/issues/1701))

--- a/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractBuildSupportMojo.java
@@ -23,24 +23,8 @@ abstract public class AbstractBuildSupportMojo extends AbstractDockerMojo {
     // Parameters required from Maven when building an assembly. They cannot be injected directly
     // into DockerAssemblyCreator.
     // See also here: http://maven.40175.n5.nabble.com/Mojo-Java-1-5-Component-MavenProject-returns-null-vs-JavaDoc-parameter-expression-quot-project-quot-s-td5733805.html
-
-    @Parameter
-    private MavenArchiveConfiguration archive;
-
-    @Component
-    private MavenFileFilter mavenFileFilter;
-
-    @Component
-    private MavenReaderFilter mavenFilterReader;
-
-    @Parameter
-    private Map<String, String> buildArgs;
-
     @Parameter(property = "docker.pull.registry")
     String pullRegistry;
-
-    @Parameter( defaultValue = "${reactorProjects}", required = true, readonly = true )
-    private List<MavenProject> reactorProjects;
 
 
     protected BuildService.BuildContext getBuildContext() throws MojoExecutionException {
@@ -49,11 +33,6 @@ abstract public class AbstractBuildSupportMojo extends AbstractDockerMojo {
                 .mojoParameters(createMojoParameters())
                 .registryConfig(getRegistryConfig(pullRegistry))
                 .build();
-    }
-
-    protected MojoParameters createMojoParameters() {
-        return new MojoParameters(session, project, archive, mavenFileFilter, mavenFilterReader,
-                                  settings, sourceDirectory, outputDirectory, reactorProjects);
     }
 
 }

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -37,9 +37,11 @@ import io.fabric8.maven.docker.util.AuthConfigFactory;
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.GavLabel;
 import io.fabric8.maven.docker.util.ImageNameFormatter;
+import io.fabric8.maven.docker.util.MojoParameters;
 import io.fabric8.maven.docker.util.NamePatternUtil;
 
 import io.fabric8.maven.docker.util.ProjectPaths;
+import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
@@ -49,6 +51,8 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
+import org.apache.maven.shared.filtering.MavenFileFilter;
+import org.apache.maven.shared.filtering.MavenReaderFilter;
 import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
@@ -224,6 +228,20 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
 
     @Parameter(property = "docker.skip.pom", defaultValue = "false")
     protected boolean skipPom;
+
+    @Parameter( defaultValue = "${reactorProjects}", required = true, readonly = true )
+    protected List<MavenProject> reactorProjects;
+    @Parameter
+    protected MavenArchiveConfiguration archive;
+
+    @Component
+    protected MavenFileFilter mavenFileFilter;
+
+    @Component
+    protected MavenReaderFilter mavenFilterReader;
+
+    @Parameter
+    protected Map<String, String> buildArgs;
 
     // Images resolved with external image resolvers and hooks for subclass to
     // mangle the image configurations.
@@ -607,5 +625,10 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
 
     protected ProjectPaths createProjectPaths() {
         return new ProjectPaths(project.getBasedir(), outputDirectory);
+    }
+
+    protected MojoParameters createMojoParameters() {
+        return new MojoParameters(session, project, archive, mavenFileFilter, mavenFilterReader,
+            settings, sourceDirectory, outputDirectory, reactorProjects);
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/PushMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/PushMojo.java
@@ -51,7 +51,7 @@ public class PushMojo extends AbstractDockerMojo {
     }
 
     private void executeDockerPush(ServiceHub hub) throws MojoExecutionException, DockerAccessException {
-        hub.getRegistryService().pushImages(createProjectPaths(), getResolvedImages(), retries, getRegistryConfig(pushRegistry), skipTag);
+        hub.getRegistryService().pushImages(createProjectPaths(), getResolvedImages(), retries, getRegistryConfig(pushRegistry), skipTag, createMojoParameters());
     }
 
     private void executeJibPush(ServiceHub hub) throws MojoExecutionException {

--- a/src/test/java/io/fabric8/maven/docker/PushMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/PushMojoTest.java
@@ -2,6 +2,7 @@ package io.fabric8.maven.docker;
 
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.service.RegistryService;
+import io.fabric8.maven.docker.util.MojoParameters;
 import io.fabric8.maven.docker.util.ProjectPaths;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.jupiter.api.Test;
@@ -81,7 +82,7 @@ class PushMojoTest extends MojoTestBase {
 
   private void verifyPush(int wantedNumberOfInvocations) throws DockerAccessException, MojoExecutionException {
     Mockito.verify(registryService, Mockito.times(wantedNumberOfInvocations))
-        .pushImages(Mockito.any(ProjectPaths.class), Mockito.anyCollection(), Mockito.anyInt(), Mockito.any(RegistryService.RegistryConfig.class), Mockito.anyBoolean());
+        .pushImages(Mockito.any(ProjectPaths.class), Mockito.anyCollection(), Mockito.anyInt(), Mockito.any(RegistryService.RegistryConfig.class), Mockito.anyBoolean(), Mockito.any(MojoParameters.class));
   }
 
   private void whenMojoExecutes() throws IOException, MojoExecutionException {

--- a/src/test/java/io/fabric8/maven/docker/service/RegistryServicePushImagesBuildXTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RegistryServicePushImagesBuildXTest.java
@@ -1,0 +1,143 @@
+package io.fabric8.maven.docker.service;
+
+import io.fabric8.maven.docker.access.AuthConfig;
+import io.fabric8.maven.docker.access.AuthConfigList;
+import io.fabric8.maven.docker.access.DockerAccess;
+import io.fabric8.maven.docker.access.DockerAccessException;
+import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.BuildXConfiguration;
+import io.fabric8.maven.docker.config.ImageConfiguration;
+import io.fabric8.maven.docker.util.AuthConfigFactory;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.docker.util.ProjectPaths;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RegistryServicePushImagesBuildXTest {
+  private RegistryService registryService;
+  private BuildXService buildXService;
+  private List<ImageConfiguration> imageConfigurationList;
+  private ProjectPaths projectPaths;
+  private RegistryService.RegistryConfig registryConfig;
+  private AuthConfigFactory authConfigFactory;
+
+  @TempDir
+  private File temporaryFolder;
+
+  @BeforeEach
+  void setUp() {
+    buildXService = mock(BuildXService.class);
+    Logger logger = mock(Logger.class);
+    authConfigFactory = mock(AuthConfigFactory.class);
+    DockerAccess dockerAccess = mock(DockerAccess.class);
+    QueryService queryService = new QueryService(dockerAccess);
+    imageConfigurationList = Collections.singletonList(createNewImageConfiguration("user1/sample-image:latest", "foo/base:latest", null));
+    registryConfig = new RegistryService.RegistryConfig.Builder()
+        .registry("registry1.org")
+        .authConfigFactory(authConfigFactory)
+        .build();
+    projectPaths = new ProjectPaths(temporaryFolder, "target/docker");
+    registryService = new RegistryService(dockerAccess, queryService, buildXService, logger);
+  }
+
+  @Test
+  void whenNoRegistryConfigured_thenAuthConfigEmpty() throws MojoExecutionException, DockerAccessException {
+    // When
+    registryService.pushImages(projectPaths, imageConfigurationList, 0, registryConfig, false, null);
+
+    // Then
+    verifyBuildXServiceInvokedWithAuthConfigListSize(0);
+  }
+
+  @Test
+  void whenOnlyPushRegistryConfigured_thenAuthConfigHasSingleEntry() throws MojoExecutionException, DockerAccessException {
+    // Given
+    givenAuthConfigExistsForRegistry("registry1.org", "user1", "password1");
+
+    // When
+    registryService.pushImages(projectPaths, imageConfigurationList, 0, registryConfig, false, null);
+
+    // Then
+    verifyBuildXServiceInvokedWithAuthConfigListSize(1);
+  }
+
+  @Test
+  void whenFromRegistryAndPushRegistryProvided_thenAuthConfigListContainsEntriesForBothPullAndPush() throws MojoExecutionException, DockerAccessException {
+    // Given
+    imageConfigurationList = Collections.singletonList(createNewImageConfiguration("user1/base-image-different-registry:latest", "registry2.org/user2/base:latest", null));
+    givenAuthConfigExistsForRegistry("registry1.org", "user1", "password1");
+    givenAuthConfigExistsForRegistry("registry2.org", "user2", "password2");
+
+    // When
+    registryService.pushImages(projectPaths, imageConfigurationList, 0, registryConfig, false, null);
+
+    // Then
+    verifyBuildXServiceInvokedWithAuthConfigListSize(2);
+  }
+
+  @Test
+  void whenDockerfileContainsFromReferencingMultipleRegistries_thenAuthConfigListContainsMultipleEntries() throws MojoExecutionException, IOException {
+    // Given
+    File dockerFile = new File(temporaryFolder, "Dockerfile");
+    Files.write(dockerFile.toPath(), String.format("FROM registry2.org/user2/test-base:latest%n").getBytes());
+    Files.write(dockerFile.toPath(), "FROM registry3.org/user3/scratch:1.0 AS build2".getBytes(), StandardOpenOption.APPEND);
+    imageConfigurationList = Collections.singletonList(createNewImageConfiguration("user1/base-image-different-registry:latest", null, dockerFile));
+    givenAuthConfigExistsForRegistry("registry1.org", "user1", "password1");
+    givenAuthConfigExistsForRegistry("registry2.org", "user2", "password2");
+    givenAuthConfigExistsForRegistry("registry3.org", "user3", "password2");
+
+    // When
+    registryService.pushImages(projectPaths, imageConfigurationList, 0, registryConfig, false, null);
+
+    // Then
+    verifyBuildXServiceInvokedWithAuthConfigListSize(3);
+  }
+
+  private void verifyBuildXServiceInvokedWithAuthConfigListSize(int expectedSize) throws MojoExecutionException {
+    ArgumentCaptor<AuthConfigList> authConfigListArgumentCaptor = ArgumentCaptor.forClass(AuthConfigList.class);
+    verify(buildXService).push(any(), any(), anyString(), authConfigListArgumentCaptor.capture());
+    assertEquals(expectedSize, authConfigListArgumentCaptor.getValue().size());
+  }
+
+  private void givenAuthConfigExistsForRegistry(String registry, String username, String password) throws MojoExecutionException {
+    AuthConfig auth = new AuthConfig(username, password, null, null);
+    auth.setRegistry(registry);
+
+    when(authConfigFactory.createAuthConfig(anyBoolean(), anyBoolean(), any(), any(), any(), eq(registry)))
+        .thenReturn(auth);
+  }
+
+  private ImageConfiguration createNewImageConfiguration(String name, String from, File dockerFile) {
+    BuildImageConfiguration buildImageConfiguration = mock(BuildImageConfiguration.class);
+    when(buildImageConfiguration.getFrom()).thenReturn(from);
+    when(buildImageConfiguration.getBuildX()).thenReturn(new BuildXConfiguration.Builder()
+        .platforms(Arrays.asList("linux/amd64", "linux/arm64"))
+        .build());
+    when(buildImageConfiguration.isBuildX()).thenReturn(true);
+    when(buildImageConfiguration.getDockerFile()).thenReturn(dockerFile);
+    when(buildImageConfiguration.getAbsoluteDockerFilePath(any())).thenReturn(dockerFile);
+    return new ImageConfiguration.Builder()
+        .name(name)
+        .buildConfig(buildImageConfiguration).build();
+  }
+}

--- a/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
@@ -519,7 +519,7 @@ class RegistryServiceTest {
                     .authConfig(authConfig)
                     .registry(registry)
                     .build();
-            registryService.pushImages(projectPaths, Collections.singleton(imageConfiguration), 1, registryConfig, false);
+            registryService.pushImages(projectPaths, Collections.singleton(imageConfiguration), 1, registryConfig, false, null);
         } catch (Exception e) {
             this.actualException = e;
         }


### PR DESCRIPTION
### Description

Fix #1709 

+ During BuildX push we also need credentials for pulling base images used in Dockerfile. Sending a single AuthConfig just for push registry will not work. 
+ Refactor code in BuildMojo to extract AuthConfig for base images used in Build configuration / Dockerfile . Move common logic as static methods in RegistryService so that it can be reused in both build and push goals.