### PR TITLE
fix #1872

### DIFF
--- a/src/main/asciidoc/inc/_authentication.adoc
+++ b/src/main/asciidoc/inc/_authentication.adoc
@@ -221,3 +221,14 @@ This extra dependency allows the usage of all link:https://docs.aws.amazon.com/s
 
 If the AWS SDK is found in the classpath, it takes precedence over the custom AWS credentials lookup mechanisms listed above.
 ====
+
+==== Custom ECR API Endpoint (VPC Endpoint)
+
+By default, the plugin contacts the ECR API at `api.ecr.<region>.amazonaws.com`.
+If your environment requires routing through a VPC Endpoint (e.g. in private subnets without internet access), you can override the ECR API endpoint using the system property `docker.ecr.endpoint`:
+
+.Example
+[source, sh, subs="+attributes"]
+----
+mvn -Ddocker.ecr.endpoint=vpce-0123456789abcdef.api.ecr.eu-south-1.vpce.amazonaws.com {plugin}:build
+----

--- a/src/main/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuth.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuth.java
@@ -32,6 +32,8 @@ import io.fabric8.maven.docker.util.Logger;
  */
 public class EcrExtendedAuth {
 
+    public static final String ECR_ENDPOINT_PROPERTY = "docker.ecr.endpoint";
+
     private static final Pattern AWS_REGISTRY =
             Pattern.compile("^(\\d{12})\\.dkr\\.ecr\\.([a-z\\-0-9]+)\\.amazonaws\\.com$");
 
@@ -39,6 +41,7 @@ public class EcrExtendedAuth {
     private final boolean isAwsRegistry;
     private final String accountId;
     private final String region;
+    private final String endpoint;
 
     /**
      * Is given the registry an ecr registry?
@@ -56,7 +59,18 @@ public class EcrExtendedAuth {
      * @param registry The registry, we may or may not be an ecr registry.
      */
     public EcrExtendedAuth(Logger logger, String registry) {
+        this(logger, registry, null);
+    }
+
+    /**
+     * Initialize an extended authentication for ecr registry with an optional custom endpoint (e.g. VPC endpoint).
+     *
+     * @param registry The registry, we may or may not be an ecr registry.
+     * @param endpoint Custom ECR API endpoint host (e.g. "vpce-xxx.api.ecr.eu-south-1.vpce.amazonaws.com"), or null for default.
+     */
+    public EcrExtendedAuth(Logger logger, String registry, String endpoint) {
         this.logger = logger;
+        this.endpoint = endpoint;
         Matcher matcher = AWS_REGISTRY.matcher(registry);
         isAwsRegistry = matcher.matches();
         if (isAwsRegistry) {
@@ -124,7 +138,8 @@ public class EcrExtendedAuth {
     }
 
     HttpPost createSignedRequest(AuthConfig localCredentials, Date time) {
-        String host = "api.ecr." + region + ".amazonaws.com";
+        String defaultHost = "api.ecr." + region + ".amazonaws.com";
+        String host = endpoint != null ? endpoint : System.getProperty(ECR_ENDPOINT_PROPERTY, defaultHost);
 
         logger.debug("Get ECR AuthorizationToken from %s", host);
 

--- a/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AuthConfigFactory.java
@@ -162,7 +162,7 @@ public class AuthConfigFactory {
      * @throws MojoExecutionException
      */
     private AuthConfig extendedAuthentication(AuthConfig standardAuthConfig, String registry) throws IOException, MojoExecutionException {
-        EcrExtendedAuth ecr = new EcrExtendedAuth(log, registry);
+        EcrExtendedAuth ecr = new EcrExtendedAuth(log, registry, System.getProperty(EcrExtendedAuth.ECR_ENDPOINT_PROPERTY));
         if (ecr.isAwsRegistry()) {
             return ecr.extendedAuth(standardAuthConfig);
         }

--- a/src/test/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuthTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/ecr/EcrExtendedAuthTest.java
@@ -55,6 +55,32 @@ class EcrExtendedAuthTest {
     }
 
     @Test
+    void testHeadersWithCustomEndpoint() throws ParseException {
+        String customEndpoint = "vpce-abc123.api.ecr.eu-west-1.vpce.amazonaws.com";
+        EcrExtendedAuth eea = new EcrExtendedAuth(logger, "123456789012.dkr.ecr.eu-west-1.amazonaws.com", customEndpoint);
+        AuthConfig localCredentials = new AuthConfig("username", "password", null, null);
+        Date signingTime = AwsSigner4Request.TIME_FORMAT.parse("20161217T211058Z");
+        HttpPost request = eea.createSignedRequest(localCredentials, signingTime);
+        Assertions.assertEquals(customEndpoint, request.getFirstHeader("host").getValue());
+        Assertions.assertEquals("https://" + customEndpoint + "/", request.getRequestLine().getUri());
+    }
+
+    @Test
+    void testHeadersWithSystemPropertyEndpoint() throws ParseException {
+        String customEndpoint = "vpce-sys.api.ecr.eu-west-1.vpce.amazonaws.com";
+        System.setProperty(EcrExtendedAuth.ECR_ENDPOINT_PROPERTY, customEndpoint);
+        try {
+            EcrExtendedAuth eea = new EcrExtendedAuth(logger, "123456789012.dkr.ecr.eu-west-1.amazonaws.com");
+            AuthConfig localCredentials = new AuthConfig("username", "password", null, null);
+            Date signingTime = AwsSigner4Request.TIME_FORMAT.parse("20161217T211058Z");
+            HttpPost request = eea.createSignedRequest(localCredentials, signingTime);
+            Assertions.assertEquals(customEndpoint, request.getFirstHeader("host").getValue());
+        } finally {
+            System.clearProperty(EcrExtendedAuth.ECR_ENDPOINT_PROPERTY);
+        }
+    }
+
+    @Test
     void testClientClosedAndCredentialsDecoded(@Mock final CloseableHttpClient closeableHttpClient,
             @Mock final CloseableHttpResponse closeableHttpResponse,
             @Mock final StatusLine statusLine)


### PR DESCRIPTION
this PR extend VPC endpoint support

- Added constant ECR_ENDPOINT_PROPERTY = "docker.ecr.endpoint"
- Added endpoint field
- In createSignedRequest(), the host resolution logic is now:
 1. If endpoint is passed to the constructor → use that
 2. Otherwise read the system property docker.ecr.endpoint
 3. Otherwise fallback to the default api.ecr.<region>.amazonaws.com

Example of additional parameter: -Ddocker.ecr.endpoint=vpce-XXXXXXXXX.api.ecr.eu-south-1.vpce.amazonaws.com