### PR TITLE
Add support for user namespace mode

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.47-SNAPSHOT**:
+  - Support for user namespace mode ([1881](https://github.com/fabric8io/docker-maven-plugin/pull/1881))
 
 * **0.46.0 (2025-04-06)**:
   - Docker-compose healthcheck configuration support ([1825](https://github.com/fabric8io/docker-maven-plugin/pull/1825))

--- a/src/main/asciidoc/inc/start/_configuration.adoc
+++ b/src/main/asciidoc/inc/start/_configuration.adoc
@@ -155,6 +155,9 @@ See below for an example.
 | *user*
 | User used inside the container
 
+| *userns*
+| User namespace mode; e.g. `keep-id:uid=185`
+
 | <<start-volumes, *volumes*>>
 | Volume configuration for binding to host directories and from other containers. See Volumes for details.
 

--- a/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerHostConfig.java
@@ -124,6 +124,10 @@ public class ContainerHostConfig {
         return this;
     }
 
+    public ContainerHostConfig userns(String userns) {
+        return add("UsernsMode", userns);
+    }
+
     private void addIfNotNull(JsonObject json, String key, Integer value) {
         if (value != null) {
             json.addProperty(key, value);

--- a/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/RunImageConfiguration.java
@@ -67,6 +67,9 @@ public class RunImageConfiguration implements Serializable {
     @Parameter
     private String user;
 
+    @Parameter
+    private String userns;
+
     // working directory
     @Parameter
     private String workingDir;
@@ -449,6 +452,10 @@ public class RunImageConfiguration implements Serializable {
         return autoRemove;
     }
 
+    public String getUserns() {
+        return userns;
+    }
+
     public StopMode getStopMode() {
         if (stopMode == null) {
             return StopMode.graceful;
@@ -736,6 +743,11 @@ public class RunImageConfiguration implements Serializable {
 
         public Builder autoRemove(Boolean autoRemove) {
             config.autoRemove = autoRemove;
+            return this;
+        }
+        
+        public Builder userns(String userns) {
+            config.userns = userns;
             return this;
         }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -137,6 +137,7 @@ public enum ConfigKey {
     TMPFS,
     ULIMITS,
     USER,
+    USERNS,
     VOLUMES,
     VOLUMES_FROM,
     WAIT_LOG("wait.log"),

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -246,6 +246,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .cpuSet(valueProvider.getString(CPUSET, config.getCpuSet()))
             .readOnly(valueProvider.getBoolean(READ_ONLY, config.getReadOnly()))
             .autoRemove(valueProvider.getBoolean(AUTO_REMOVE, config.getAutoRemove()))
+            .userns(valueProvider.getString(USERNS, config.getUserns()))
             .build();
     }
 

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -440,7 +440,8 @@ public class RunService {
                 .cpus(runConfig.getCpus())
                 .cpuSet(runConfig.getCpuSet())
                 .readonlyRootfs(runConfig.getReadOnly())
-                .autoRemove(runConfig.getAutoRemove());
+                .autoRemove(runConfig.getAutoRemove())
+                .userns(runConfig.getUserns());
 
         addVolumeConfig(config, runConfig, baseDir);
         addNetworkingConfig(config, runConfig);

--- a/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ContainerHostConfigTest.java
@@ -138,6 +138,13 @@ class ContainerHostConfigTest {
     }
 
     @Test
+    void testUserns() {
+        ContainerHostConfig hc = new ContainerHostConfig();
+        JsonObject result = hc.userns("keep-id").toJsonObject();
+        Assertions.assertEquals(JsonFactory.newJsonObject("{'UsernsMode':'keep-id'}"), result);
+    }
+
+    @Test
     void testLogConfig() {
         ContainerHostConfig hc = new ContainerHostConfig();
         Map<String,String> opts = new HashMap<>();

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -1107,6 +1107,7 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
         Assertions.assertEquals("Never", runConfig.getImagePullPolicy());
         Assertions.assertEquals(true, runConfig.getReadOnly());
         Assertions.assertEquals(true, runConfig.getAutoRemove());
+        Assertions.assertEquals("keep-id", runConfig.getUserns());
         Assertions.assertEquals("linux/amd64", runConfig.getPlatform());
 
         validateEnv(runConfig.getEnv());
@@ -1249,6 +1250,7 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
             k(ConfigKey.PLATFORM), "linux/amd64",
             k(ConfigKey.READ_ONLY), "true",
             k(ConfigKey.AUTO_REMOVE), "true",
+            k(ConfigKey.USERNS), "keep-id",
         };
     }
 

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -408,6 +408,7 @@ class RunServiceTest {
                 .network(networkConfiguration())
                 .readOnly(false)
                 .autoRemove(false)
+                .userns("keep-id")
                 .build();
     }
 

--- a/src/test/resources/docker/containerCreateConfigAll.json
+++ b/src/test/resources/docker/containerCreateConfigAll.json
@@ -73,6 +73,7 @@
     "CpusetCpus":"0,1",
     "ReadonlyRootfs":false,    
     "AutoRemove":false,    
+    "UsernsMode":"keep-id",
     "Binds":[
       "/host_tmp:/container_tmp"
     ],

--- a/src/test/resources/docker/containerHostConfigAll.json
+++ b/src/test/resources/docker/containerHostConfigAll.json
@@ -53,6 +53,7 @@
   "CpusetCpus":"0,1",
   "ReadonlyRootfs":false,    
   "AutoRemove":false,    
+  "UsernsMode":"keep-id",
   "Binds":[
     "/host_tmp:/container_tmp"
   ],


### PR DESCRIPTION
Populates `HostConfig/UsernsMode` while creating the container.

Fixes #1634.