### PR TITLE
Fix broken Maven Central badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-maven-plugin
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.fabric8/docker-maven-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/io.fabric8/docker-maven-plugin/)
+[![Maven Central](https://img.shields.io/maven-central/v/io.fabric8/docker-maven-plugin.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.fabric8/docker-maven-plugin)
 [![Test](https://github.com/fabric8io/docker-maven-plugin/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/fabric8io/docker-maven-plugin/actions/workflows/test.yml)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=fabric8io_docker-maven-plugin&metric=coverage)](https://sonarcloud.io/summary/new_code?id=fabric8io_docker-maven-plugin)
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=fabric8io_docker-maven-plugin&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=fabric8io_docker-maven-plugin)


### PR DESCRIPTION
### Problem

The **Maven Central** badge no longer renders in the README. The badge service host `maven-badges.herokuapp.com` has been decommissioned — it returns a Heroku **"No such app"** `404` (verified) for both the badge image URL *and* its link target. GitHub's image proxy receives a 404 HTML page instead of an SVG, so the badge shows as a broken image, and clicking it 404s too.

### Fix

Replace it with the equivalent, actively maintained **shields.io** Maven Central badge and point the link at the current Maven Central listing:

- image → `https://img.shields.io/maven-central/v/io.fabric8/docker-maven-plugin.svg?label=Maven%20Central`
- link → `https://central.sonatype.com/artifact/io.fabric8/docker-maven-plugin`

Verified: the new image returns `HTTP 200` / `image/svg+xml` (renders `maven-central: v0.48.1`, the current release) and the link returns `200`.

Only `README.md` is touched; no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
