### PR TITLE
ci : Update release snapshots configuration after Fabric8 namespace migration to central portal

### DIFF
--- a/.github/workflows/release-snapshots.yml
+++ b/.github/workflows/release-snapshots.yml
@@ -3,8 +3,8 @@ name: Release to SNAPSHOTS Maven Central
 env:
   MAVEN_ARGS: -B -C -V -ntp -Dhttp.keepAlive=false -e ${{ github.event.inputs.additional_args }}
   RELEASE_MAVEN_ARGS: -Prelease -Denforcer.skip=true
-  OSSRHUSERNAME: ${{ secrets.OSSRHUSERNAME }}
-  OSSRHPASSWORD: ${{ secrets.OSSRHPASSWORD }}
+  MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+  MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
   SIGNINGPASSWORD: ${{ secrets.SIGNINGPASSWORD }}
 
 on:
@@ -27,9 +27,9 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-          server-id: sonatype-nexus-snapshots
-          server-username: OSSRHUSERNAME
-          server-password: OSSRHPASSWORD
+          server-id: central-portal-snapshots
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.SIGNINGKEY }}
           gpg-passphrase: SIGNINGPASSWORD
       - name: Build and Release Project

--- a/pom.xml
+++ b/pom.xml
@@ -62,14 +62,15 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
     <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <id>central-portal-snapshots</id>
+      <name>Central Portal (Snapshots)</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
 
   <properties>
     <byte-buddy.version>1.12.10</byte-buddy.version>
+    <central-publishing-maven-plugin>0.7.0</central-publishing-maven-plugin>
     <httpclient.version>4.5.13</httpclient.version>
     <jib-core.version>0.24.0</jib-core.version>
     <jnr-jffi.version>1.3.11</jnr-jffi.version>
@@ -609,12 +610,12 @@
           </plugin>
 
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-maven-plugin.version}</version>
             <configuration>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <serverId>oss-sonatype-staging</serverId>
+              <publishingServerId>central-portal</publishingServerId>
+              <autoPublish>false</autoPublish>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
## Description

CI Pipeline to push SNAPSHOTs is failing:
```
Caused by: org.eclipse.aether.transfer.ArtifactTransferException: Could not transfer artifact io.fabric8:docker-maven-plugin:jar.asc:0.47-20250618.031628-53 from/to sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots/): Authorization failed for https://oss.sonatype.org/content/repositories/snapshots/io/fabric8/docker-maven-plugin/0.47-SNAPSHOT/docker-maven-plugin-0.47-20250618.031628-53.jar.asc 403 Forbidden
```

Migrate SNAPSHOT release pipeline to the new Central Portal.