### PR TITLE
Add tests for docker:save multi-image feature and fix docker.save.aliases

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,4 +1,5 @@
 * **0.49-SNAPSHOT**:
+  - Fix `docker.save.aliases`: a non-existent alias in the list was silently ignored instead of failing the save with a clear error
   - Add opt-in `<buildAllPlatforms>` buildx option to build all platforms during docker:build, warming the builder cache so a later docker:push reuses it ([#1866](https://github.com/fabric8io/docker-maven-plugin/issues/1866))
   - Normalize empty `<args>` build argument values (e.g. from a property that resolves to an empty value) to an empty string instead of failing the build ([#1858](https://github.com/fabric8io/docker-maven-plugin/issues/1858))
 

--- a/src/main/java/io/fabric8/maven/docker/SaveMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/SaveMojo.java
@@ -225,7 +225,7 @@ public class SaveMojo extends AbstractDockerMojo {
 			exit.add(saveAlias);
 		}
 		if (saveAliases != null && !saveAliases.isEmpty()) {
-			return exit;
+			exit.addAll(saveAliases);
 		}
 		return exit;
 	}

--- a/src/test/java/io/fabric8/maven/docker/SaveMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/SaveMojoTest.java
@@ -266,6 +266,76 @@ class SaveMojoTest extends MojoTestBase {
         // fails
     }
 
+    @Test
+    void failureWithSaveNameAndSaveNames() {
+        givenProjectWithResolvedImage(singleImageWithBuild());
+
+        saveMojo.saveName = "not-null";
+        saveMojo.saveNames = Arrays.asList("example1:latest");
+
+        Assertions.assertThrows(MojoExecutionException.class, this::whenMojoExecutes);
+    }
+
+    @Test
+    void failureWithSaveNameAndSaveAliases() {
+        givenProjectWithResolvedImage(singleImageWithBuild());
+
+        saveMojo.saveName = "not-null";
+        saveMojo.saveAliases = Arrays.asList("example1");
+
+        Assertions.assertThrows(MojoExecutionException.class, this::whenMojoExecutes);
+    }
+
+    @Test
+    void failureWithSaveAliasAndSaveNames() {
+        givenProjectWithResolvedImage(singleImageWithBuild());
+
+        saveMojo.saveAlias = "not-null";
+        saveMojo.saveNames = Arrays.asList("example1:latest");
+
+        Assertions.assertThrows(MojoExecutionException.class, this::whenMojoExecutes);
+    }
+
+    @Test
+    void failureWithSaveAliasAndSaveAliases() {
+        givenProjectWithResolvedImage(singleImageWithBuild());
+
+        saveMojo.saveAlias = "not-null";
+        saveMojo.saveAliases = Arrays.asList("example1");
+
+        Assertions.assertThrows(MojoExecutionException.class, this::whenMojoExecutes);
+    }
+
+    @Test
+    void saveWithNonExistentName() {
+        givenProjectWithResolvedImage(singleImageWithBuild());
+
+        saveMojo.saveName = "nonexistent:latest";
+
+        MojoExecutionException ex = Assertions.assertThrows(MojoExecutionException.class, this::whenMojoExecutes);
+        Assertions.assertTrue(ex.getMessage().contains("Can not find image with name"));
+    }
+
+    @Test
+    void saveWithNonExistentNames() {
+        givenProjectWithResolvedImage(singleImageWithBuild());
+
+        saveMojo.saveNames = Arrays.asList("nonexistent1:latest", "nonexistent2:latest");
+
+        MojoExecutionException ex = Assertions.assertThrows(MojoExecutionException.class, this::whenMojoExecutes);
+        Assertions.assertTrue(ex.getMessage().contains("Can not find images with name"));
+    }
+
+    @Test
+    void saveWithNonExistentAliases() {
+        givenProjectWithResolvedImage(singleImageWithBuild());
+
+        saveMojo.saveAliases = Arrays.asList("nonexistent1", "nonexistent2");
+
+        MojoExecutionException ex = Assertions.assertThrows(MojoExecutionException.class, this::whenMojoExecutes);
+        Assertions.assertTrue(ex.getMessage().contains("Can not find images with alias"));
+    }
+
     @Override
     protected void givenMavenProject(AbstractDockerMojo mojo) {
         super.givenMavenProject(mojo);

--- a/src/test/java/io/fabric8/maven/docker/UrlBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/UrlBuilderTest.java
@@ -18,6 +18,7 @@ package io.fabric8.maven.docker;
 
 import java.io.UnsupportedEncodingException;
 import java.net.*;
+import java.util.Arrays;
 import java.util.HashMap;
 
 import io.fabric8.maven.docker.access.BuildOptions;
@@ -86,6 +87,13 @@ class UrlBuilderTest {
     void getImage() throws URISyntaxException {
         UrlBuilder builder = new UrlBuilder("", "1.0");
         Assertions.assertEquals(new URI("/1.0/images/n1%3Alatest/get"), new URI(builder.getImage(new ImageName("n1:latest"))));
+    }
+
+    @Test
+    void getImages() {
+        UrlBuilder builder = new UrlBuilder("", "1.0");
+        Assertions.assertEquals("/1.0/images/get?names=n1%3Alatest&names=n2%3Alatest",
+            builder.getImages(Arrays.asList(new ImageName("n1:latest"), new ImageName("n2:latest"))));
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -210,6 +211,23 @@ class DockerAccessWithHcClientTest {
         givenCompression(ArchiveCompression.none);
         givenTheGetWillFail();
         whenSaveImage();
+        thenImageWasNotSaved();
+    }
+
+    @Test
+    void testSaveImages() {
+        givenFilename("images.tar");
+        givenCompression(ArchiveCompression.none);
+        whenSaveImages();
+        thenNoException();
+    }
+
+    @Test
+    void testSaveImagesFail() throws IOException {
+        givenFilename("images.tar");
+        givenCompression(ArchiveCompression.none);
+        givenTheGetWillFail();
+        whenSaveImages();
         thenImageWasNotSaved();
     }
 
@@ -453,6 +471,14 @@ class DockerAccessWithHcClientTest {
     private void whenSaveImage() {
         try {
             client.saveImage(imageName, filename, compression);
+        } catch (Exception e) {
+            thrownException = e;
+        }
+    }
+
+    private void whenSaveImages() {
+        try {
+            client.saveImages(Arrays.asList("image1", "image2"), filename, compression);
         } catch (Exception e) {
             thrownException = e;
         }

--- a/src/test/java/io/fabric8/maven/docker/model/ContainerDetailsTest.java
+++ b/src/test/java/io/fabric8/maven/docker/model/ContainerDetailsTest.java
@@ -1,6 +1,7 @@
 package io.fabric8.maven.docker.model;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -291,9 +292,27 @@ class ContainerDetailsTest {
         // Test case with no IP address available
         JsonObject networkSettings = new JsonObject();
         json.add("NetworkSettings", networkSettings);
-        
+
         whenCreateContainer();
-        
+
+        Assertions.assertNull(container.getIPAddress());
+    }
+
+    @Test
+    void testGetIPAddressNewFormatWithoutIp() {
+        // New format where the Networks entries carry no usable IPAddress: the loop completes
+        // without returning and getIPAddress() falls through to null.
+        JsonObject networkSettings = new JsonObject();
+        JsonObject networks = new JsonObject();
+        networks.add("bridge", new JsonObject());        // network without an IPAddress property
+        JsonObject custom = new JsonObject();
+        custom.add("IPAddress", JsonNull.INSTANCE);      // network with an explicit null IPAddress
+        networks.add("custom", custom);
+        networkSettings.add("Networks", networks);
+        json.add("NetworkSettings", networkSettings);
+
+        whenCreateContainer();
+
         Assertions.assertNull(container.getIPAddress());
     }
 


### PR DESCRIPTION
### Why

The SonarCloud Quality Gate on `master` is failing on **Coverage on New Code (70.8% < 80%)**. The build/test CI is all green — the gap is new code from the `docker:save` multi-image feature (`saveNames` / `saveAliases`) that was merged without unit tests, plus one branch of the Docker 29+ `IPAddress` parsing in `ContainerDetails`.

This PR backfills unit tests for those paths and fixes a small bug found while doing so.

### Tests added

- **`UrlBuilderTest.getImages`** — `images/get?names=…&names=…` URL building for multiple images (covers the `getImages(List<ImageName>)` method and the array-query-parameter support in `build()`).
- **`DockerAccessWithHcClientTest.testSaveImages` / `testSaveImagesFail`** — the multi-image `saveImages(...)` happy path and the `DockerAccessException` wrapping on I/O failure.
- **`SaveMojoTest`** (7 tests) — the parameter-conflict validation branches (name/alias vs. name-list/alias-list) and the "image(s) not found by name/alias" paths.
- **`ContainerDetailsTest.testGetIPAddressNewFormatWithoutIp`** — `getIPAddress()` returns `null` when `NetworkSettings.Networks` is present but no network carries an IP.

### Bug fix

`SaveMojo.getSaveAliasesPendingToSave()` had a copy/paste error: when `docker.save.aliases` was non-empty it `return`ed the list **without adding the aliases** (the sibling `getSaveNamesPendingToSave()` correctly does `addAll`). As a result a non-existent alias in `docker.save.aliases` was silently ignored instead of failing the save with a clear "Can not find images with alias" error. Fixed to `exit.addAll(saveAliases)`; the new `SaveMojoTest.saveWithNonExistentAliases` locks in the corrected behaviour.

### Verification

- Affected classes: green (`UrlBuilderTest`, `DockerAccessWithHcClientTest`, `SaveMojoTest`, `ContainerDetailsTest`).
- Full unit-test suite green (`943` tests, `0` failures).
- No production behaviour change other than the `docker.save.aliases` validation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
