### PR TITLE
Make all mojos threadsafe

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -35,7 +35,7 @@ import static io.fabric8.maven.docker.service.RegistryService.createCompleteAuth
  * @author roland
  * @since 28.07.14
  */
-@Mojo(name = "build", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "build", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class BuildMojo extends AbstractDockerMojo {
 
     public static final String DMP_PLUGIN_DESCRIPTOR = "META-INF/maven/io.fabric8/dmp-plugin";

--- a/src/main/java/io/fabric8/maven/docker/CopyMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/CopyMojo.java
@@ -41,7 +41,7 @@ import io.fabric8.maven.docker.util.Logger;
  * matching images configured in the project are searched and the copying is performed from the found containers
  * only.</p>
  */
-@Mojo(name = "copy", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
+@Mojo(name = "copy", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, threadSafe = true)
 public class CopyMojo extends AbstractDockerMojo {
 
     private static final String COPY_NAME_PATTERN_CONFIG = "copyNamePattern";

--- a/src/main/java/io/fabric8/maven/docker/LogsMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/LogsMojo.java
@@ -24,7 +24,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @since 26.03.14
  *
  */
-@Mojo(name = "logs")
+@Mojo(name = "logs", threadSafe = true)
 public class LogsMojo extends AbstractDockerMojo {
 
     // Whether to log infinitely or to show only the logs happened until now.

--- a/src/main/java/io/fabric8/maven/docker/PushMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/PushMojo.java
@@ -15,7 +15,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  *
  * @author roland
  */
-@Mojo(name = "push", defaultPhase = LifecyclePhase.DEPLOY)
+@Mojo(name = "push", defaultPhase = LifecyclePhase.DEPLOY, threadSafe = true)
 public class PushMojo extends AbstractDockerMojo {
 
     // Registry to use for push operations if no registry is specified

--- a/src/main/java/io/fabric8/maven/docker/RemoveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/RemoveMojo.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  * @since 23.10.14
  *
  */
-@Mojo(name = "remove", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
+@Mojo(name = "remove", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, threadSafe = true)
 public class RemoveMojo extends AbstractDockerMojo {
 
     private static final String REMOVE_NAME_PATTERN_CONFIG = "removeNamePattern";

--- a/src/main/java/io/fabric8/maven/docker/RunMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/RunMojo.java
@@ -24,7 +24,7 @@ import org.apache.maven.plugins.annotations.Mojo;
  * @author roland
  * @since 26/04/16
  */
-@Mojo(name = "run", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+@Mojo(name = "run", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, threadSafe = true)
 public class RunMojo extends StartMojo {
 
     @Override

--- a/src/main/java/io/fabric8/maven/docker/SaveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/SaveMojo.java
@@ -18,7 +18,7 @@ import io.fabric8.maven.docker.access.DockerAccessException;
 import io.fabric8.maven.docker.config.ImageConfiguration;
 import io.fabric8.maven.docker.service.ServiceHub;
 
-@Mojo(name = "save")
+@Mojo(name = "save", threadSafe = true)
 public class SaveMojo extends AbstractDockerMojo {
 
     // Used when not automatically determined

--- a/src/main/java/io/fabric8/maven/docker/SourceMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/SourceMojo.java
@@ -44,7 +44,7 @@ import org.apache.maven.project.MavenProjectHelper;
  * @author roland
  * @since 25/10/15
  */
-@Mojo(name = "source", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "source", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class SourceMojo extends AbstractDockerMojo {
 
     @Component

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -52,7 +52,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  *
  * @author roland
  */
-@Mojo(name = "start", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+@Mojo(name = "start", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, threadSafe = true)
 public class StartMojo extends AbstractDockerMojo {
 
     @Parameter(property = "docker.showLogs")

--- a/src/main/java/io/fabric8/maven/docker/StopMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StopMojo.java
@@ -43,7 +43,7 @@ import io.fabric8.maven.docker.util.GavLabel;
  * @since 26.03.14
  *
  */
-@Mojo(name = "stop", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
+@Mojo(name = "stop", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, threadSafe = true)
 public class StopMojo extends AbstractDockerMojo {
 
     private static final String STOP_NAME_PATTERN_CONFIG = "stopNamePattern";

--- a/src/main/java/io/fabric8/maven/docker/TagMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/TagMojo.java
@@ -15,7 +15,7 @@ import java.util.List;
  * Goal for Tagging an image so that it becomes part of a repository.
  *
  */
-@Mojo(name = "tag", defaultPhase = LifecyclePhase.INSTALL)
+@Mojo(name = "tag", defaultPhase = LifecyclePhase.INSTALL, threadSafe = true)
 public class TagMojo extends AbstractDockerMojo {
     @Parameter(property = "docker.skip.tag", defaultValue = "false")
     private boolean skipTag;

--- a/src/main/java/io/fabric8/maven/docker/VolumeCreateMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/VolumeCreateMojo.java
@@ -15,7 +15,7 @@ import org.apache.maven.plugins.annotations.Mojo;
  * @author Tom Burton
  * @version Dec 15, 2016
  */
-@Mojo(name = "volume-create", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
+@Mojo(name = "volume-create", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, threadSafe = true)
 public class VolumeCreateMojo extends AbstractDockerMojo {
 
     @Override

--- a/src/main/java/io/fabric8/maven/docker/VolumeRemoveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/VolumeRemoveMojo.java
@@ -15,7 +15,7 @@ import org.apache.maven.plugins.annotations.Mojo;
  *
  *  @author Tom Burton
  */
-@Mojo(name = "volume-remove", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST)
+@Mojo(name = "volume-remove", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, threadSafe = true)
 public class VolumeRemoveMojo extends AbstractDockerMojo {
 
    @Override

--- a/src/main/java/io/fabric8/maven/docker/WatchMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/WatchMojo.java
@@ -40,7 +40,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * @author roland
  * @since 16/06/15
  */
-@Mojo(name = "watch")
+@Mojo(name = "watch", threadSafe = true)
 public class WatchMojo extends AbstractDockerMojo {
 
     /**

--- a/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
@@ -21,7 +21,7 @@ class ContainerHostConfigTest {
     @Test
     void testExtraHostsDoesNotResolve() {
         ContainerHostConfig hc = new ContainerHostConfig();
-        List<String> extraHosts = Collections.singletonList("database.pvt:ahostnamewhichreallyshouldnot.exist.zz");
+        List<String> extraHosts = Collections.singletonList("database.pvtahostnamewhichreallyshouldnot.exist.zz");
         Assertions.assertThrows(IllegalArgumentException.class, () -> hc.extraHosts(extraHosts));
     }
 


### PR DESCRIPTION
## Description
When using `mvnd` to build Docker images with the `BuildMojo`, users get the following warning

```bash
[INFO] ----------------------------[ docker-build ]----------------------------
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but this         *
[WARNING] * project contains the following plugin(s) that have goals not  *
[WARNING] * marked as thread-safe to support parallel execution.          *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against Apache Maven.                           *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked as thread-safe in <modules>:
[WARNING]   io.fabric8:docker-maven-plugin:0.46.0
[WARNING] 
[WARNING] Enable debug to see precisely which goals are not marked as thread-safe.
[WARNING] *****************************************************************
```

The purpose of this PR is to resolve this warning by making all of the Mojos thread safe.

## Notes
`testExtraHostsDoesNotResolve` method was broken, so I updated the test to resolve the issue.