### PR TITLE
Remove usage of AnsiConsole

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/AnsiLogger.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AnsiLogger.java
@@ -14,7 +14,6 @@ import java.util.function.Predicate;
 import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.StringUtils;
 import org.fusesource.jansi.Ansi;
-import org.fusesource.jansi.AnsiConsole;
 
 import static org.fusesource.jansi.Ansi.Color.*;
 import static org.fusesource.jansi.Ansi.ansi;
@@ -244,13 +243,7 @@ public class AnsiLogger implements Logger, Closeable {
 
     private void initializeColor(boolean useColor) {
         this.useAnsi = useColor && !log.isDebugEnabled();
-        if (useAnsi) {
-            AnsiConsole.systemInstall();
-            Ansi.setEnabled(true);
-        }
-        else {
-            Ansi.setEnabled(false);
-        }
+        Ansi.setEnabled(useAnsi);
     }
 
     private void initializePrintWriter() throws FileNotFoundException {

--- a/src/test/java/io/fabric8/maven/docker/util/AnsiLoggerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AnsiLoggerTest.java
@@ -21,11 +21,7 @@ package io.fabric8.maven.docker.util;
 import org.apache.maven.monitor.logging.DefaultLog;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.fusesource.jansi.Ansi;
-import org.fusesource.jansi.AnsiConsole;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,29 +29,6 @@ import org.junit.jupiter.api.Test;
  * @since 07/10/16
  */
 class AnsiLoggerTest {
-    @BeforeAll
-    public static void installAnsi() {
-        AnsiConsole.systemInstall();
-    }
-
-    @BeforeEach
-    void forceAnsiPassthrough() {
-        // Because the AnsiConsole keeps a per-VM counter of calls to systemInstall, it is
-        // difficult to force it to pass through escapes to stdout during test.
-        // Additionally, running the test in a suite (e.g. with mvn test) means other
-        // code may have already initialized or manipulated the AnsiConsole.
-        // Hence we just reset the stdout/stderr references to those captured by AnsiConsole
-        // during its static initialization and restore them after tests.
-        System.setOut(AnsiConsole.system_out);
-        System.setErr(AnsiConsole.system_err);
-    }
-
-    @AfterAll
-    public static void restoreAnsiPassthrough() {
-        AnsiConsole.systemUninstall();
-        System.setOut(AnsiConsole.out);
-        System.setErr(AnsiConsole.err);
-    }
 
     @Test
     void emphasizeDebug() {


### PR DESCRIPTION
Init of Ansi system is not needed in Maven plugin.

Additionally, Maven 4 switch to JLine
https://issues.apache.org/jira/browse/MNG-7995
and this class will be not available anymore