### PR TITLE
Issue #1763 & #1676

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -476,7 +476,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
             return null;
         }
         JsonObject imageDetails = JsonFactory.newJsonObject(response.getBody());
-        return imageDetails.get("Id").getAsString().substring(0, 12);
+        return imageDetails.get("Id").getAsString();
     }
 
     @Override


### PR DESCRIPTION
I don't understand the reason to limit the image id. This works on Podman and Docker.