### PR TITLE
Support platform in external docker-compose config

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 * **0.45-SNAPSHOT**:
   - Automatically create parent directories of portPropertyFile path
+  - Added support for `platform` attribute of a container in the docker-compose configuration.
   
 * **0.44.0** (2024-02-17):
   - Add new option "useDefaultExclusion" for build configuration to handle exclusion of hidden files ([1708](https://github.com/fabric8io/docker-maven-plugin/issues/1708))

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandler.java
@@ -212,6 +212,7 @@ public class DockerComposeConfigHandler implements ExternalConfigHandler {
                 .labels(wrapper.getLabels())
                 .links(wrapper.getLinks()) // external_links and links are handled the same in d-m-p
                 .log(wrapper.getLogConfiguration())
+                .platform(wrapper.getPlatform())
                 .network(wrapper.getNetworkConfig()) // TODO: Up to now only a single network is supported and not ipv4, ipv6
                 // pid not supported
                 .ports(wrapper.getPortMapping())

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -128,7 +128,11 @@ class DockerComposeServiceWrapper {
     boolean usesLongSyntaxDependsOn() {
         return asObject("depends_on") instanceof Map;
     }
-    
+
+    public String getPlatform() {
+        return asString("platform");
+    }
+
     /**
      * <a href="https://docs.docker.com/compose/compose-file/compose-file-v2/#depends_on">Docker Compose Spec v2.1+ defined conditions</a>
      */

--- a/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
@@ -6,7 +6,6 @@ import io.fabric8.maven.docker.config.RestartPolicy;
 import io.fabric8.maven.docker.config.RunImageConfiguration;
 import io.fabric8.maven.docker.config.RunVolumeConfiguration;
 import io.fabric8.maven.docker.config.handler.ExternalConfigHandlerException;
-import net.jodah.failsafe.internal.util.Assert;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
@@ -70,6 +69,15 @@ class DockerComposeConfigHandlerTest {
         validateRunConfiguration(configs.get(0).getRunConfiguration());
     }
 
+    @Test
+    void simpleExtraIn24() throws IOException, MavenFilteringException {
+        setupComposeExpectations("docker-compose_2.4.yml");
+        List<ImageConfiguration> configs = handler.resolve(unresolved, project, session);
+        Assertions.assertEquals(1, configs.size());
+        RunImageConfiguration runConfig = configs.get(0).getRunConfiguration();
+        Assertions.assertEquals("linux/amd64", runConfig.getPlatform());
+    }
+    
     @Test
     void networkAliases() throws IOException, MavenFilteringException {
         setupComposeExpectations("docker-compose-network-aliases.yml");
@@ -266,7 +274,6 @@ class DockerComposeConfigHandlerTest {
      * system
      */
     private void assertHostBindingExists(String bindString) {
-        //        System.err.println(">>>> " + bindString);
 
         // Extract the host-portion of the volume binding string, accounting for windows platform paths and unix style
         // paths.  For example:

--- a/src/test/resources/compose/docker-compose_2.4.yml
+++ b/src/test/resources/compose/docker-compose_2.4.yml
@@ -1,0 +1,5 @@
+version: 2.4
+services:
+  service:
+    image: image
+    platform: linux/amd64


### PR DESCRIPTION
On Mac M1 docker-maven-plugin when using external docker-compose.yml configuration produces the following error:
```
I/O Error: Unable to create container for [...] : {"message":"image with reference ... was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64"} (Not Found: 404)
```

The solution is to add platform declaration to each service image:
```
services:
  alias1:
    image: host/org/image:1.0.0
    platform: linux/amd64
```
which overrides the native platform value `linux/arm64` used by default. Unfortunately, the `platform` field in docker-compose config was ignored. This PR fixes that.

PS: Virtualization on Mac allows running amd64 build images.