### PR TITLE
issue #1834: Refactor to Replace Guava with JDK Built-In Functionalities

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,7 +57,7 @@ jobs:
           path: ~/.m2/repository
           key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
       - name: Set up Docker
-        uses: crazy-max/ghaction-setup-docker@v3
+        uses: crazy-max/ghaction-setup-docker@v4
         with:
           version: ${{ matrix.docker }}
       - name: Run Integration tests
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker: [v27.1.1, v26.1.4, v25.0.2, v24.0.9, v23.0.6, v20.10.24]
+        docker: [v27.5.1, v26.1.4]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -91,7 +91,7 @@ jobs:
         name: Install QEMU 9.0.2
         uses: docker/actions-toolkit/.github/actions/macos-setup-qemu@19ca9ade20f5da695f76a10988d6532058575f82
       - name: Set up Docker
-        uses: crazy-max/ghaction-setup-docker@v3
+        uses: crazy-max/ghaction-setup-docker@v4
         with:
           version: ${{ matrix.docker }}
       - name: Set up Docker Buildx

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -2,7 +2,12 @@ package io.fabric8.maven.docker;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Date;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -2,15 +2,11 @@ package io.fabric8.maven.docker;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableList;
 import io.fabric8.maven.docker.access.DockerAccess;
 import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.access.ExecException;
@@ -501,8 +497,9 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         return dispatcher;
     }
 
-    private ImmutableList<ImageConfiguration> getAllImages() {
-        ImmutableList.Builder<ImageConfiguration> allImages = ImmutableList.builder();
+    private List<ImageConfiguration> getAllImages() {
+        List<ImageConfiguration> allImages = new ArrayList<>();
+
         if (images != null) {
             allImages.addAll(images);
         }
@@ -514,7 +511,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
                 allImages.add(config);
             });
         }
-        return allImages.build();
+        return Collections.unmodifiableList(allImages);
     }
 
     public ImagePullManager getImagePullManager(String imagePullPolicy, String autoPull) {

--- a/src/main/java/io/fabric8/maven/docker/util/ContainerNamingUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/ContainerNamingUtil.java
@@ -1,6 +1,13 @@
 package io.fabric8.maven.docker.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 

--- a/src/main/java/io/fabric8/maven/docker/util/ContainerNamingUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/ContainerNamingUtil.java
@@ -1,15 +1,9 @@
 package io.fabric8.maven.docker.util;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableSet;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.config.RunImageConfiguration;
 import io.fabric8.maven.docker.model.Container;
@@ -164,11 +158,12 @@ public class ContainerNamingUtil {
     }
 
     private static Set<String> extractContainerNames(final Collection<Container> existingContainers) {
-        final ImmutableSet.Builder<String> containerNamesBuilder = ImmutableSet.builder();
+        final Set<String> containerNamesBuilder = new HashSet<>();
         for (final Container container : existingContainers) {
             containerNamesBuilder.add(container.getName());
         }
-        return containerNamesBuilder.build();
+
+        return Collections.unmodifiableSet(containerNamesBuilder);
     }
 
     private static String extractContainerNamePattern(ImageConfiguration image, String defaultContainerNamePattern) {

--- a/src/main/java/io/fabric8/maven/docker/util/CredentialHelperClient.java
+++ b/src/main/java/io/fabric8/maven/docker/util/CredentialHelperClient.java
@@ -1,12 +1,11 @@
 package io.fabric8.maven.docker.util;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import com.google.gson.JsonObject;
 
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
 
 import io.fabric8.maven.docker.access.AuthConfig;
@@ -93,7 +92,7 @@ public class CredentialHelperClient {
     // echo <registryToLookup> | docker-credential-XXX get
     private class GetCommand extends ExternalCommand {
 
-        private List<String> reply = Lists.newLinkedList();
+        private final List<String> reply = new LinkedList<>();
 
         GetCommand() {
             super(CredentialHelperClient.this.log);
@@ -119,9 +118,10 @@ public class CredentialHelperClient {
                     throw ex;
                 }
             }
-            JsonObject credentials = JsonFactory.newJsonObject(Joiner.on('\n').join(reply));
+            String joinedReply = String.join("\n", reply);
+            JsonObject credentials = JsonFactory.newJsonObject(joinedReply);
             if (!credentials.has(SECRET_KEY) || !credentials.has(USERNAME_KEY)) {
-                return null;
+                return null;  // If keys are missing, return null
             }
             return credentials;
         }

--- a/src/main/java/io/fabric8/maven/docker/util/ImageNameFormatter.java
+++ b/src/main/java/io/fabric8/maven/docker/util/ImageNameFormatter.java
@@ -20,8 +20,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
-import com.google.common.base.Strings;
 import io.fabric8.maven.docker.config.ConfigHelper;
 import org.apache.maven.project.MavenProject;
 
@@ -178,7 +178,7 @@ public class ImageNameFormatter implements ConfigHelper.NameFormatter {
 
             public String transform(MavenProject project, String tag, Date now) {
                 // In case the Maven property is also a placeholder, replace it as well
-                if (Strings.isNullOrEmpty(tag) || tag.equals("%" + letter)) {
+                if(isNullorEmpty(tag) || tag.equals("%" + letter)) {
                     tag = project.getVersion();
                 }
                 return doTransform(tag, now);
@@ -247,5 +247,9 @@ public class ImageNameFormatter implements ConfigHelper.NameFormatter {
 
         // All characters must be lowercase
         return ret.toString().toLowerCase();
+    }
+
+    private static boolean isNullorEmpty(String s) {
+        return Objects.isNull(s) || s.isEmpty();
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/util/ImageNameFormatter.java
+++ b/src/main/java/io/fabric8/maven/docker/util/ImageNameFormatter.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import io.fabric8.maven.docker.config.ConfigHelper;
 import org.apache.maven.project.MavenProject;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 /**
  * Replace placeholders in an image name with certain properties found in the
  * project
@@ -178,7 +180,7 @@ public class ImageNameFormatter implements ConfigHelper.NameFormatter {
 
             public String transform(MavenProject project, String tag, Date now) {
                 // In case the Maven property is also a placeholder, replace it as well
-                if(isNullorEmpty(tag) || tag.equals("%" + letter)) {
+                if(isEmpty(tag) || tag.equals("%" + letter)) {
                     tag = project.getVersion();
                 }
                 return doTransform(tag, now);
@@ -247,9 +249,5 @@ public class ImageNameFormatter implements ConfigHelper.NameFormatter {
 
         // All characters must be lowercase
         return ret.toString().toLowerCase();
-    }
-
-    private static boolean isNullorEmpty(String s) {
-        return Objects.isNull(s) || s.isEmpty();
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/util/JibServiceUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/util/JibServiceUtil.java
@@ -20,7 +20,6 @@ import io.fabric8.maven.docker.assembly.AssemblyFiles;
 import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
 import io.fabric8.maven.docker.config.ImageConfiguration;
-import io.fabric8.maven.docker.model.Image;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;


### PR DESCRIPTION
@rohanKanojia, This PR refactors several classes by replacing Guava-specific collections and utilities with their corresponding Java Standard Library counterparts #1834. The following changes have been made:

- **`AbstractDockerMojo.java`**: 
  - I replaced `ImmutableList` with `List` and used `ArrayList` to build the list and `Collections.unmodifiableList` for immutability.
  
- **`ContainerNamingUtil.java`**: 
  - I replaced `ImmutableSet` with `HashSet` and switched to `Collections.unmodifiableSet` for immutability.

- **`CredentialHelperClient.java`**:
  - I replaced Guava's `Joiner` with `String.join()` and `Lists.newLinkedList()` with `new LinkedList<>()`.

- **`ImageNameFormatter.java`**:
  - I replaced Guava's `Strings.isNullOrEmpty()` with `String.isNullOrEmpty()`.

- **`JibServiceUtil.java`**:
  - Removed unused Guava imports.



Please review and merge when ready. Feel free to let me know if you have any questions or concerns.
