### PR TITLE
ci : upgrade actions/setup-java from v1 to v4

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -21,8 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build Project
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,8 +30,9 @@ jobs:
           path: ~/.m2/repository
           key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: '11'
       - name: Install DMP
         run: mvn ${MAVEN_ARGS} clean install -DskipTests -Djacoco.skip=true
@@ -48,8 +49,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: '11'
       - name: Cache .m2 registry
         uses: actions/cache@v4
@@ -81,8 +83,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: '11'
       - name: Cache .m2 registry
         uses: actions/cache@v4

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: '11'
       - name: Install DMP
         run: mvn ${MAVEN_ARGS} clean install -DskipTests

--- a/.github/workflows/linux-mavenwrapper-build.yml
+++ b/.github/workflows/linux-mavenwrapper-build.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build Project
         run: ./mvnw -B -C -V -ntp clean install

--- a/.github/workflows/macos-mavenwrapper-build.yml
+++ b/.github/workflows/macos-mavenwrapper-build.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build Project
         run: ./mvnw -B -C -V -ntp clean install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Test Project
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build Project
         run: mvn %MAVEN_ARGS% clean install

--- a/.github/workflows/windows-mavenwrapper-build.yml
+++ b/.github/workflows/windows-mavenwrapper-build.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build Project
         run: ./mvnw.cmd %MAVEN_ARGS% clean install


### PR DESCRIPTION
## Desription

fix as per https://github.com/fabric8io/docker-maven-plugin/pull/1913#issuecomment-4351300057

The v1 action downloads x64 JDK on ARM64 runners (macos-14-arm64), causing builds to fail after the runner image update on April 27 (20260427.0019) which dropped Rosetta 2 support. Version 4 properly supports ARM64 architecture and requires the distribution parameter (using 'temurin').