### PR TITLE
Move off direct SecDispatcher use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,13 @@
 
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${maven.version}</version>
       <scope>provided</scope>
@@ -186,6 +193,13 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-settings-builder</artifactId>
       <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -244,7 +258,6 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <version>3.0.24</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -293,13 +306,6 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.plexus</groupId>
-      <artifactId>plexus-sec-dispatcher</artifactId>
-      <version>1.3</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/src/test/java/io/fabric8/maven/docker/PushMojoBuildXTest.java
+++ b/src/test/java/io/fabric8/maven/docker/PushMojoBuildXTest.java
@@ -14,6 +14,8 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.crypto.DefaultSettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.junit.jupiter.api.AfterEach;
@@ -62,6 +64,7 @@ class PushMojoBuildXTest {
     DockerAccess dockerAccess = mock(DockerAccess.class);
     PlexusContainer mockedPlexusContainer = mock(PlexusContainer.class);
     SecDispatcher mockedSecDispatcher = mock(SecDispatcher.class);
+    when(mockedPlexusContainer.lookup(SettingsDecrypter.class)).thenReturn(new DefaultSettingsDecrypter(mockedSecDispatcher));
     ServiceHubFactory serviceHubFactory = new ServiceHubFactory();
     when(mockedMavenSettings.getInteractiveMode()).thenReturn(false);
     Properties properties = new Properties();

--- a/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AuthConfigFactoryTest.java
@@ -14,6 +14,8 @@ import org.apache.http.impl.bootstrap.ServerBootstrap;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.crypto.DefaultSettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.codehaus.plexus.util.Base64;
@@ -101,7 +103,7 @@ class AuthConfigFactoryTest {
 
     @BeforeEach
     void containerSetup() throws ComponentLookupException, SecDispatcherException {
-        Mockito.lenient().when(container.lookup(SecDispatcher.ROLE, "maven")).thenReturn(secDispatcher);
+        Mockito.lenient().when(container.lookup(SettingsDecrypter.class)).thenReturn(new DefaultSettingsDecrypter(secDispatcher));
         Mockito.lenient().when(secDispatcher.decrypt(Mockito.anyString())).thenAnswer(invocation -> invocation.getArguments()[0]);
 
         factory = new AuthConfigFactory(container);


### PR DESCRIPTION
Use the "official" way instead, and it solves Maven 4 support as well.

Changes:
* align Maven deps (maven-compat was 3.0 while maven-core 3.8.1)
* since Maven 3.9 plexus util is NOT provided
* do not use directly SecDispatcher, use Maven APIs instead
* fix UTs