### PR TITLE
fix: respects network configuration for buildx

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,7 +3,7 @@
 * **0.46-SNAPSHOT**:
   - Docker-compose healthcheck configuration support ([1825](https://github.com/fabric8io/docker-maven-plugin/pull/1825))
   - Docker container wait timeout default value made configurable using startContainerWaitTimeout configuration option ([1825](https://github.com/fabric8io/docker-maven-plugin/pull/1825))
-  - Respect `network` configuration in POM and with property `docker.build.network` or system property `docker.network.mode` in docker buildx [TBD](https://github.com/fabric8io/docker-maven-plugin/pull/TBD))
+  - Respect `network` configuration in POM and with property `docker.build.network` or system property `docker.network.mode` in docker buildx [1850](https://github.com/fabric8io/docker-maven-plugin/pull/1850))
 
 * **0.45.1 (2024-09-29)**:
   - Make copy docker-buildx binary to temporary config directory work on windows too ([1819](https://github.com/fabric8io/docker-maven-plugin/pull/1819))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,7 +1,9 @@
 # ChangeLog
+
 * **0.46-SNAPSHOT**:
   - Docker-compose healthcheck configuration support ([1825](https://github.com/fabric8io/docker-maven-plugin/pull/1825))
   - Docker container wait timeout default value made configurable using startContainerWaitTimeout configuration option ([1825](https://github.com/fabric8io/docker-maven-plugin/pull/1825))
+  - Respect `network` configuration in POM and with property `docker.build.network` or system property `docker.network.mode` in docker buildx [TBD](https://github.com/fabric8io/docker-maven-plugin/pull/TBD))
 
 * **0.45.1 (2024-09-29)**:
   - Make copy docker-buildx binary to temporary config directory work on windows too ([1819](https://github.com/fabric8io/docker-maven-plugin/pull/1819))

--- a/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/ConfigHelper.java
@@ -173,6 +173,20 @@ public class ConfigHelper {
         }
     }
 
+    public static String getNetwork(ImageConfiguration imageConfig) {
+        String network = imageConfig.getBuildConfiguration().getNetwork();
+        if (network == null) {
+            network = System.getProperty("docker.network.mode");
+        }
+        if (network == null) {
+            network = System.getProperty("docker.build.network");
+        }
+        if(network!=null && network.isEmpty()) {
+           network = null;
+        }
+        return network;
+    }
+
     public static boolean isNoCache(ImageConfiguration imageConfig) {
         String noCache = System.getProperty("docker.noCache");
         if (noCache == null) {

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -169,6 +169,11 @@ public class BuildXService {
             cmdLine.add("--no-cache");
         }
 
+        String networkMode = ConfigHelper.getNetwork(imageConfig);
+        if (networkMode!=null) {
+            cmdLine.add("--network="+networkMode);
+        }
+
         BuildXConfiguration buildXConfiguration = buildConfiguration.getBuildX();
         AttestationConfiguration attestations = buildXConfiguration.getAttestations();
         if (attestations != null) {
@@ -294,7 +299,8 @@ public class BuildXService {
             }
             int rc = exec.process(cmds);
             if (rc != 0) {
-                throw new MojoExecutionException("Error status (" + rc + ") while creating builder " + builderName);
+                logger.warn("Failed to execute: {}", cmds);
+                // throw new MojoExecutionException("Error status (" + rc + ") while creating builder " + builderName);
             }
         }
         return builderName;

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -299,8 +299,7 @@ public class BuildXService {
             }
             int rc = exec.process(cmds);
             if (rc != 0) {
-                logger.warn("Failed to execute: {}", cmds);
-                // throw new MojoExecutionException("Error status (" + rc + ") while creating builder " + builderName);
+                throw new MojoExecutionException("Error status (" + rc + ") while creating builder " + builderName);
             }
         }
         return builderName;

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
@@ -127,6 +127,19 @@ class BuildXServiceTest {
     }
 
     @Test
+    void testNetworkIsPropagatedToBuildx() throws Exception {
+
+        //Given
+        buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> buildImage.network("host"));
+
+        // When
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+
+        //Then
+        verifyBuildXArgumentPresentInExec("--network=host");
+    }
+
+    @Test
     void testNoCacheIsPropagatedToBuildx() throws Exception {
 
         //Given


### PR DESCRIPTION
### Description

I have found that the configuration of the network (in Docker with the parameter `--network`) is not respected in multi-arch builds using `buildx`. One can configure the network as stated in the documentation, however, this has no effect on the commandline call of `docker`.

### Cause

The reason is that the configuration of `network` is simply not considered.

### Solution

I provided a unit tests which shows the problem and a fix that considers the configuration done via System properties, Maven properties, and in the configuration of the plugin.

