### PR TITLE
Docker build cache friendly example updated

### DIFF
--- a/samples/build-cache/README.md
+++ b/samples/build-cache/README.md
@@ -30,24 +30,36 @@ When building the project multiple times, note that subsequent builds log "Using
 ```
 $ mvn clean package
 ...
-[INFO] DOCKER> Step 1 : FROM gcr.io/distroless/java-debian10
-[INFO] DOCKER> ---> f6a5dc137f9b
-[INFO] DOCKER> Step 2 : USER nonroot
+[INFO] DOCKER> Step 1/10 : FROM gcr.io/distroless/java-debian10
+[INFO] DOCKER>
+[INFO] DOCKER> ---> 444adf12984c
+[INFO] DOCKER> Step 2/10 : USER nonroot
+[INFO] DOCKER>
 [INFO] DOCKER> ---> Using cache
-[INFO] DOCKER> ---> 26d64b9907e3
-[INFO] DOCKER> Step 3 : ENTRYPOINT
+[INFO] DOCKER> ---> 043b487914d1
+[INFO] DOCKER> Step 3/10 : WORKDIR "/app"
+[INFO] DOCKER>
 [INFO] DOCKER> ---> Using cache
-[INFO] DOCKER> ---> 6eb12980cd38
-[INFO] DOCKER> Step 4 : WORKDIR "/app"
+[INFO] DOCKER> ---> 08ef41fef30f
+[INFO] DOCKER> Step 4/10 : CMD ["tini", "-e", "130", "-e", "143", "--", "java", "org.springframework.boot.loader.JarLauncher"]
+[INFO] DOCKER>
 [INFO] DOCKER> ---> Using cache
-[INFO] DOCKER> ---> d6a408147d7c
-[INFO] DOCKER> Step 5 : CMD tini -e 130 -e 143 -- java org.springframework.boot.loader.JarLauncher
+[INFO] DOCKER> ---> 2ac94352abe0
+[INFO] DOCKER> Step 5/10 : ADD ["dependencies.tar", "/"]
+[INFO] DOCKER>
 [INFO] DOCKER> ---> Using cache
-[INFO] DOCKER> ---> 461505b7ade9
-[INFO] DOCKER> Step 6 : ADD dependencies.tar /
+[INFO] DOCKER> ---> aafdf67c0508
+[INFO] DOCKER> Step 6/10 : ADD ["spring-boot-loader.tar", "/"]
+[INFO] DOCKER>
 [INFO] DOCKER> ---> Using cache
-[INFO] DOCKER> ---> df87a8d003f3
-[INFO] DOCKER> Step 7 : ADD spring-boot-loader.tar /
+[INFO] DOCKER> ---> f593e7c3c58d
+[INFO] DOCKER> Step 7/10 : ADD ["snapshot-dependencies.tar", "/"]
+[INFO] DOCKER>
 [INFO] DOCKER> ---> Using cache
-[INFO] DOCKER> ---> 2de1bf3ac9ad
+[INFO] DOCKER> ---> ef1f89b783b5
+[INFO] DOCKER> Step 8/10 : ADD ["application.tar", "/"]
+[INFO] DOCKER>
+[INFO] DOCKER> ---> Using cache
+[INFO] DOCKER> ---> 055ba36bb45f
+...
 ```

--- a/samples/build-cache/app/pom.xml
+++ b/samples/build-cache/app/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <!-- Avoid docker build cache invalidation due to new commits -->
-    <project.build.outputTimestamp>1970-01-01T00:00:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2000-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>

--- a/samples/build-cache/image/pom.xml
+++ b/samples/build-cache/image/pom.xml
@@ -17,7 +17,7 @@
 
     <image>fabric8/dmp-sample-build-cache-app:${project.version}</image>
     <!-- Avoid docker build cache invalidation due to new commits -->
-    <project.build.outputTimestamp>1970-01-01T00:00:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2000-01-01T00:00:00Z</project.build.outputTimestamp>
     <tini.sha512>8053cc21a3a9bdd6042a495349d1856ae8d3b3e7664c9654198de0087af031f5d41139ec85a2f5d7d2febd22ec3f280767ff23b9d5f63d490584e2b7ad3c218c</tini.sha512>
 
     <tini.version>0.19.0</tini.version>

--- a/samples/build-cache/image/src/main/docker/Dockerfile
+++ b/samples/build-cache/image/src/main/docker/Dockerfile
@@ -11,11 +11,6 @@ FROM gcr.io/distroless/java-debian10
 # Just for security
 USER nonroot
 
-# Entry point of the base image executes java which we don't need because we use tini in the image command.
-# tini (https://github.com/krallin/tini) is used to enforce zero exit code when Java application is stopped
-# using SIGINT or SIGTERM.
-ENTRYPOINT []
-
 # /app directory contains all items of the wanted Java class path.
 WORKDIR "/app"
 
@@ -31,6 +26,11 @@ ADD ["spring-boot-loader.tar", "/"]
 ADD ["snapshot-dependencies.tar", "/"]
 # ... application code
 ADD ["application.tar", "/"]
+
+# Entry point of the base image executes java which we don't need because we use tini in the image command.
+# tini (https://github.com/krallin/tini) is used to enforce zero exit code when Java application is stopped
+# using SIGINT or SIGTERM.
+ENTRYPOINT []
 
 # Put version into the last layer because LABEL directive produces more lightweight layer than ADD.
 LABEL name="@{image}" \

--- a/samples/build-cache/pom.xml
+++ b/samples/build-cache/pom.xml
@@ -26,7 +26,7 @@
     <git-commit-id-plugin.version>4.0.3</git-commit-id-plugin.version>
 
     <git.commit.dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</git.commit.dateFormat>
-    <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Update of example introduced in #1412 to make it compatible with recent versions of Docker Engine (tested on 19.03.12 and 27.1.1).