### PR TITLE
Update:  size > 0 check  to isEmpty method and rename configuration field

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -404,20 +404,20 @@ class DockerComposeServiceWrapper {
         RunVolumeConfiguration.Builder builder = new RunVolumeConfiguration.Builder();
         List<String> volumes = asList("volumes");
         boolean added = false;
-        if (volumes.size() > 0) {
+        if (!volumes.isEmpty()) {
             builder.bind(volumes);
             added = true;
         }
         List<String> volumesFrom = asList("volumes_from");
-        if (volumesFrom.size() > 0) {
+        if (!volumesFrom.isEmpty()) {
             builder.from(volumesFrom);
             added = true;
         }
 
         if (added) {
-            RunVolumeConfiguration configuration = builder.build();
-            VolumeBindingUtil.resolveRelativeVolumeBindings(baseDir, configuration);
-            return configuration;
+            RunVolumeConfiguration runVolumeConfiguration = builder.build();
+            VolumeBindingUtil.resolveRelativeVolumeBindings(baseDir, runVolumeConfiguration);
+            return runVolumeConfiguration;
         }
 
         return null;


### PR DESCRIPTION
Fix #1779

## What's changed ?
> Inside [DockerComposeServiceWrapper.java](https://github.com/fabric8io/docker-maven-plugin/blob/fc53963fc57c466dc10757ac98d2009927f6ef15/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java#L407-L412) made below changes addrssing issue #1779 

- [X] size() > 0 check is replaced by isEmpty()
- [X] Rename configuration field so that it doesn't collide with class level field