### PR TITLE
ci : fix docs pipeline by updating github action upload-artifact to latest version

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           mvn -Pdoc-html && mvn -Pdoc-pdf
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3    
         with:
           path: ./target/generated-docs
   deploy:
@@ -40,4 +40,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description

Documentaiton pipeline is failing https://github.com/fabric8io/docker-maven-plugin/actions/runs/14295932021

bump github action upload-artifact version to v4 to fix failure.