### PR TITLE
Replace stale CircleCI badge with GitHub Actions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # docker-maven-plugin
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.fabric8/docker-maven-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/io.fabric8/docker-maven-plugin/)
-[![Circle CI](https://circleci.com/gh/fabric8io/docker-maven-plugin/tree/master.svg?style=shield)](https://circleci.com/gh/fabric8io/docker-maven-plugin/tree/master)
+[![Test](https://github.com/fabric8io/docker-maven-plugin/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/fabric8io/docker-maven-plugin/actions/workflows/test.yml)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=fabric8io_docker-maven-plugin&metric=coverage)](https://sonarcloud.io/summary/new_code?id=fabric8io_docker-maven-plugin)
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=fabric8io_docker-maven-plugin&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=fabric8io_docker-maven-plugin)
 


### PR DESCRIPTION
### Problem

The **Circle CI** badge in the README is stale and misleading. CircleCI was dropped in favour of GitHub Actions in `a1090e01` ("ci : Migrate to GitHub Actions from CircleCI", Jan 2023). There is no `.circleci/config.yml` in the repo any more, so CircleCI (2.x) runs no pipelines for this project — the badge simply serves a frozen `passing` from the last pre-migration build, regardless of the real CI state.

### Fix

Point the badge at the actual CI — the **Test** GitHub Actions workflow on `master`:

- image → `https://github.com/fabric8io/docker-maven-plugin/actions/workflows/test.yml/badge.svg?branch=master`
- link → `https://github.com/fabric8io/docker-maven-plugin/actions/workflows/test.yml`

Verified the `Test` workflow's latest run on `master` is green, so the badge renders **Test | passing**. Note this reflects the unit-test build status only; code coverage / quality continues to be shown by the existing SonarCloud badges below it.

Only `README.md` is touched. (Separate from the Maven Central badge fix in #1923; different line, no conflict.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
