### PR TITLE
Reconnect container log stream on transient errors to fix flaky log-wait

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,6 @@
 * **0.49-SNAPSHOT**:
   - Fix `docker.save.aliases`: a non-existent alias in the list was silently ignored instead of failing the save with a clear error
+  - Make container log streaming (`<wait><log>` and log following) resilient to transient stream disconnects by reconnecting and resuming instead of aborting, fixing flaky log-wait timeouts (e.g. `jnr ... Bad file descriptor` on macOS CI)
   - Add opt-in `<buildAllPlatforms>` buildx option to build all platforms during docker:build, warming the builder cache so a later docker:push reuses it ([#1866](https://github.com/fabric8io/docker-maven-plugin/issues/1866))
   - Normalize empty `<args>` build argument values (e.g. from a property that resolves to an empty value) to an empty string instead of failing the build ([#1858](https://github.com/fabric8io/docker-maven-plugin/issues/1858))
 

--- a/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/UrlBuilder.java
@@ -53,12 +53,19 @@ public final class UrlBuilder {
     }
 
     public String containerLogs(String containerId, boolean follow) {
-        return u("containers/%s/logs", containerId)
+        return containerLogs(containerId, follow, null);
+    }
+
+    public String containerLogs(String containerId, boolean follow, String since) {
+        Builder builder = u("containers/%s/logs", containerId)
                 .p("stdout",true)
                 .p("stderr",true)
                 .p("timestamps", true)
-                .p("follow", follow)
-                .build();
+                .p("follow", follow);
+        if (since != null) {
+            builder.p("since", since);
+        }
+        return builder.build();
     }
 
     public String createContainer(String name, String platform) {

--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -54,10 +54,21 @@ public class LogRequestor extends Thread implements LogGetHandle {
 
     private DockerAccessException exception;
 
-    // Remember for asynchronous handling so that the request can be aborted from the outside
-    private HttpUriRequest request;
+    // Remember for asynchronous handling so that the request can be aborted from the outside.
+    // Volatile because finish() reads/aborts it from another thread while run() reassigns it on each reconnect.
+    private volatile HttpUriRequest request;
 
     private final UrlBuilder urlBuilder;
+
+    // Set to true once finish() has been called so that an aborted request is not treated as a retryable error.
+    private volatile boolean stopped;
+
+    // Timestamp of the last received log line; used to resume the stream (docker "since") after a reconnect.
+    private ZonedDateTime lastTimestamp;
+
+    // Reconnect policy for the asynchronous follow stream (run()): retry transient IO errors instead of aborting.
+    private int maxReconnectAttempts = 5;
+    private long reconnectBackoffMillis = 1000L;
 
     /**
      * Create a helper object for requesting log entries synchronously ({@link #fetchLogs()}) or asynchronously ({@link #start()}.
@@ -83,7 +94,7 @@ public class LogRequestor extends Thread implements LogGetHandle {
     public void fetchLogs() {
         try {
             callback.open();
-            this.request = getLogRequest(false);
+            this.request = getLogRequest(false, null);
             final HttpResponse response = client.execute(request);
             parseResponse(response);
         } catch (LogCallback.DoneException e) {
@@ -95,19 +106,83 @@ public class LogRequestor extends Thread implements LogGetHandle {
         }
     }
 
-    // Fetch log asynchronously as stream and follow stream
+    // Visible for testing: tune the reconnect behaviour of the asynchronous follow stream.
+    LogRequestor reconnectPolicy(int maxAttempts, long backoffMillis) {
+        this.maxReconnectAttempts = maxAttempts;
+        this.reconnectBackoffMillis = backoffMillis;
+        return this;
+    }
+
+    // Fetch log asynchronously as stream and follow stream. Transient stream errors (e.g. a dropped
+    // Docker socket connection) are retried by reconnecting rather than aborting the wait; the stream
+    // is resumed from the last received timestamp so already-consumed lines are (largely) not repeated.
     public void run() {
         try {
             callback.open();
-            this.request = getLogRequest(true);
-            final HttpResponse response = client.execute(request);
-            parseResponse(response);
+            int attempt = 0;
+            // lastTimestamp as observed at the previous failure; used to tell genuine forward progress
+            // from a connection that merely replayed already-seen lines out of the "since" window.
+            ZonedDateTime progressMark = null;
+            while (!stopped) {
+                try {
+                    this.request = getLogRequest(true, resumeSince());
+                    // finish() may have run between the while-check and here; don't open a fresh
+                    // connection that nobody will abort.
+                    if (stopped) {
+                        return;
+                    }
+                    parseResponse(client.execute(request));
+                    return;
+                } catch (IOException e) {
+                    if (stopped) {
+                        // finish() aborted the request on purpose; not an error.
+                        return;
+                    }
+                    // Reset the reconnect budget only when the stream actually advanced past the point
+                    // of the previous failure. A socket that keeps replaying the same boundary line (or a
+                    // persistently malformed frame) makes no progress and must not refill the budget, or a
+                    // permanently broken stream would reconnect forever on the untimed log-following path.
+                    boolean advanced = lastTimestamp != null && (progressMark == null || lastTimestamp.isAfter(progressMark));
+                    if (advanced) {
+                        attempt = 0;
+                    }
+                    progressMark = lastTimestamp;
+                    if (attempt++ >= maxReconnectAttempts) {
+                        callback.error("IO Error while requesting logs: " + e + " " + Thread.currentThread().getName());
+                        return;
+                    }
+                    sleepBeforeReconnect(reconnectBackoffMillis);
+                }
+            }
         } catch (LogCallback.DoneException e) {
             // Signifies we're finished with the log stream.
         } catch (IOException e) {
+            // Only reached if callback.open() itself fails; stream errors are handled inside the loop above.
             callback.error("IO Error while requesting logs: " + e + " " + Thread.currentThread().getName());
         } finally {
             callback.close();
+        }
+    }
+
+    // Docker "since" value for resuming the follow stream after a reconnect, at nanosecond precision so
+    // that at most the single line at the exact resume instant can be re-delivered (docker's "since" is an
+    // inclusive lower bound) rather than every line sharing the same whole second. Returns null before any
+    // line has been received, which streams from the beginning.
+    private String resumeSince() {
+        if (lastTimestamp == null) {
+            return null;
+        }
+        return lastTimestamp.toEpochSecond() + "." + String.format("%09d", lastTimestamp.getNano());
+    }
+
+    private void sleepBeforeReconnect(long millis) {
+        if (millis <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -199,15 +274,17 @@ public class LogRequestor extends Thread implements LogGetHandle {
         }
         ZonedDateTime ts = TimestampFactory.createTimestamp(matcher.group("timestamp"));
         String logTxt = matcher.group("entry");
+        this.lastTimestamp = ts;
         callback.log(type, ts, logTxt);
     }
 
-    private HttpUriRequest getLogRequest(boolean follow) {
-        return RequestUtil.newGet(urlBuilder.containerLogs(containerId, follow));
+    private HttpUriRequest getLogRequest(boolean follow, String since) {
+        return RequestUtil.newGet(urlBuilder.containerLogs(containerId, follow, since));
     }
 
     @Override
     public void finish() {
+        this.stopped = true;
         if (request != null) {
             request.abort();
             request = null;

--- a/src/test/java/io/fabric8/maven/docker/UrlBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/UrlBuilderTest.java
@@ -73,7 +73,8 @@ class UrlBuilderTest {
         UrlBuilder builder = new UrlBuilder("", "1.0");
         Assertions.assertEquals(new URI("/1.0/containers/cid/logs?follow=0&stderr=1&stdout=1&timestamps=1"),
             new URI(builder.containerLogs("cid", false)));
-
+        Assertions.assertEquals(new URI("/1.0/containers/cid/logs?follow=1&since=1620000000.500000000&stderr=1&stdout=1&timestamps=1"),
+            new URI(builder.containerLogs("cid", true, "1620000000.500000000")));
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
@@ -260,7 +260,85 @@ class LogRequestorTest {
         final IOExceptionStream stream = new IOExceptionStream();
         setupMocks(stream);
 
-        new LogRequestor(client, urlBuilder, containerId, callback).run();
+        // reconnectPolicy(0, ...) => give up immediately (keeps the test fast and asserts a single error).
+        new LogRequestor(client, urlBuilder, containerId, callback).reconnectPolicy(0, 0).run();
+        Mockito.verify(callback).error(Mockito.anyString());
+    }
+
+    @Test
+    void runReconnectsAfterTransientIOException() throws Exception {
+        final Streams type = Streams.STDOUT;
+        final String message = "Hello, world!";
+        final InputStream inputStream = new ByteArrayInputStream(messageToBuffer(type, message).array());
+
+        // First connection attempt fails with a transient IO error; the reconnect then succeeds.
+        Mockito.doThrow(new IOException("Bad file descriptor"))
+               .doReturn(httpResponse)
+               .when(client).execute(Mockito.any(HttpUriRequest.class));
+        Mockito.doReturn(statusLine).when(httpResponse).getStatusLine();
+        Mockito.doReturn(200).when(statusLine).getStatusCode();
+        Mockito.doReturn(httpEntity).when(httpResponse).getEntity();
+        Mockito.doReturn(inputStream).when(httpEntity).getContent();
+        Mockito.doReturn("url").when(urlBuilder).containerLogs(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any());
+
+        new LogRequestor(client, urlBuilder, containerId, callback).reconnectPolicy(3, 0).run();
+
+        Mockito.verify(callback).log(Mockito.eq(type.type), Mockito.any(ZonedDateTime.class), Mockito.eq(message));
+        Mockito.verify(callback, Mockito.never()).error(Mockito.anyString());
+        Mockito.verify(client, Mockito.times(2)).execute(Mockito.any(HttpUriRequest.class));
+    }
+
+    @Test
+    void runGivesUpAfterMaxReconnectAttempts() throws Exception {
+        Mockito.doThrow(new IOException("Bad file descriptor"))
+               .when(client).execute(Mockito.any(HttpUriRequest.class));
+        Mockito.doReturn("url").when(urlBuilder).containerLogs(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any());
+
+        new LogRequestor(client, urlBuilder, containerId, callback).reconnectPolicy(3, 0).run();
+
+        // Initial attempt + 3 reconnect attempts, then a single error is reported.
+        Mockito.verify(client, Mockito.times(4)).execute(Mockito.any(HttpUriRequest.class));
+        Mockito.verify(callback).error(Mockito.anyString());
+    }
+
+    @Test
+    void reconnectRequestResumesWithSince() throws Exception {
+        final Streams type = Streams.STDOUT;
+        final InputStream frameThenThrow = new FrameThenIOExceptionStream(messageToBuffer(type, "before disconnect").array());
+        final InputStream empty = new ByteArrayInputStream(new byte[0]);
+
+        Mockito.doReturn(httpResponse).when(client).execute(Mockito.any(HttpUriRequest.class));
+        Mockito.doReturn(statusLine).when(httpResponse).getStatusLine();
+        Mockito.doReturn(200).when(statusLine).getStatusCode();
+        Mockito.doReturn(httpEntity).when(httpResponse).getEntity();
+        Mockito.doReturn(frameThenThrow, empty).when(httpEntity).getContent();
+        Mockito.doReturn("url").when(urlBuilder).containerLogs(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any());
+
+        new LogRequestor(client, urlBuilder, containerId, callback).reconnectPolicy(3, 0).run();
+
+        // First attempt streams from the beginning (since == null); after receiving a line it reconnects with a since timestamp.
+        Mockito.verify(urlBuilder).containerLogs(Mockito.eq(containerId), Mockito.eq(true), Mockito.isNull());
+        Mockito.verify(urlBuilder).containerLogs(Mockito.eq(containerId), Mockito.eq(true), Mockito.isNotNull());
+    }
+
+    @Test
+    void runGivesUpWhenReconnectsOnlyReplaySeenLines() throws Exception {
+        final Streams type = Streams.STDOUT;
+        // Every connection re-delivers the very same (already-seen) log line and then drops. Because the
+        // stream never advances past the last received line, delivering a line must NOT refill the reconnect
+        // budget, or a permanently broken socket would reconnect forever. The requestor has to give up.
+        Mockito.doReturn(httpResponse).when(client).execute(Mockito.any(HttpUriRequest.class));
+        Mockito.doReturn(statusLine).when(httpResponse).getStatusLine();
+        Mockito.doReturn(200).when(statusLine).getStatusCode();
+        Mockito.doReturn(httpEntity).when(httpResponse).getEntity();
+        Mockito.doAnswer(invocation -> new FrameThenIOExceptionStream(messageToBuffer(type, "same line").array()))
+               .when(httpEntity).getContent();
+        Mockito.doReturn("url").when(urlBuilder).containerLogs(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any());
+
+        new LogRequestor(client, urlBuilder, containerId, callback).reconnectPolicy(3, 0).run();
+
+        // Initial attempt + exactly 3 reconnects, then give up — bounded, not an unbounded loop.
+        Mockito.verify(client, Mockito.times(4)).execute(Mockito.any(HttpUriRequest.class));
         Mockito.verify(callback).error(Mockito.anyString());
     }
 
@@ -271,7 +349,7 @@ class LogRequestorTest {
         Mockito.doReturn(httpEntity).when(httpResponse).getEntity();
         Mockito.doReturn(inputStream).when(httpEntity).getContent();
 
-        Mockito.doReturn("url").when(urlBuilder).containerLogs(Mockito.anyString(), Mockito.anyBoolean());
+        Mockito.doReturn("url").when(urlBuilder).containerLogs(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any());
     }
 
     private enum Streams {
@@ -346,6 +424,26 @@ class LogRequestorTest {
     private class IOExceptionStream extends InputStream {
         public int read() throws IOException {
             throw new IOException("Something bad happened");
+        }
+    }
+
+    /**
+     * Delivers the given bytes (one complete log frame) and then throws an IOException on the next read,
+     * simulating a mid-stream socket disconnect after some log output was already consumed.
+     */
+    private class FrameThenIOExceptionStream extends InputStream {
+        private final ByteArrayInputStream delegate;
+
+        FrameThenIOExceptionStream(byte[] frame) {
+            this.delegate = new ByteArrayInputStream(frame);
+        }
+
+        public int read() throws IOException {
+            int b = delegate.read();
+            if (b == -1) {
+                throw new IOException("Bad file descriptor");
+            }
+            return b;
         }
     }
 }


### PR DESCRIPTION
### Problem

When following container logs — for `<wait><log>` pattern matching or console log following — a **transient failure of the log stream** makes `LogRequestor.run()` give up: it catches the `IOException`, calls `callback.error(...)`, and the streaming thread ends. For a log-wait, `LogMatchCallback.error()` only logs the message and never notifies `LogWaitChecker`, so the `CountDownLatch` is never released and the wait silently runs to its timeout.

This shows up as flaky `<wait><log>` timeouts, most visibly on the macOS CI runners where Docker runs inside a Lima/QEMU VM and the log socket intermittently drops with `jnr.enxio.channels.NativeException: Bad file descriptor` (e.g. the `dmp-multi-assembly` IT: *"Timeout ... while waiting on log out 'Hello from Spring Boot!'"*).

### Fix

Make `LogRequestor.run()` **reconnect on a transient `IOException` instead of aborting**:

- Retry with a small backoff, **resuming the stream from the last received timestamp** (new `UrlBuilder.containerLogs(..., String since)` overload that passes docker's `since` at **nanosecond precision**). Because docker's `since` is an inclusive lower bound, at most the single line at the exact resume instant can reappear — rather than every line sharing the same whole second.
- The reconnect budget resets **only when the stream makes genuine forward progress** (the last-received timestamp advances past the previous failure point), not merely because some line was delivered. A healthy long-running stream that blips isn't penalised, while a socket that only ever **replays already-seen lines never refills the budget** and is therefore bounded — important for the untimed console-following path, which has no wait timeout to stop it.
- `finish()` marks the requestor `stopped`; the `request` field is `volatile` and `stopped` is re-checked right before each connection is opened, so a deliberate abort (wait completed/timed out) is **not** retried and no post-`finish()` connection is opened.
- If the stream never recovers, the reconnect budget is exhausted and the error is surfaced via `callback.error(...)`; behaviour on the wait side is unchanged — the wait still times out. No functional change on healthy Docker.

Only the asynchronous follow path (`run()`) retries; the synchronous one-shot `fetchLogs()` is untouched.

### Tests

- `LogRequestorTest`: reconnect-then-succeed after a transient `IOException`; give-up after the reconnect budget is exhausted; that the reconnect request carries a `since` timestamp; and that a stream which only ever **replays the same already-seen line is bounded and gives up** (no unbounded reconnect loop).
- `UrlBuilderTest`: the `since` query parameter (nanosecond precision).
- Unit tests updated accordingly; CI validates the full suite.

### Verification on real Docker (e2e)

Ran the e2e suite on a fork (initial implementation of this reconnect approach):

- **Linux (all 6 Docker versions): green** across runs — no regression to real-Docker log following.
- **macOS**: the `dmp-multi-assembly` log-wait — which fails consistently on `master` with the `Bad file descriptor` timeout — **passed** with this change. (macOS CI is independently flaky in the Lima/QEMU **VM boot** step, and some borderline `<wait><time>` budgets can be exceeded on the slower macOS + newer-Docker runners regardless of this change; those remain infra concerns unrelated to the reconnect logic.)

The reconnect budget/`since` refinements above were added after a code review; the core reconnect behaviour is unchanged from the e2e-verified version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
