### PR TITLE
Fix for missing classes required on executeStopOnVMShutdown:true

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StopMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StopMojo.java
@@ -98,6 +98,11 @@ public class StopMojo extends AbstractDockerMojo {
                 // HttpDelete class is not used during start mojo, so we need to load it and initialize it. It is not
                 // possible to load classes in the shutdown hook as
                 Class.forName("org.apache.http.client.methods.HttpDelete", true, this.getClass().getClassLoader());
+
+                // com.google.common.base.Strings class from com.google.guava is required and it depends on Platforms
+                // Used in @see io.fabric8.maven.docker.util.ImageNameFormatter
+                Class.forName("com.google.common.base.Strings", true, this.getClass().getClassLoader());
+                Class.forName("com.google.common.base.Platform", true, this.getClass().getClassLoader());
             } catch (ClassNotFoundException e) {
                 log.error("Failure in loading org.apache.http.client.methods.HttpDelete class: %s", e.getMessage());
             }


### PR DESCRIPTION
I encountered the following issue:
![image](https://github.com/user-attachments/assets/eb390032-6d1e-4150-a431-8385c7898400)

Using:

```
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: C:\Program Files\apache-maven
Java version: 17.0.12, vendor: Eclipse Adoptium, runtime: C:\Program Files\Java\jdk-17.0.12+7
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 10", version: "10.0", arch: "amd64", family: "windows"
```
Adding the two required classes to the Class loader resolved the issue. I didn't go in too deep why that check using Strings occurs.

Here's the execution config which lead to this:
```xml
					<execution>
						<id>remove-it-database</id>
						<goals>
							<goal>stop</goal>
						</goals>
						<configuration>
							<executeStopOnVMShutdown>true</executeStopOnVMShutdown>
							<removeVolumes>true</removeVolumes>
							<skip>${skipTests}</skip>
						</configuration>
						<phase>pre-integration-test</phase>
					</execution>
```