### PR TITLE
Gracefully handle 404 when removing container

### DIFF
--- a/it/graceful-container-removal/pom.xml
+++ b/it/graceful-container-removal/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.fabric8.dmp.itests</groupId>
+    <artifactId>dmp-it-parent</artifactId>
+    <version>0.45-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>fabric8io</groupId>
+  <artifactId>dmp-it-graceful-container-removal</artifactId>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <images>
+            <image>
+              <name>busybox</name>
+              <run>
+                <autoRemove>true</autoRemove>
+                <wait>
+                  <shutdown>128</shutdown>
+                </wait>
+              </run>
+            </image>
+          </images>
+        </configuration>
+        <executions>
+          <execution>
+            <id>start-docker</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop-docker</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -33,6 +33,7 @@
     <module>dockerfile-base-as-arg</module>
     <module>dockerfile-base-as-arg-buildconfig</module>
     <module>dockerignore</module>
+    <module>graceful-container-removal</module>
     <module>healthcheck</module>
     <module>helloworld</module>
     <module>log</module>

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -517,7 +517,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
         String url = urlBuilder.removeContainer(containerId, removeVolumes);
         log.verbose(Logger.LogVerboseCategory.API, API_LOG_FORMAT_DELETE, url);
         try {
-            delegate.delete(url, HTTP_NO_CONTENT);
+            delegate.delete(url, HTTP_NO_CONTENT, HTTP_NOT_FOUND);
         } catch (IOException e) {
             throw new DockerAccessException(e, "Unable to remove container [%s]", containerId);
         }


### PR DESCRIPTION
If a container is to be removed - yet doesn't exist anymore, we can gracefully handle the 404 by treating it as though the container had been removed.