### PR TITLE
fix: Only apply wait config on alias match

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -304,9 +304,11 @@ class DockerComposeServiceWrapper {
             return new WaitConfiguration.Builder().healthy(healthyWaitRequested).build();
         } else if (successExitWaitRequested) {
             return new WaitConfiguration.Builder().exit(0).build();
+        } else if (getAlias().equals(enclosingImageConfig.getAlias())) {
+            return enclosingImageConfig.getRunConfiguration() == null ? null :
+                enclosingImageConfig.getRunConfiguration().getWaitConfiguration();
         }
-        return enclosingImageConfig.getRunConfiguration() == null ? null :
-            enclosingImageConfig.getRunConfiguration().getWaitConfiguration();
+        return null;
     }
 
     List<String> getDns() {

--- a/src/test/resources/compose/docker-compose_wait.yml
+++ b/src/test/resources/compose/docker-compose_wait.yml
@@ -1,0 +1,14 @@
+version: 2.4
+services:
+
+  service:
+    image: image
+    platform: linux/amd64
+
+  supportingService1:
+    image: image
+    platform: linux/amd64
+
+  supportingService2:
+    image: image
+    platform: linux/amd64


### PR DESCRIPTION
Only apply the wait config for a given service if the docker compose alias matches the image config alias.

The fix in #1897 was not correct, resulting in the wait config being applied for all services found in a Docker Compose file.