### PR TITLE
Normalize empty build arg values instead of failing the build

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,6 @@
 * **0.49-SNAPSHOT**:
   - Add opt-in `<buildAllPlatforms>` buildx option to build all platforms during docker:build, warming the builder cache so a later docker:push reuses it ([#1866](https://github.com/fabric8io/docker-maven-plugin/issues/1866))
+  - Normalize empty `<args>` build argument values (e.g. from a property that resolves to an empty value) to an empty string instead of failing the build ([#1858](https://github.com/fabric8io/docker-maven-plugin/issues/1858))
 
 * **0.48.1 (2026-02-07)**:
   - Use wait config if no Docker Compose healthcheck ([1771](https://github.com/fabric8io/docker-maven-plugin/issues/1771))

--- a/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildImageConfiguration.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -793,6 +794,8 @@ public class BuildImageConfiguration implements Serializable {
             healthCheck.validate();
         }
 
+        normalizeBuildArgs();
+
         ensureUniqueAssemblyNames(log);
 
         if (command != null) {
@@ -836,6 +839,21 @@ public class BuildImageConfiguration implements Serializable {
                 throw new IllegalArgumentException("Assembly names must be unique");
             }
         }
+    }
+
+    /**
+     * Build args coming from a Maven property that resolves to an empty or undefined value are injected
+     * as {@code null} (e.g. {@code <FOO>${someEmptyProperty}</FOO>}). Docker treats a build arg without a
+     * value as an empty string, so normalize {@code null} values to {@code ""} instead of letting the build
+     * fail later when the args are collected into a map that rejects null values. See #1858.
+     */
+    private void normalizeBuildArgs() {
+        if (args == null || !args.containsValue(null)) {
+            return;
+        }
+        Map<String, String> normalizedArgs = new LinkedHashMap<>();
+        args.forEach((key, value) -> normalizedArgs.put(key, value == null ? "" : value));
+        args = normalizedArgs;
     }
 
     // Initialize the dockerfile location and the build mode

--- a/src/test/java/io/fabric8/maven/docker/config/BuildImageConfigurationTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/BuildImageConfigurationTest.java
@@ -28,6 +28,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import static io.fabric8.maven.docker.config.ArchiveCompression.gzip;
 import static io.fabric8.maven.docker.config.ArchiveCompression.none;
@@ -48,6 +50,22 @@ class BuildImageConfigurationTest {
         BuildImageConfiguration config = new BuildImageConfiguration();
         config.initAndValidate(logger);
         Assertions.assertFalse(config.isDockerFileMode());
+    }
+
+    @Test
+    // Tests fix for #1858: a build arg whose value resolves to an empty/undefined property is
+    // injected as null and must be normalized to an empty string instead of failing the build
+    void buildArgWithNullValueIsNormalizedToEmptyString() {
+        Map<String, String> args = new HashMap<>();
+        args.put("EMPTY_ARG", null);
+        args.put("REAL_ARG", "value");
+        BuildImageConfiguration config =
+            new BuildImageConfiguration.Builder().args(args).build();
+
+        config.initAndValidate(logger);
+
+        Assertions.assertEquals("", config.getArgs().get("EMPTY_ARG"));
+        Assertions.assertEquals("value", config.getArgs().get("REAL_ARG"));
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Fixes #1858.

When a `<build>` argument value comes from a Maven property that resolves to
an empty or undefined value, e.g.:

```xml
<properties>
  <testproperty/>
</properties>
...
<args>
  <TESTARG>${testproperty}</TESTARG>
</args>
```

the value is injected as `null`. The build args are then collected into a
Guava `ImmutableMap` (which rejects null values), so the build fails with:

    Execution ... failed: null value in entry: TESTARG=null

There is currently no way to legitimately set a build arg to an empty value.

### How does it fix it?

Docker treats a build arg without a value as an empty string. This PR
normalizes `null` build-arg values to `""` in
`BuildImageConfiguration.initAndValidate()`, which runs before the args are
consumed by both the classic and the buildx build paths. The normalization
is a no-op when no `null` values are present, so existing configurations are
unaffected.

### Testing

- Added `BuildImageConfigurationTest#buildArgWithNullValueIsNormalizedToEmptyString`.
- Full unit test suite passes locally (932 tests, 0 failures).
- Added a changelog entry under `0.49-SNAPSHOT`.
