### PR TITLE
fix: Use wait config if no docker compose healthcheck

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -305,7 +305,8 @@ class DockerComposeServiceWrapper {
         } else if (successExitWaitRequested) {
             return new WaitConfiguration.Builder().exit(0).build();
         }
-        return null;
+        return enclosingImageConfig.getRunConfiguration() == null ? null :
+            enclosingImageConfig.getRunConfiguration().getWaitConfiguration();
     }
 
     List<String> getDns() {

--- a/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandlerTest.java
@@ -227,6 +227,22 @@ class DockerComposeConfigHandlerTest {
 
     }
 
+    @Test
+    void testWaitConfig() throws IOException, MavenFilteringException {
+        setupComposeExpectations("docker-compose_2.4.yml");
+        WaitConfiguration wait = new WaitConfiguration.Builder()
+            .url("http://localhost:8080/health")
+            .method("GET")
+            .status("200..399")
+            .build();
+        Mockito.when(unresolved.getRunConfiguration()).thenReturn(new RunImageConfiguration.Builder().wait(wait).build());
+
+        List<ImageConfiguration> configs = handler.resolve(unresolved, project, session);
+        RunImageConfiguration runConfig = findRunConfigurationByAlias(configs, "service");
+        Assertions.assertNotNull(runConfig.getWaitConfiguration());
+        Assertions.assertSame(wait, runConfig.getWaitConfiguration());
+    }
+
     private void setupComposeExpectations(final String file) throws IOException, MavenFilteringException {
         final File input = getAsFile("/compose/" + file);
 


### PR DESCRIPTION
Fixes #1771. 

Up until version 0.44.0 it was possible to use a configured wait together with a docker compose file, but since #888 this has been broken. We have been pinned on version 0.43.4 since then, but now we need it fixed because of the Docker API 29+ changes.