### PR TITLE
Fix: LogRequestor : Replaced `com.google.common.base.Charsets.UTF_8` with `StandardCharsets.UTF_8` 

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -15,27 +15,26 @@ package io.fabric8.maven.docker.access.log;/*
  * limitations under the License.
  */
 
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.time.ZonedDateTime;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.UrlBuilder;
 import io.fabric8.maven.docker.access.util.RequestUtil;
 import io.fabric8.maven.docker.util.TimestampFactory;
-
 import org.apache.commons.codec.binary.Hex;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Extractor for parsing the response of a log request
@@ -170,7 +169,7 @@ public class LogRequestor extends Thread implements LogGetHandle {
                                   " [ Header: " + Hex.encodeHexString(headerBuffer.array()) + "]", e);
         }
 
-        String message = Charsets.UTF_8.newDecoder().decode(payload).toString();
+        String message = StandardCharsets.UTF_8.decode(payload).toString();
         callLogCallback(type, message);
         return true;
     }

--- a/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
@@ -1,6 +1,5 @@
 package io.fabric8.maven.docker.access.log;
 
-import com.google.common.base.Charsets;
 import io.fabric8.maven.docker.access.UrlBuilder;
 import org.apache.commons.text.RandomStringGenerator;
 import org.apache.http.HttpEntity;
@@ -22,12 +21,12 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.regex.Matcher;
- 
-import java.time.ZonedDateTime;
 
 @ExtendWith(MockitoExtension.class)
 class LogRequestorTest {
@@ -321,7 +320,7 @@ class LogRequestorTest {
     private static ByteBuffer messageToBuffer(Streams stream, String message) throws IOException {
         String logMessage = logMessage(message);
 
-        CharsetEncoder encoder = Charsets.UTF_8.newEncoder();
+        CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
         ByteBuffer payload = encoder.encode(CharBuffer.wrap(logMessage.toCharArray()));
         assert payload.order() == ByteOrder.BIG_ENDIAN;
         int length = payload.limit();


### PR DESCRIPTION
Dear @rohanKanojia ,

I wanted to inform you that I have made a change in the code. The `Charset.UTF_8` has been replaced with `StandardCharsets.UTF_8`.

Best Regards,
F Mohamed Abdullah

