### PR TITLE
#1762 - Upgrading spring to 2.7.18 for spring-boot-with-jib sample

### DIFF
--- a/samples/spring-boot-with-jib/pom.xml
+++ b/samples/spring-boot-with-jib/pom.xml
@@ -30,7 +30,7 @@
     <dmp.version>${project.version}</dmp.version>
     <docker.build.jib>true</docker.build.jib>
     <docker.user>fabric8</docker.user>
-    <spring.version>2.5.12</spring.version>
+    <spring.version>2.7.18</spring.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
- [x] Spring Boot version is updated in 
- [x] Quickstart should still work as expected as documented in it's [README.md](https://github.com/fabric8io/docker-maven-plugin/blob/master/samples/spring-boot-with-jib/README.md)