### PR TITLE
Simplify macOS Docker setup: drop obsolete QEMU workaround, use macos-26-intel

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,9 +72,9 @@ jobs:
   macos-build:
     name: MacOS
     needs: buildWithoutTests
-    # Using macos-15-intel (not macos-14) because ARM64 runners don't support nested virtualization
+    # Using an Intel runner because ARM64 macOS runners don't support nested virtualization
     # required for Docker/QEMU. See: https://github.com/actions/runner-images/issues/9460
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     strategy:
       fail-fast: false
       matrix:
@@ -92,9 +92,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: cache-e2e-${{ github.sha }}-${{ github.run_id }}
-      - # https://github.com/crazy-max/ghaction-setup-docker/issues/108
-        name: Install QEMU 9.0.2
-        uses: docker/actions-toolkit/.github/actions/macos-setup-qemu@19ca9ade20f5da695f76a10988d6532058575f82
       - name: Set up Docker
         uses: docker/setup-docker-action@v5
         with:


### PR DESCRIPTION
### Why

The macOS `E2E Tests` job carried a separate **"Install QEMU 9.0.2"** step (`docker/actions-toolkit .../macos-setup-qemu`, pinned to an old SHA). It was added as a workaround for [docker/setup-docker-action#108](https://github.com/docker/setup-docker-action/issues/108): back then **QEMU 9.1.0 broke the Lima VM boot** on macOS runners, so a known-good QEMU 9.0.2 was force-installed first.

That workaround is **no longer needed** — `docker/setup-docker-action@v5` brings up Docker (Lima) on an Intel macOS runner **without** a pre-pinned QEMU.

### Change

- Remove the separate `macos-setup-qemu` step.
- Use **`docker/setup-docker-action@v5`** for the macOS "Set up Docker" step.
- Move the runner from `macos-15-intel` to the current **`macos-26-intel`**. It stays **Intel** because arm64 macOS runners can't run Docker (no nested virtualization — see [actions/runner-images#9460](https://github.com/actions/runner-images/issues/9460)).

Only `.github/workflows/e2e-tests.yml` (the `macos-build` job) is touched.

### Verification

Ran the full e2e suite on a fork on **both** `macos-15-intel` and `macos-26-intel`:

- **Both macOS runs and all Linux jobs: green.** Docker/Lima comes up and the integration tests pass without the pinned-QEMU step.
- Dropping the QEMU step speeds up `Set up Docker` (~14 min → ~6 min).
- Integration-test time was comparable across the two runners (macOS timing is noisy between runs); `macos-26-intel` is chosen to track the current macOS image.

Complements #1926 (which bumps the action versions repo-wide); this PR is the focused macOS-setup cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
