### PR TITLE
ci : E2E tests should also run on GitHub MacOS runners

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Install DMP
         run: mvn ${MAVEN_ARGS} clean install -DskipTests -Djacoco.skip=true
 
-  build:
-    name: Docker ${{ matrix.docker }} on Linux
+  linux-build:
+    name: Linux
     runs-on: ubuntu-latest
     needs: buildWithoutTests
     strategy:
       fail-fast: false
       matrix:
-        docker: [v25.0.2, v24.0.9, v23.0.6]
+        docker: [v25.0.2, v24.0.9, v23.0.6, v20.10.24]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -62,5 +62,42 @@ jobs:
           version: ${{ matrix.docker }}
       - name: Run Integration tests
         run: |
+          # Workaround for https://github.com/docker/for-linux/issues/748
+          DOCKER_INSTALL_PATH=`which docker`
+          sudo cp $DOCKER_INSTALL_PATH-init /sbin/docker-init
+          cd it/
+          mvn clean install
+  macos-build:
+    name: MacOS
+    needs: buildWithoutTests
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        docker: [v25.0.2,v24.0.9,v23.0.6,v20.10.24]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Cache .m2 registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
+      - name: Set up Docker
+        uses: crazy-max/ghaction-setup-docker@v2
+        with:
+          version: ${{ matrix.docker }}
+      - name: Set up Docker Buildx
+        run: |
+          brew install docker-buildx
+          mkdir -p ~/.docker/cli-plugins
+          ln -sfn /usr/local/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
+      - name: Run Integration tests
+        run: |
+          export DOCKER_HOST=unix:///Users/runner/.colima/default/docker.sock
           cd it/
           mvn clean install

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: E2E Windows
 
 env:
   MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e

--- a/it/multi-assembly/pom.xml
+++ b/it/multi-assembly/pom.xml
@@ -97,6 +97,7 @@
               <run>
                 <wait>
                   <log>Hello from Spring Boot!</log>
+                  <time>30000</time>
                 </wait>
               </run>
             </image>


### PR DESCRIPTION
### Description

+ Enable E2E tests to run on GitHub MacOS runners
+ Use `crazy-max/ghaction-setup-docker` action to set up docker on MacOS