### PR TITLE
ci : Add a pipeline for release to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release to Maven Central
+
+env:
+  MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e ${{ github.event.inputs.additional_args }}
+  RELEASE_MAVEN_ARGS: -Prelease -DstagingProgressTimeoutMinutes=20
+  OSSRHUSERNAME: ${{ secrets.OSSRHUSERNAME }}
+  OSSRHPASSWORD: ${{ secrets.OSSRHPASSWORD }}
+  SIGNINGPASSWORD: ${{ secrets.SIGNINGPASSWORD }}
+
+on:
+  workflow_dispatch:
+    input:
+      tag:
+        description: Tag to release
+        required: true
+      additional_args:
+        description: Additional Maven Args
+        required: false
+        default: ''
+      java_distribution:
+        description: Java Distribution to use for release
+        required: true
+        default: 'temurin'
+
+jobs:
+  release:
+    name: Release to maven central
+    # Cheap way to prevent accidental releases
+    # Modify the list to add users with release permissions
+    if: contains('["rhuss","rohanKanojia"]', github.actor)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: ${{ github.event.inputs.java_distribution }}
+          server-id: sonatype-nexus-staging 
+          server-username: OSSRHUSERNAME
+          server-password: OSSRHPASSWORD
+          gpg-private-key: ${{ secrets.SIGNINGKEY }}
+          gpg-passphrase: SIGNINGPASSWORD
+      - name: Build and Release Project
+        run: ./mvnw ${MAVEN_ARGS} ${RELEASE_MAVEN_ARGS} clean deploy


### PR DESCRIPTION
This is taken from [Fabric8 Kubernetes Client release pipeline](https://github.com/fabric8io/kubernetes-client/blob/main/.github/workflows/release.yaml)

It would take input of release tag and perform release of project at that specific revision. There are some additional inputs as well with java version and additional_args (for release).