### PR TITLE
feat(buildx): add buildAllPlatforms for parallel multi-arch docker bu…

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,4 +1,5 @@
 * **0.49-SNAPSHOT**:
+  - Add opt-in `<buildAllPlatforms>` buildx option to build all platforms during docker:build, warming the builder cache so a later docker:push reuses it ([#1866](https://github.com/fabric8io/docker-maven-plugin/issues/1866))
 
 * **0.48.1 (2026-02-07)**:
   - Use wait config if no Docker Compose healthcheck ([1771](https://github.com/fabric8io/docker-maven-plugin/issues/1771))

--- a/src/main/asciidoc/inc/build/_buildx.adoc
+++ b/src/main/asciidoc/inc/build/_buildx.adoc
@@ -61,6 +61,13 @@ element defaults to `min` and the `<sbom>` element defaults to `false`.
 | A value to be passed through to the `--cache-from` option of `docker buildx build`. See https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-from[docker buildx reference docs].
 | *cacheTo*
 | A value to be passed through to the `--cache-to` option of `docker buildx build`. See https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to[docker buildx reference docs].
+| *buildAllPlatforms*
+| When `true` and more than one `<platform>` is configured, the `docker:build` goal builds *all*
+configured platforms (warming the builder cache) in addition to building and loading the native
+platform for local use / integration tests. This brings the cross-platform build work forward from
+`docker:push` to `docker:build` so that a later push (re)uses the cache. Since multi-platform images
+cannot be loaded into the docker daemon, the all-platforms build produces no output and only populates
+the cache. Defaults to `false`.
 | *secret*
 |This option enables to https://docs.docker.com/reference/cli/docker/buildx/build/#secret[pass secrets to buildx build] as `--secret id=ID[,[env\|src]=VALUE]`.
 For environment variables add a `<env>` element with a list of variables in the form `<secret name>env variable name</secret name>` (whereas the `secret name` can then be referenced in your Dockerfile.

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -97,6 +97,9 @@ when a `docker.from` or a `docker.fromExt` is set.
 | *docker.buildx.cacheTo*
 | Cache destination for buildx builder
 
+| *docker.buildx.buildAllPlatforms*
+| When `true`, build all configured platforms already during `docker:build` (warming the cache) instead of only the native platform
+
 | *docker.capAdd.idx*
 | List of kernel capabilities to add to the container. See <<list-properties>>.
 

--- a/src/main/java/io/fabric8/maven/docker/config/BuildXConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildXConfiguration.java
@@ -67,6 +67,16 @@ public class BuildXConfiguration implements Serializable {
     @Parameter
     private SecretConfiguration secret;
 
+    /**
+     * Whether to build all configured {@link #platforms} already during the {@code docker:build}
+     * goal (populating the builder cache), instead of building only the native platform. Since
+     * multi-platform images cannot be loaded into the docker daemon, this extra build produces no
+     * output and only warms the build cache; the native platform is still built with {@code --load}
+     * so the image is available locally for integration tests. Defaults to {@code false}.
+     */
+    @Parameter
+    private Boolean buildAllPlatforms;
+
     public String getBuilderName() {
         return builderName;
     }
@@ -114,6 +124,14 @@ public class BuildXConfiguration implements Serializable {
 
     public SecretConfiguration getSecret() {
         return secret;
+    }
+
+    public Boolean getBuildAllPlatforms() {
+        return buildAllPlatforms;
+    }
+
+    public boolean isBuildAllPlatforms() {
+        return Boolean.TRUE.equals(buildAllPlatforms);
     }
 
     public static class Builder {
@@ -200,6 +218,14 @@ public class BuildXConfiguration implements Serializable {
         public Builder secret(SecretConfiguration secret) {
             config.secret = secret;
             if (secret != null) {
+                isEmpty = false;
+            }
+            return this;
+        }
+
+        public Builder buildAllPlatforms(Boolean buildAllPlatforms) {
+            config.buildAllPlatforms = buildAllPlatforms;
+            if (buildAllPlatforms != null) {
                 isEmpty = false;
             }
             return this;

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -51,6 +51,7 @@ public enum ConfigKey {
     BUILDX_ATTESTATION_SBOM("buildx.attestations.sbom"),
     BUILDX_CACHE_FROM("buildx.cacheFrom"),
     BUILDX_CACHE_TO("buildx.cacheTo"),
+    BUILDX_BUILD_ALL_PLATFORMS("buildx.buildAllPlatforms"),
     BUILDX_SECRET_ENVS("buildx.secret.envs", ValueCombinePolicy.Merge),
     BUILDX_SECRET_FILES("buildx.secret.files", ValueCombinePolicy.Merge),
     CAP_ADD,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -347,6 +347,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .attestations(extractAttestations(config.getAttestations(), valueProvider))
             .cacheFrom(valueProvider.getString(BUILDX_CACHE_FROM, config.getCacheFrom()))
             .cacheTo(valueProvider.getString(BUILDX_CACHE_TO, config.getCacheTo()))
+            .buildAllPlatforms(valueProvider.getBoolean(BUILDX_BUILD_ALL_PLATFORMS, config.getBuildAllPlatforms()))
             .secret(extractSecret(config.getSecret(), valueProvider))
             .build();
     }

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -122,8 +122,18 @@ public class BuildXService {
 
     protected void buildAndLoadSinglePlatform(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String configuredRegistry, File buildArchive) throws MojoExecutionException {
         List<String> platforms = imageConfig.getBuildConfiguration().getBuildX().getPlatforms();
-        // build and load the single-platform image by re-building, image should be cached and build should be quick
         String nativePlatform = dockerAccess.getNativePlatform();
+
+        // Optionally build ALL configured platforms already here so the cross-platform layers are
+        // computed and cached in the builder ahead of the push goal. Multi-platform images cannot be
+        // loaded into the docker daemon, so this build specifies no output (neither --load nor --push)
+        // and only warms the build cache; the native platform is then (re)built with --load below.
+        if (imageConfig.getBuildConfiguration().getBuildX().isBuildAllPlatforms() && platforms.size() > 1) {
+            logger.info("Building all configured platforms %s to populate the build cache", String.join(",", platforms));
+            buildX(buildX, builderName, buildDirs, imageConfig, configuredRegistry, platforms, buildArchive, null);
+        }
+
+        // build and load the single-platform image by re-building, image should be cached and build should be quick
         if (platforms.size() == 1) {
             buildX(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, platforms, buildArchive, "--load");
         } else if (platforms.isEmpty() || platforms.contains(nativePlatform)) {

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
@@ -244,6 +245,37 @@ class BuildXServiceTest {
                 .name("build-image")
                 .buildConfig(buildImageConfig)
                 .build();
+    }
+
+    @Test
+    void testBuildAllPlatformsBuildsAllThenLoadsNative() throws Exception {
+        givenAnImageConfiguration(new BuildXConfiguration.Builder()
+            .platforms(Arrays.asList(NATIVE, FOREIGN1))
+            .buildAllPlatforms(true)
+            .build());
+        mockBuildX();
+
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+
+        // first: all platforms are built with no output (neither --load nor --push) to warm the cache
+        Mockito.verify(buildx).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+            Mockito.argThat(l -> Arrays.asList(NATIVE, FOREIGN1).equals(l)), Mockito.any(), Mockito.isNull());
+        // then: the native platform is (re)built and loaded for local use / integration tests
+        Mockito.verify(buildx).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+            Mockito.argThat(l -> Collections.singletonList(NATIVE).equals(l)), Mockito.any(), Mockito.eq("--load"));
+    }
+
+    @Test
+    void testBuildAllPlatformsDisabledOnlyBuildsNative() throws Exception {
+        // buildAllPlatforms defaults to false -> only the native platform is built at build time
+        givenAnImageConfiguration(NATIVE, FOREIGN1);
+        mockBuildX();
+
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+
+        Mockito.verify(buildx, Mockito.times(1)).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        verifyBuildXPlatforms(NATIVE);
     }
 
     @Test


### PR DESCRIPTION
…ildx (#1866)

By default the docker:build goal only builds the native platform (multi-arch images cannot be loaded into the docker daemon), deferring the cross-platform build to docker:push. In a CI pipeline this means the slow (often emulated) non-native build happens last, serially, at push time.

Add an opt-in buildx option <buildAllPlatforms> (property docker.buildx.buildAllPlatforms), default false. When enabled with more than one configured platform, docker:build performs a parallel multi-arch docker buildx build of all configured platforms (with no output, to warm the builder cache), then builds and loads the native platform for local use / integration tests. A subsequent docker:push then reuses the warmed cache.

Default false preserves the existing behaviour exactly.

- BuildXConfiguration: buildAllPlatforms field, getters, builder method
- BuildXService.buildAndLoadSinglePlatform: warm-cache pass for all platforms
- PropertyConfigHandler/ConfigKey: docker.buildx.buildAllPlatforms property
- docs (_buildx.adoc, _property_configuration.adoc), unit tests (BuildXServiceTest)
- changelog entry for 0.49-SNAPSHOT