### PR TITLE
Feat: Automatically create parent directories of portPropertyFile path

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 * **0.45-SNAPSHOT**:
-
+  - Automatically create parent directories of portPropertyFile path
+  
 * **0.44.0** (2024-02-17):
   - Add new option "useDefaultExclusion" for build configuration to handle exclusion of hidden files ([1708](https://github.com/fabric8io/docker-maven-plugin/issues/1708))
   - The <noCache> option is now propagated down to the buildx command, if it is set in the <build> section. ([1717](https://github.com/fabric8io/docker-maven-plugin/pull/1717))

--- a/src/main/java/io/fabric8/maven/docker/access/PortMapping.java
+++ b/src/main/java/io/fabric8/maven/docker/access/PortMapping.java
@@ -403,6 +403,10 @@ public class PortMapping {
 
         private void writeProperties(Properties props, String file) throws IOException {
             File propFile = new File(file);
+            File parent = propFile.getParentFile();
+            if (!parent.exists()) {
+                parent.mkdirs();
+            }
             try (OutputStream os = new FileOutputStream(propFile)) {
                 props.store(os, "Docker ports");
             } catch (IOException e) {


### PR DESCRIPTION
This adds a new option enabling automatic folder creation for the path specified in `portPropertyFile`. 
