### PR TITLE
Allow saving multiple images in docker:save using new parameters saveNames and saveAliases.

### DIFF
--- a/src/main/asciidoc/inc/_docker-save.adoc
+++ b/src/main/asciidoc/inc/_docker-save.adoc
@@ -41,11 +41,19 @@ Note that using overriding the default to use `docker` or `docker-%a` may lead t
 | Element | Description | Property
 
 | *saveName*
-| The name of the image configuration to save. Must not be used together with `alias`.
+| The name of the image configuration to save. Must not be used together with `alias`, `aliases` or `names`.
 | `docker.save.name`
 
+| *saveNames*
+| The name list of the image configurations to save. Must not be used together with `alias`, `aliases` or `name`.
+| `docker.save.names`
+
 | *saveAlias*
-| The alias of the image configuration to save. Must not be used together with `name`.
+| The alias of the image configuration to save. Must not be used together with `name`, `names` or `aliases`.
+| `docker.save.alias`
+
+| *saveAliases*
+| The alias list of the image configurations to save. Must not be used together with `name`, `names` or `alias`.
 | `docker.save.alias`
 
 | *saveFile*

--- a/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerAccess.java
@@ -300,6 +300,16 @@ public interface DockerAccess {
     void saveImage(String image, String filename, ArchiveCompression compression) throws DockerAccessException;
 
     /**
+     * Save several images to a tar file
+     *
+     * @param images image to save
+     * @param filename target filename
+     * @param compression compression to use for the archive
+     * @throws DockerAccessException if an image cannot be removed
+     */
+    void saveImages(List<String> images, String filename, ArchiveCompression compression) throws DockerAccessException;
+
+    /**
      * List all networks
      *
      * @return list of <code>Network<code> objects

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -577,6 +577,21 @@ public class DockerAccessWithHcClient implements DockerAccess {
         }
     }
 
+    @Override
+    public void saveImages(List<String> images, String filename, ArchiveCompression compression) throws DockerAccessException {
+         List<ImageName> names = new ArrayList<>();
+        for(String image : images){
+            names.add(new ImageName(image));
+        }
+        String url = urlBuilder.getImages(names);
+        log.verbose(Logger.LogVerboseCategory.API, API_LOG_FORMAT_GET, url);
+        try {
+            delegate.get(url, getImageResponseHandler(filename, compression), HTTP_OK);
+        } catch (IOException e) {
+            throw new DockerAccessException(e, "Unable to save '%s' to '%s'", images.toArray(), filename);
+        }
+    }
+
     private ResponseHandler<Object> getImageResponseHandler(final String filename, final ArchiveCompression compression) throws FileNotFoundException {
         return new ResponseHandler<Object>() {
             @Override


### PR DESCRIPTION
Docker API allows exporting several images to the same tar in the same request:

https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Image/operation/ImageGetAll

I needed this feature to save the same image with different tags (e.g. :latest and :version) to the same tar file.

The proposed solution is to add two new parameters to the save mojo, "saveNames" and "saveAliases", where you can put a list of image names or aliases separated with commas.

I tried to keep the original behavior as intact as possible, I also added a few tests.

I think this feature may be useful for some people, please feel free to provide any feedback or directly reject the PR.

Regards,
Uklosk