### PR TITLE
chore (deps) : bump `jib-core` to v0.27.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,9 @@
   <properties>
     <byte-buddy.version>1.12.10</byte-buddy.version>
     <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+    <guava.version>32.1.2-jre</guava.version>
     <httpclient.version>4.5.13</httpclient.version>
-    <jib-core.version>0.24.0</jib-core.version>
+    <jib-core.version>0.27.3</jib-core.version>
     <jnr-jffi.version>1.3.11</jnr-jffi.version>
     <jnr-unixsocket.version>0.38.19</jnr-unixsocket.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
@@ -129,7 +130,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.1-jre</version>
+      <version>${guava.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

+ Bump `jib-core` to v0.27.3
+ Bump `guava` to v32.1.2-jre