### PR TITLE
refactor: replace list iteration with List.replaceAll method

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/VolumeBindingUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/VolumeBindingUtil.java
@@ -233,9 +233,7 @@ public class VolumeBindingUtil {
             return;
         }
 
-        for (int i = 0; i < bindings.size(); i++) {
-            bindings.set(i, resolveRelativeVolumeBinding(baseDir, bindings.get(i)));
-        }
+        bindings.replaceAll(binding -> resolveRelativeVolumeBinding(baseDir, binding));
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/fabric8io/docker-maven-plugin/issues/1813

This pull request resolves the mentioned issue by updating the volumeBinding list iteration and set operation by using Java's built-in replaceAll method.