### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -19,9 +19,9 @@ jobs:
         java: [11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -29,7 +29,7 @@ jobs:
         run: |
           mvn -Pdoc-html && mvn -Pdoc-pdf
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3    
+        uses: actions/upload-pages-artifact@v5    
         with:
           path: ./target/generated-docs
   deploy:
@@ -41,4 +41,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Cache .m2 registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.m2/repository
           key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -47,19 +47,19 @@ jobs:
         docker: [v27.1.1, v26.1.4, v25.0.2, v24.0.9, v23.0.6, v20.10.24]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
       - name: Cache .m2 registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.m2/repository
           key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
       - name: Set up Docker
-        uses: crazy-max/ghaction-setup-docker@v4
+        uses: docker/setup-docker-action@v5
         with:
           version: ${{ matrix.docker }}
       - name: Run Integration tests
@@ -81,14 +81,14 @@ jobs:
         docker: [v27.5.1, v26.1.4]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
       - name: Cache .m2 registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.m2/repository
           key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
@@ -96,7 +96,7 @@ jobs:
         name: Install QEMU 9.0.2
         uses: docker/actions-toolkit/.github/actions/macos-setup-qemu@19ca9ade20f5da695f76a10988d6532058575f82
       - name: Set up Docker
-        uses: crazy-max/ghaction-setup-docker@v4
+        uses: docker/setup-docker-action@v5
         with:
           version: ${{ matrix.docker }}
       - name: Set up Docker Buildx

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -22,9 +22,9 @@ jobs:
         run: |
           ver
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/linux-mavenwrapper-build.yml
+++ b/.github/workflows/linux-mavenwrapper-build.yml
@@ -15,9 +15,9 @@ jobs:
         java: [11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/macos-mavenwrapper-build.yml
+++ b/.github/workflows/macos-mavenwrapper-build.yml
@@ -15,9 +15,9 @@ jobs:
         java: [11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/release-snapshots.yml
+++ b/.github/workflows/release-snapshots.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag }}
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 11
           distribution: ${{ github.event.inputs.java_distribution }}

--- a/.github/workflows/sonar-pr-analysis-publish.yml
+++ b/.github/workflows/sonar-pr-analysis-publish.yml
@@ -29,7 +29,7 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - name: Setup Java 17 # Move Sonar analysis to Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -41,7 +41,7 @@ jobs:
             "https://api.github.com/repos/$GITHUB_REPO/pulls?head=$GITHUB_PR_AUTHOR:$GITHUB_BASE_REF&state=open" | jq '.[0].number')
           echo "PR_NUMBER=$PR_QUERY_RESULT" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ env.PR_NUMBER }}/head
           # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/sonar-pr-request.yml
+++ b/.github/workflows/sonar-pr-request.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
       - name: Setup Java 17 # Move Sonar analysis to Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -25,12 +25,12 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
       - name: Setup Java 17 # Move Sonar analysis to Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
         java: [11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -18,9 +18,9 @@ jobs:
         java: [8, 11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/windows-mavenwrapper-build.yml
+++ b/.github/workflows/windows-mavenwrapper-build.yml
@@ -18,9 +18,9 @@ jobs:
         java: [11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
### Why

The workflows pin GitHub Actions to an outdated and inconsistent mix — `actions/checkout` alone was used at **v2, v3 and v4** across different files — and the runners now emit `Node.js 20 is deprecated` warnings for the older ones (they are being force-run on Node 24). This maintenance PR bumps every action used in `.github/workflows/` to its current major release. **No workflow logic is changed — only action versions.**

### Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v2 / v3 / v4 (mixed) | **v7** |
| `actions/setup-java` | v3 / v4 (mixed) | **v5** |
| `actions/cache` | v4 | **v6** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |
| `crazy-max/ghaction-setup-docker` | v4 | **`docker/setup-docker-action@v5`** |

### Notes

- **`crazy-max/ghaction-setup-docker` → `docker/setup-docker-action`**: the action was transferred to its canonical `docker/` namespace (same action, same tags). The `version: ${{ matrix.docker }}` input is unchanged.
- The `docker/actions-toolkit .../macos-setup-qemu` step (the QEMU 9.0.2 workaround for macOS, per docker/setup-docker-action#108) is **intentionally left at its current pinned SHA** — it is a deliberate, still-needed workaround, not a version to bump here.
- Verified the latest versions against each action's releases at the time of writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
