### PR TITLE
Issue #1870 - dmp:tag should skip <image>s with no <build>

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/TagMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/TagMojo.java
@@ -35,7 +35,8 @@ public class TagMojo extends AbstractDockerMojo {
         List<ImageConfiguration> imageConfigs = getResolvedImages();
         for (ImageConfiguration imageConfig : imageConfigs) {
             BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
-            if (buildConfig.skipTag() || buildConfig.isBuildX()) {
+
+            if (buildConfig == null || buildConfig.skipTag() || buildConfig.isBuildX()) {
                 // Tag happens at the building stage.
                 continue;
             }


### PR DESCRIPTION
Fix #1870