### PR TITLE
chore: upgrade postgres to 16.3-alpine

### DIFF
--- a/it/docker-compose-dependon/Postgres.Dockerfile
+++ b/it/docker-compose-dependon/Postgres.Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:13-alpine
+FROM postgres:16.3-alpine
 HEALTHCHECK --interval=5s --timeout=5s --retries=5 \
     CMD "pg_isready" "-U" "postgres"

--- a/it/properties/pom.xml
+++ b/it/properties/pom.xml
@@ -23,7 +23,7 @@
     <postgres.docker.envRun.POSTGRES_PASSWORD>superuser-password</postgres.docker.envRun.POSTGRES_PASSWORD>
     <postgres.docker.envRun.POSTGRES_USER>superuser</postgres.docker.envRun.POSTGRES_USER>
     <postgres.docker.log.prefix>postgres</postgres.docker.log.prefix>
-    <postgres.docker.name>postgres:9.5.2</postgres.docker.name>
+    <postgres.docker.name>postgres:16.3-alpine</postgres.docker.name>
     <postgres.docker.ports.1>${itest.postgres.port}:5432</postgres.docker.ports.1>
     <postgres.docker.wait.log>PostgreSQL init process complete</postgres.docker.wait.log>
     <postgres.docker.wait.time>10000</postgres.docker.wait.time>

--- a/samples/multi-wait/pom.xml
+++ b/samples/multi-wait/pom.xml
@@ -23,7 +23,7 @@
           <images>
             <image>
               <alias>db</alias>
-              <name>postgres:9.6.0</name>
+              <name>postgres:16.3-alpine</name>
               <run>
                 <env>
                   <POSTGRES_PASSWORD>password</POSTGRES_PASSWORD>
@@ -35,7 +35,7 @@
             </image>
             <image>
               <alias>db2</alias>
-              <name>postgres:9.6.0</name>
+              <name>postgres:16.3-alpine</name>
               <run>
                 <env>
                   <POSTGRES_PASSWORD>password</POSTGRES_PASSWORD>

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -22,7 +22,7 @@
     <postgres.docker.envRun.POSTGRES_PASSWORD>superuser-password</postgres.docker.envRun.POSTGRES_PASSWORD>
     <postgres.docker.envRun.POSTGRES_USER>superuser</postgres.docker.envRun.POSTGRES_USER>
     <postgres.docker.log.prefix>postgres</postgres.docker.log.prefix>
-    <postgres.docker.name>postgres:9.5.2</postgres.docker.name>
+    <postgres.docker.name>postgres:16.3-alpine</postgres.docker.name>
     <postgres.docker.ports.1>${itest.postgres.port}:5432</postgres.docker.ports.1>
     <postgres.docker.wait.log>PostgreSQL init process complete</postgres.docker.wait.log>
     <postgres.docker.wait.time>10000</postgres.docker.wait.time>


### PR DESCRIPTION
Fix DEPRECATION NOTICE:

```
Error:  DOCKER> I/O Error [Unable to pull 'postgres:9.5.2' : [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/postgres:9.5.2 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/ ]
```
