### PR TITLE
ci : Enable publishing snapshot artifacts to maven central

### DIFF
--- a/.github/workflows/release-snapshots.yml
+++ b/.github/workflows/release-snapshots.yml
@@ -1,0 +1,36 @@
+name: Release to SNAPSHOTS Maven Central
+
+env:
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e ${{ github.event.inputs.additional_args }}
+  RELEASE_MAVEN_ARGS: -Prelease -Denforcer.skip=true
+  OSSRHUSERNAME: ${{ secrets.OSSRHUSERNAME }}
+  OSSRHPASSWORD: ${{ secrets.OSSRHPASSWORD }}
+  SIGNINGPASSWORD: ${{ secrets.SIGNINGPASSWORD }}
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # Every day at 2am
+
+jobs:
+  release-snapshots:
+    name: Release SNAPSHOT
+    # Cheap way to prevent accidental releases
+    # Modify the list to add users with release permissions
+    if: contains('["rhuss","rohanKanojia"]', github.actor)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+          server-id: sonatype-nexus-snapshots
+          server-username: OSSRHUSERNAME
+          server-password: OSSRHPASSWORD
+          gpg-private-key: ${{ secrets.SIGNINGKEY }}
+          gpg-passphrase: SIGNINGPASSWORD
+      - name: Build and Release Project
+        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} clean deploy

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ It works with Maven 3.0.5 and Docker 1.6.0 or later.
   setups that you can use as blueprints for your projects.
 * [ChangeLog](doc/changelog.md) has the release history of this plugin.
 * [Contributing](CONTRIBUTING.md) explains how you can contribute to this project. Pull requests are highly appreciated!
+* We publish nightly builds on maven central. Read How to use [Docker Maven Plugin Snapshot artifacts](./doc/HowToUseDockerMavenPluginSnapshotArtifacts.md).
 
 
 #### Docker API Support

--- a/doc/HowToUseDockerMavenPluginSnapshotArtifacts.md
+++ b/doc/HowToUseDockerMavenPluginSnapshotArtifacts.md
@@ -1,0 +1,41 @@
+# How to use Fabric8 docker-maven-plugin snapshot artifacts?
+
+Artifacts are hosted at [docker-maven-plugin's Sonatype Snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/io/fabric8/docker-maven-plugin/)
+
+Our [GitHub Action Snapshot release workflow](https://github.com/fabric8io/docker-maven-plugin/blob/master/.github/workflows/release-snapshots.yml) updates SNAPSHOT artifacts every night.
+
+## Using SNAPSHOTs in Maven Project
+
+In order to use these artifacts, update your `pom.xml` with these:
+
+```xml
+<pluginRepositories>
+  <pluginRepository>
+    <id>oss.sonatype.org</id>
+    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    <snapshots>
+      <enabled>true</enabled>
+      <updatePolicy>always</updatePolicy>
+    </snapshots>
+  </pluginRepository>
+</pluginRepositories>
+```
+
+You'd also need to update version of the plugin you're using to use a SNAPSHOT version instead of a stable version. Here is an example:
+
+```xml
+<properties>
+    <docker-maven-plugin.version>x.yz-SNAPSHOT</docker-maven-plugin.version>
+</properties>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>${docker-maven-plugin.version}</version>
+        </plugin>
+    </plugins>
+</build>
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -529,18 +529,23 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
-            <configuration>
-              <skip>false</skip>
-            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
+                <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>
-                <phase>verify</phase>
               </execution>
             </executions>
+            <configuration>
+              <skip>false</skip>
+              <gpgArguments>
+                <arg>--batch</arg>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
           </plugin>
 
           <plugin>


### PR DESCRIPTION
### Description

Add GitHub action workflow to do nightly builds and publish SNAPSHOT artifacts at maven central. This would help us get early feedback from users before doing releases.

Release pipeline is taken from [Fabric8 Kubernetes Client Release Snapshot GitHub Action Workflow](https://github.com/fabric8io/kubernetes-client/blob/main/.github/workflows/release-snapshots.yaml)