### PR TITLE
Fix #1863 by treating a buildArchiveOnly path as `true`

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -137,6 +137,7 @@ public class BuildMojo extends AbstractDockerMojo {
                     buildArchiveOnly.equalsIgnoreCase("true")) {
                 return Boolean.parseBoolean(buildArchiveOnly);
             }
+            return true;
         }
         return false;
     }

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -87,6 +87,27 @@ class BuildMojoTest extends MojoTestBase {
     }
 
     @Test
+    void noSkipWhenDefaultBuildArchiveOnly() throws IOException, MojoExecutionException {
+        givenMavenProject(buildMojo);
+        givenResolvedImages(buildMojo, Collections.singletonList(singleImageConfiguration(builder -> {})));
+
+        whenMojoExecutes();
+
+        thenBuildRun();
+    }
+
+    @Test
+    void skipImageBuildWhenBuildArchiveOnlyPath() throws IOException, MojoExecutionException {
+        givenMavenProject(buildMojo);
+        givenResolvedImages(buildMojo, Collections.singletonList(singleImageConfiguration(builder -> {})));
+        givenBuildArchiveOnly("target");
+
+        whenMojoExecutes();
+
+        thenBuildNotRun();
+    }
+
+    @Test
     void buildUsingBuildx() throws IOException, MojoExecutionException {
         givenBuildXService();
 
@@ -456,6 +477,10 @@ class BuildMojoTest extends MojoTestBase {
 
     private void givenSkipPom(boolean skipPom) {
         buildMojo.skipPom = skipPom;
+    }
+
+    private void givenBuildArchiveOnly(String archiveOnly) {
+        buildMojo.buildArchiveOnly = archiveOnly;
     }
 
     private void whenMojoExecutes() throws IOException, MojoExecutionException {


### PR DESCRIPTION
Adds a fall-through return for when `buildArchiveOnly` is not empty, but is not a boolean.  Adds unit tests for this logic and the default case to ensure `buildArchiveOnly` continues to default to `false` if not set.