### PR TITLE
 "Refactor to use getOrDefault method for default values #59"

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfiguration.java
@@ -7,11 +7,13 @@ public class DockerComposeConfiguration {
     private final String basedir;
     private final String composeFile;
     private final boolean ignoreBuild;
+    
     public DockerComposeConfiguration(Map<String, String> config) {
-        basedir = config.containsKey("basedir") ? config.get("basedir") : "src/main/docker";
-        composeFile = config.containsKey("composeFile") ? config.get("composeFile") : "docker-compose.yml";
-        ignoreBuild = config.containsKey("ignoreBuild") ? Boolean.parseBoolean(config.get("ignoreBuilder")) : false;
+    basedir = config.getOrDefault("basedir", "src/main/docker");
+    composeFile = config.getOrDefault("composeFile", "docker-compose.yml");
+    ignoreBuild = Boolean.parseBoolean(config.getOrDefault("ignoreBuild", "false"));
     }
+
 
     String getBasedir() {
         return basedir;


### PR DESCRIPTION
This pull request refactors the DockerComposeConfiguration constructor to use Java's built-in getOrDefault method available on the Map interface for assigning default values. This change enhances code readability and simplifies the logic for default value assignment.

Changes Made
Replaced the usage of ternary operators with getOrDefault for retrieving configuration values from the config map.
Updated the assignment of basedir, composeFile, and ignoreBuild fields to use getOrDefault.