### PR TITLE
Allow non-standard build directory.

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -196,7 +196,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     @Parameter(property = "docker.source.dir", defaultValue="src/main/docker")
     public String sourceDirectory;
 
-    @Parameter(property = "docker.target.dir", defaultValue="target/docker")
+    @Parameter(property = "docker.target.dir", defaultValue="${project.build.directory}/docker")
     public String outputDirectory;
 
     // Authentication information


### PR DESCRIPTION
Currently, the general `outputDirectory` has a fixed default of `target/docker`, which breaks projects with a diverting `${project.build.directory}`.
This change simply adjusts the default, so this aligns correctly.