### PR TITLE
feat: add wslc:// transport for WSL Containers (wslc) (fixes #1928)

### DIFF
--- a/src/main/asciidoc/inc/_global-configuration.adoc
+++ b/src/main/asciidoc/inc/_global-configuration.adoc
@@ -62,8 +62,20 @@ a| The URL of the Docker Daemon. If this configuration option is not given, then
 depending on whether plain HTTP communication is enabled or SSL should
 be used. Alternatively the scheme could be `tcp` in which case the
 protocol is determined via the IANA assigned port: 2375 for `http`
-and 2376 for `https`. Finally, Unix sockets are supported by using
+and 2376 for `https`. Unix sockets are supported by using
 the scheme `unix` together with the filesystem path to the unix socket.
+Windows named pipes are supported with the scheme `npipe`. Finally,
+https://learn.microsoft.com/windows/wsl/wsl-container[WSL Containers (wslc)]
+are supported with the scheme `wslc`: since wslc exposes neither a Windows
+named pipe nor a TCP port, the plugin reaches the Docker daemon running inside
+the wslc virtual machine through a stdio bridge
+(`wslc system session run docker system dial-stdio`). The URL path, if given,
+is the wslc executable to invoke, e.g. `wslc:///wslc.exe` (defaults to `wslc.exe`
+on the `PATH`; can also be overridden with the `WSLC_EXECUTABLE` environment
+variable). This requires a WSL installation that provides `wslc` (WSL 2.9.x or
+later) with an available session. Note that auto-detection only checks that the
+`wslc` CLI is present, so if `wslc` is installed but no session/daemon is ready
+it is still selected and the failure surfaces as a connection error at build time.
 The discovery sequence used by the docker-maven-plugin to determine
 the URL is:
 
@@ -72,6 +84,7 @@ the URL is:
 . the value of the environment variable `DOCKER_HOST`.
 . `/var/run/docker.sock` if it is a readable socket (Unix & OS X).
 . `//./pipe/docker_engine` if it is a readable named pipe (Windows)
+. `wslc://localhost` if `wslc` (WSL Containers) is installed and available (Windows)
 | `docker.host`
 
 | *filter*

--- a/src/main/java/io/fabric8/maven/docker/access/DockerConnectionDetector.java
+++ b/src/main/java/io/fabric8/maven/docker/access/DockerConnectionDetector.java
@@ -3,6 +3,7 @@ package io.fabric8.maven.docker.access;
 import java.io.*;
 import java.util.*;
 
+import io.fabric8.maven.docker.access.hc.wslc.WslcClientBuilder;
 import io.fabric8.maven.docker.access.util.LocalSocketUtil;
 import io.fabric8.maven.docker.util.*;
 
@@ -29,7 +30,8 @@ public class DockerConnectionDetector {
     private Collection<? extends DockerHostProvider> getDefaultEnvProviders() {
         return Arrays.asList(new EnvDockerHostProvider(),
                              new UnixSocketDockerHostProvider(),
-                             new WindowsPipeDockerHostProvider());
+                             new WindowsPipeDockerHostProvider(),
+                             new WslcDockerHostProvider());
     }
 
 
@@ -85,7 +87,8 @@ public class DockerConnectionDetector {
             }
         }
         throw new IllegalArgumentException("No <dockerHost> given, no DOCKER_HOST environment variable, " +
-                                           "no read/writable '/var/run/docker.sock' or '//./pipe/docker_engine' " +
+                                           "no read/writable '/var/run/docker.sock' or '//./pipe/docker_engine', " +
+                                           "no running 'wslc' (WSL Containers) session " +
                                            "and no external provider like Docker machine configured");
     }
 
@@ -138,6 +141,68 @@ public class DockerConnectionDetector {
         @Override
         public int getPriority() {
             return 50;
+        }
+    }
+
+    // Check for WSL Containers (wslc). The Docker daemon runs inside the wslc VM and is not
+    // exposed as a Windows named pipe or TCP port, so it is reached through a stdio bridge
+    // (see the 'wslc://' transport). Priority is below the real Docker/Podman named pipe so an
+    // existing Docker Desktop / Podman endpoint always wins; wslc is only used as a fallback.
+    static class WslcDockerHostProvider implements DockerHostProvider {
+
+        // Allow overriding the wslc executable (e.g. non-default install location) when probing for
+        // availability. The transport resolves the same WSLC_EXECUTABLE variable, so it is not
+        // carried through the connection URL (which would break on paths with spaces or backslashes).
+        private static final String WSLC_EXECUTABLE =
+            System.getenv("WSLC_EXECUTABLE") != null ? System.getenv("WSLC_EXECUTABLE") : "wslc.exe";
+
+        @Override
+        public ConnectionParameter getConnectionParameter(String certPath) throws IOException {
+            if (!isWindows() || !isWslcAvailable()) {
+                return null;
+            }
+            return new ConnectionParameter(WslcClientBuilder.AUTO_DETECT_URL, certPath);
+        }
+
+        @Override
+        public int getPriority() {
+            return 45;
+        }
+
+        private boolean isWindows() {
+            return System.getProperty("os.name", "").toLowerCase().contains("win");
+        }
+
+        // 'wslc version' is a cheap metadata call that does not start the container VM.
+        boolean isWslcAvailable() {
+            Process process = null;
+            try {
+                process = startWslcVersionProbe();
+                if (!process.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    return false;
+                }
+                return process.exitValue() == 0;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            } catch (IOException | RuntimeException e) {
+                return false;
+            } finally {
+                if (process != null && process.isAlive()) {
+                    process.destroyForcibly();
+                }
+            }
+        }
+
+        // Spawn the 'wslc version' probe. Package-visible and overridable so a test can inject a
+        // controlled process (this is a Windows-only path, otherwise never run on the Linux CI).
+        Process startWslcVersionProbe() throws IOException {
+            // Windows-only method (guarded by isWindows() in the caller), so discard output to NUL.
+            return new ProcessBuilder(WSLC_EXECUTABLE, "version")
+                .redirectErrorStream(true)
+                .redirectOutput(ProcessBuilder.Redirect.to(new File("NUL")))
+                .start();
         }
     }
 

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -42,6 +42,7 @@ import io.fabric8.maven.docker.access.hc.http.HttpClientBuilder;
 import io.fabric8.maven.docker.access.hc.unix.UnixSocketClientBuilder;
 import io.fabric8.maven.docker.access.hc.util.ClientBuilder;
 import io.fabric8.maven.docker.access.hc.win.NamedPipeClientBuilder;
+import io.fabric8.maven.docker.access.hc.wslc.WslcClientBuilder;
 import io.fabric8.maven.docker.access.log.LogCallback;
 import io.fabric8.maven.docker.access.log.LogGetHandle;
 import io.fabric8.maven.docker.access.log.LogRequestor;
@@ -93,6 +94,9 @@ public class DockerAccessWithHcClient implements DockerAccess {
     // Base URL which is given through when using NamedPipe communication but is not really used
     private static final String NPIPE_URL = "npipe://127.0.0.1:1/";
 
+    // Base URL which is given through when using wslc (WSL Containers) communication but is not really used
+    private static final String WSLC_URL = "wslc://127.0.0.1:1/";
+
     // Minimal API version, independent of any feature used
     public static final String API_VERSION = "1.18";
 
@@ -137,6 +141,9 @@ public class DockerAccessWithHcClient implements DockerAccess {
         } else if (uri.getScheme().equalsIgnoreCase("npipe")) {
             this.delegate = createHttpClient(new NamedPipeClientBuilder(uri.getPath(), maxConnections, log), false);
             baseUrl = NPIPE_URL;
+        } else if (uri.getScheme().equalsIgnoreCase("wslc")) {
+            this.delegate = createHttpClient(new WslcClientBuilder(uri.getPath(), maxConnections, log), false);
+            baseUrl = WSLC_URL;
         } else {
             this.delegate = createHttpClient(new HttpClientBuilder(isSSL(baseUrl) ? certPath : null, maxConnections));
         }

--- a/src/main/java/io/fabric8/maven/docker/access/hc/unix/UnixSocket.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/unix/UnixSocket.java
@@ -6,32 +6,24 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import java.net.InetAddress;
-import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 
 import java.nio.channels.Channels;
-import java.nio.channels.SocketChannel;
 
+import io.fabric8.maven.docker.access.hc.util.AbstractPlainSocket;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
 import jnr.unixsocket.UnixSocketOptions;
 
-final class UnixSocket extends Socket {
+final class UnixSocket extends AbstractPlainSocket {
 
     private final Object connectLock = new Object();
-    private volatile boolean inputShutdown, outputShutdown;
 
     private final UnixSocketChannel channel;
 
     UnixSocket() throws IOException {
         channel = UnixSocketChannel.open();
-    }
-
-    @Override
-    public void connect(SocketAddress endpoint) throws IOException {
-        connect(endpoint, 0);
     }
 
     @Override
@@ -50,31 +42,6 @@ final class UnixSocket extends Socket {
     }
 
     @Override
-    public void bind(SocketAddress bindpoint) throws IOException {
-        throw new SocketException("Bind is not supported");
-    }
-
-    @Override
-    public InetAddress getInetAddress() {
-        return null;
-    }
-
-    @Override
-    public InetAddress getLocalAddress() {
-        return null;
-    }
-
-    @Override
-    public int getPort() {
-        return -1;
-    }
-
-    @Override
-    public int getLocalPort() {
-        return -1;
-    }
-
-    @Override
     public SocketAddress getRemoteSocketAddress() {
         synchronized (connectLock) {
             return channel.getRemoteSocketAddress();
@@ -86,11 +53,6 @@ final class UnixSocket extends Socket {
         synchronized (connectLock) {
             return channel.getLocalSocketAddress();
         }
-    }
-
-    @Override
-    public SocketChannel getChannel() {
-        return null;
     }
 
     @Override
@@ -142,10 +104,6 @@ final class UnixSocket extends Socket {
         };
     }
 
-    @Override
-    public void sendUrgentData(int data) throws IOException {
-        throw new SocketException("Urgent data not supported");
-    }
     @Override
     public void setSoTimeout(int timeout) throws SocketException {
         try {
@@ -240,22 +198,12 @@ final class UnixSocket extends Socket {
     }
 
     @Override
-    public int getTrafficClass() throws SocketException {
-        throw new UnsupportedOperationException("Getting the traffic class is not supported");
-    }
-
-    @Override
     public void setReuseAddress(boolean on) throws SocketException {
         if (isClosed()) {
             throw new SocketException("Socket is closed");
         }
 
         // just ignore
-    }
-
-    @Override
-    public boolean getReuseAddress() throws SocketException {
-        throw new UnsupportedOperationException("Getting the SO_REUSEADDR option is not supported");
     }
 
     @Override
@@ -292,27 +240,7 @@ final class UnixSocket extends Socket {
     }
 
     @Override
-    public boolean isBound() {
-        return false;
-    }
-
-    @Override
     public boolean isClosed() {
         return !channel.isOpen();
-    }
-
-    @Override
-    public boolean isInputShutdown() {
-        return inputShutdown;
-    }
-
-    @Override
-    public boolean isOutputShutdown() {
-        return outputShutdown;
-    }
-
-    @Override
-    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
-        // no-op
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/access/hc/util/AbstractPlainSocket.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/util/AbstractPlainSocket.java
@@ -1,0 +1,199 @@
+package io.fabric8.maven.docker.access.hc.util;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+
+/**
+ * Base class for {@link Socket} transports that wrap a raw byte stream rather than a real TCP socket
+ * (for example the wslc:// bridge). It provides the boilerplate handling of the {@link Socket} API
+ * surface that does not apply to such a transport: address/port accessors return empty values, socket
+ * options are no-ops or unsupported, {@code bind}/urgent-data are rejected, and the input/output
+ * shutdown state is tracked here.
+ * <p>
+ * Subclasses implement the transport itself &mdash; {@link #connect(SocketAddress, int)},
+ * {@link #getInputStream()}, {@link #getOutputStream()}, {@link #close()}, {@link #isConnected()} and
+ * {@link #isClosed()} &mdash; and use {@link #validateEndpoint(SocketAddress, int, Class)} to validate
+ * their connect arguments. Any option method below may be overridden by a subclass that has genuine
+ * behaviour for it &mdash; the channel-backed unix:// and npipe:// transports, for example, override
+ * the buffer-size, traffic-class and stream methods while inheriting the rest of this boilerplate.
+ */
+public abstract class AbstractPlainSocket extends Socket {
+
+    /** Remote address, set once on connect by {@link #validateEndpoint(SocketAddress, int, Class)}
+     * (or directly by a subclass' connect) before the socket is handed to the HTTP client. */
+    protected SocketAddress socketAddress;
+
+    protected volatile boolean inputShutdown;
+
+    protected volatile boolean outputShutdown;
+
+    /**
+     * Validate {@link #connect(SocketAddress, int)} arguments: reject a negative timeout and an
+     * endpoint that is not of the expected type, remember the endpoint as the remote address, and
+     * return it cast to that type.
+     */
+    protected final <T extends SocketAddress> T validateEndpoint(SocketAddress endpoint, int timeout, Class<T> type) {
+        if (timeout < 0) {
+            throw new IllegalArgumentException("Timeout may not be negative: " + timeout);
+        }
+        if (!type.isInstance(endpoint)) {
+            throw new IllegalArgumentException("Unsupported address type: "
+                + (endpoint == null ? "null" : endpoint.getClass().getName()));
+        }
+        this.socketAddress = endpoint;
+        return type.cast(endpoint);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint) throws IOException {
+        connect(endpoint, 0);
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        return socketAddress;
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        inputShutdown = true;
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        outputShutdown = true;
+    }
+
+    @Override
+    public boolean isInputShutdown() {
+        return inputShutdown;
+    }
+
+    @Override
+    public boolean isOutputShutdown() {
+        return outputShutdown;
+    }
+
+    @Override
+    public void bind(SocketAddress bindpoint) throws IOException {
+        throw new SocketException("Bind is not supported");
+    }
+
+    @Override
+    public void sendUrgentData(int data) throws IOException {
+        throw new SocketException("Urgent data not supported");
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+        return null;
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public int getPort() {
+        return -1;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return -1;
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        return null;
+    }
+
+    @Override
+    public SocketChannel getChannel() {
+        return null;
+    }
+
+    @Override
+    public synchronized void setSoTimeout(int timeout) throws SocketException {
+        // no-op: a stream/pipe transport has no socket-level read timeout
+    }
+
+    @Override
+    public synchronized int getSoTimeout() throws SocketException {
+        return 0;
+    }
+
+    @Override
+    public void setKeepAlive(boolean on) throws SocketException {
+        // just ignore
+    }
+
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+        return true;
+    }
+
+    @Override
+    public synchronized void setSendBufferSize(int size) throws SocketException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Send buffer size must be positive: " + size);
+        }
+        // just ignore
+    }
+
+    @Override
+    public synchronized int getSendBufferSize() throws SocketException {
+        throw new UnsupportedOperationException("Getting the send buffer size is not supported");
+    }
+
+    @Override
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Receive buffer size must be positive: " + size);
+        }
+        // just ignore
+    }
+
+    @Override
+    public synchronized int getReceiveBufferSize() throws SocketException {
+        throw new UnsupportedOperationException("Getting the receive buffer size is not supported");
+    }
+
+    @Override
+    public void setTrafficClass(int tc) throws SocketException {
+        if (tc < 0 || tc > 255) {
+            throw new IllegalArgumentException("Traffic class is not in range 0 -- 255: " + tc);
+        }
+        // just ignore
+    }
+
+    @Override
+    public int getTrafficClass() throws SocketException {
+        throw new UnsupportedOperationException("Getting the traffic class is not supported");
+    }
+
+    @Override
+    public void setReuseAddress(boolean on) throws SocketException {
+        // just ignore
+    }
+
+    @Override
+    public boolean getReuseAddress() throws SocketException {
+        throw new UnsupportedOperationException("Getting the SO_REUSEADDR option is not supported");
+    }
+
+    @Override
+    public boolean isBound() {
+        return false;
+    }
+
+    @Override
+    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+        // no-op
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/hc/win/NamedPipe.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/win/NamedPipe.java
@@ -6,42 +6,31 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
-import java.net.InetAddress;
-import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
-import java.nio.channels.SocketChannel;
 import java.nio.charset.Charset;
 
+import io.fabric8.maven.docker.access.hc.util.AbstractPlainSocket;
 import io.fabric8.maven.docker.util.Logger;
 
 import static com.google.common.base.CharMatcher.ascii;
 
-final class NamedPipe extends Socket {
+final class NamedPipe extends AbstractPlainSocket {
 
 	// Logging
     private final Logger log;
-	//for development purposes
-	private final static boolean DEBUG = false;
 
     private final Object connectLock = new Object();
-    private volatile boolean inputShutdown, outputShutdown;
 
     private String socketPath;
-    private volatile SocketAddress socketAddress;
     private RandomAccessFile namedPipe;
 
     private FileChannel channel;
 
     NamedPipe(Logger log) throws IOException {
     	this.log = log;
-    }
-
-    @Override
-    public void connect(SocketAddress endpoint) throws IOException {
-        connect(endpoint, 0);
     }
 
     @Override
@@ -61,46 +50,6 @@ final class NamedPipe extends Socket {
         	this.namedPipe = new RandomAccessFile(socketPath, "rw");
         	this.channel = this.namedPipe.getChannel();
         }
-    }
-
-    @Override
-    public void bind(SocketAddress bindpoint) throws IOException {
-        throw new SocketException("Bind is not supported");
-    }
-
-    @Override
-    public InetAddress getInetAddress() {
-        return null;
-    }
-
-    @Override
-    public InetAddress getLocalAddress() {
-        return null;
-    }
-
-    @Override
-    public int getPort() {
-        return -1;
-    }
-
-    @Override
-    public int getLocalPort() {
-        return -1;
-    }
-
-    @Override
-    public SocketAddress getRemoteSocketAddress() {
-        return socketAddress;
-    }
-
-    @Override
-    public SocketAddress getLocalSocketAddress() {
-        return null;
-    }
-
-    @Override
-    public SocketChannel getChannel() {
-        return null;
     }
 
     @Override
@@ -158,20 +107,6 @@ final class NamedPipe extends Socket {
     }
 
     @Override
-    public void sendUrgentData(int data) throws IOException {
-        throw new SocketException("Urgent data not supported");
-    }
-
-    @Override
-    public void setSoTimeout(int timeout) {
-    }
-
-    @Override
-    public int getSoTimeout() throws SocketException {
-    	return 0;
-    }
-
-    @Override
     public void setSendBufferSize(int size) throws SocketException {
         if (size <= 0) {
             throw new IllegalArgumentException("Send buffer size must be positive: " + size);
@@ -216,15 +151,6 @@ final class NamedPipe extends Socket {
     }
 
     @Override
-    public void setKeepAlive(boolean on) throws SocketException {
-    }
-
-    @Override
-    public boolean getKeepAlive() throws SocketException {
-    	return true;
-    }
-
-    @Override
     public void setTrafficClass(int tc) throws SocketException {
         if (tc < 0 || tc > 255) {
             throw new IllegalArgumentException("Traffic class is not in range 0 -- 255: " + tc);
@@ -238,21 +164,6 @@ final class NamedPipe extends Socket {
     }
 
     @Override
-    public int getTrafficClass() throws SocketException {
-        throw new UnsupportedOperationException("Getting the traffic class is not supported");
-    }
-
-    @Override
-    public void setReuseAddress(boolean on) throws SocketException {
-        // just ignore
-    }
-
-    @Override
-    public boolean getReuseAddress() throws SocketException {
-        throw new UnsupportedOperationException("Getting the SO_REUSEADDR option is not supported");
-    }
-
-    @Override
     public void close() throws IOException {
         if (isClosed()) {
             return;
@@ -261,16 +172,6 @@ final class NamedPipe extends Socket {
             channel.close();
         }
         inputShutdown = true;
-        outputShutdown = true;
-    }
-
-    @Override
-    public void shutdownInput() throws IOException {
-        inputShutdown = true;
-    }
-
-    @Override
-    public void shutdownOutput() throws IOException {
         outputShutdown = true;
     }
 
@@ -289,27 +190,7 @@ final class NamedPipe extends Socket {
     }
 
     @Override
-    public boolean isBound() {
-        return false;
-    }
-
-    @Override
     public boolean isClosed() {
         return channel != null && !channel.isOpen();
-    }
-
-    @Override
-    public boolean isInputShutdown() {
-        return inputShutdown;
-    }
-
-    @Override
-    public boolean isOutputShutdown() {
-        return outputShutdown;
-    }
-
-    @Override
-    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
-        // no-op
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/access/hc/wslc/WslcClientBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/wslc/WslcClientBuilder.java
@@ -1,0 +1,48 @@
+package io.fabric8.maven.docker.access.hc.wslc;
+
+import io.fabric8.maven.docker.access.hc.util.AbstractNativeClientBuilder;
+import io.fabric8.maven.docker.util.Logger;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+
+/**
+ * HttpClient builder for the WSL Containers (wslc) transport. Each connection is a child process
+ * ({@code wslc system session run docker system dial-stdio}) whose stdio is bridged to the Docker
+ * daemon socket inside the wslc virtual machine.
+ * <p>
+ * The {@code path} carried through the {@code wslc://} URL is interpreted as the wslc executable to
+ * invoke (default {@code wslc.exe}); this lets a build point at a non-default wslc location.
+ */
+public class WslcClientBuilder extends AbstractNativeClientBuilder {
+
+    public static final String DEFAULT_WSLC_EXECUTABLE = "wslc.exe";
+
+    // URL used on auto-detection. It carries no executable in the path (that would break URI parsing
+    // for paths with spaces/backslashes); the executable is resolved from WSLC_EXECUTABLE instead.
+    // Needs a (dummy) authority because "wslc://" alone is not a valid URI.
+    public static final String AUTO_DETECT_URL = "wslc://localhost";
+
+    public WslcClientBuilder(String wslcExecutable, int maxConnections, Logger log) {
+        super(resolveExecutable(wslcExecutable), maxConnections, log);
+    }
+
+    static String resolveExecutable(String wslcExecutable) {
+        if (wslcExecutable == null || wslcExecutable.trim().isEmpty() || "/".equals(wslcExecutable)) {
+            // No executable in the URL: honour WSLC_EXECUTABLE (read from the environment here rather
+            // than via the URL, so paths with spaces or backslashes are not forced through URI parsing).
+            String fromEnv = System.getenv("WSLC_EXECUTABLE");
+            return fromEnv != null && !fromEnv.trim().isEmpty() ? fromEnv : DEFAULT_WSLC_EXECUTABLE;
+        }
+        // A leading slash comes from a URL like wslc:///wslc.exe -- strip it for the executable name.
+        return wslcExecutable.startsWith("/") ? wslcExecutable.substring(1) : wslcExecutable;
+    }
+
+    @Override
+    protected ConnectionSocketFactory getConnectionSocketFactory() {
+        return new WslcConnectionSocketFactory(path, log);
+    }
+
+    @Override
+    protected String getProtocol() {
+        return "wslc";
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/hc/wslc/WslcConnectionSocketFactory.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/wslc/WslcConnectionSocketFactory.java
@@ -1,0 +1,42 @@
+package io.fabric8.maven.docker.access.hc.wslc;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.fabric8.maven.docker.access.hc.util.AbstractNativeSocketFactory;
+import io.fabric8.maven.docker.util.Logger;
+import org.apache.http.protocol.HttpContext;
+
+final class WslcConnectionSocketFactory extends AbstractNativeSocketFactory {
+
+    private final Logger log;
+
+    WslcConnectionSocketFactory(String wslcExecutable, Logger log) {
+        super(wslcExecutable);
+        this.log = log;
+    }
+
+    @Override
+    public Socket createSocket(HttpContext context) throws IOException {
+        return new WslcProcessSocket(log);
+    }
+
+    @Override
+    protected SocketAddress createSocketAddress(String wslcExecutable) {
+        // Build the stdio-bridge command: <wslc> system session run docker system dial-stdio
+        // `docker system dial-stdio` locates the daemon socket inside the VM itself, so no socket
+        // path is needed on the Windows side.
+        List<String> command = new ArrayList<>();
+        command.add(wslcExecutable);
+        command.add("system");
+        command.add("session");
+        command.add("run");
+        command.add("docker");
+        command.add("system");
+        command.add("dial-stdio");
+        return new WslcSocketAddress(command);
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/hc/wslc/WslcProcessSocket.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/wslc/WslcProcessSocket.java
@@ -1,0 +1,161 @@
+package io.fabric8.maven.docker.access.hc.wslc;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import io.fabric8.maven.docker.access.hc.util.AbstractPlainSocket;
+import io.fabric8.maven.docker.util.Logger;
+
+/**
+ * A {@link java.net.Socket} whose input/output streams are backed by a child process that bridges
+ * stdin/stdout to the Docker daemon socket inside the wslc virtual machine
+ * (typically {@code wslc.exe system session run docker system dial-stdio}).
+ * <p>
+ * This mirrors how {@code DOCKER_HOST=ssh://} works: the transport is a command producing a
+ * raw byte stream to the remote daemon socket, which Apache HttpClient then drives as if it
+ * were a normal socket. wslc does not expose a Windows named pipe or TCP port, so this stdio
+ * bridge is the only host-visible channel to the daemon. All the socket-API boilerplate lives in
+ * {@link AbstractPlainSocket}; this class holds only the process-bridge specifics.
+ */
+final class WslcProcessSocket extends AbstractPlainSocket {
+
+    private final Logger log;
+
+    private Process process;
+    private volatile boolean closed;
+
+    WslcProcessSocket(Logger log) {
+        this.log = log;
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        List<String> command = validateEndpoint(endpoint, timeout, WslcSocketAddress.class).command();
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(false);
+        try {
+            this.process = pb.start();
+        } catch (IOException e) {
+            throw new IOException("Failed to start wslc Docker bridge process " + command + ": " + e.getMessage(), e);
+        }
+        if (log != null) {
+            // One bridge process per HTTP connection; HTTP keep-alive reuses it across requests.
+            log.debug("Opened wslc Docker bridge: %s", command);
+        }
+
+        // Drain the bridge's stderr so a full pipe buffer can never block the daemon stream,
+        // and so connection failures (e.g. dial-stdio cannot reach the daemon) surface in the log.
+        final Process p = this.process;
+        Thread errorDrain = new Thread(() -> {
+            byte[] buf = new byte[1024];
+            try (InputStream err = p.getErrorStream()) {
+                int n;
+                while ((n = err.read(buf)) != -1) {
+                    if (n > 0 && log != null) {
+                        log.debug("wslc bridge stderr: %s", new String(buf, 0, n, StandardCharsets.UTF_8).trim());
+                    }
+                }
+            } catch (IOException ignore) {
+                // process gone
+            }
+        }, "wslc-bridge-stderr");
+        errorDrain.setDaemon(true);
+        errorDrain.start();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        ensureConnected();
+        if (inputShutdown) {
+            throw new SocketException("Socket input is shutdown");
+        }
+        // stdout of the bridge process = bytes coming back from the Docker daemon socket
+        return new FilterInputStream(process.getInputStream()) {
+            @Override
+            public void close() throws IOException {
+                shutdownInput();
+            }
+        };
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        ensureConnected();
+        if (outputShutdown) {
+            throw new SocketException("Socket output is shutdown");
+        }
+        // stdin of the bridge process = bytes written to the Docker daemon socket
+        return new FilterOutputStream(process.getOutputStream()) {
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                out.write(b, off, len);
+            }
+
+            @Override
+            public void close() throws IOException {
+                shutdownOutput();
+            }
+        };
+    }
+
+    private void ensureConnected() throws SocketException {
+        if (process == null) {
+            throw new SocketException("Socket is not connected");
+        }
+    }
+
+    @Override
+    public void setTcpNoDelay(boolean on) {
+        // No-op: HttpClient sets this on the still-unconnected socket before the connect call, and a
+        // process-backed socket has no TCP layer. Overriding avoids the inherited close-state guard.
+    }
+
+    @Override
+    public boolean getTcpNoDelay() {
+        return true;
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        closed = true;
+        inputShutdown = true;
+        outputShutdown = true;
+        if (process != null) {
+            process.destroyForcibly();
+        }
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        super.shutdownOutput();
+        // Closing the bridge's stdin signals EOF to the daemon socket (half-close).
+        if (process != null) {
+            process.getOutputStream().close();
+        }
+    }
+
+    @Override
+    public boolean isConnected() {
+        return process != null && !isClosed();
+    }
+
+    @Override
+    public boolean isClosed() {
+        // Not closed before connect (process == null), so HttpClient can set socket options on the
+        // fresh socket. Once connected, a dead bridge process counts as closed.
+        return closed || (process != null && !process.isAlive());
+    }
+
+    @Override
+    public String toString() {
+        return isConnected() ? "WslcProcessSocket[" + socketAddress + "]" : "WslcProcessSocket[unconnected]";
+    }
+}

--- a/src/main/java/io/fabric8/maven/docker/access/hc/wslc/WslcSocketAddress.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/wslc/WslcSocketAddress.java
@@ -1,0 +1,41 @@
+package io.fabric8.maven.docker.access.hc.wslc;
+
+import java.net.SocketAddress;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Address of a WSL Containers (wslc) Docker endpoint. There is no real socket path on the
+ * Windows host: the Docker daemon lives inside the wslc virtual machine and is reached by
+ * spawning a bridge command whose stdin/stdout stream raw bytes to {@code /var/run/docker.sock}
+ * inside the VM. This address therefore carries the command line to spawn.
+ */
+class WslcSocketAddress extends SocketAddress {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> command;
+
+    WslcSocketAddress(List<String> command) {
+        this.command = command;
+    }
+
+    List<String> command() {
+        return command;
+    }
+
+    @Override
+    public String toString() {
+        return "WslcSocketAddress{command=" + command + "}";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof WslcSocketAddress && command.equals(((WslcSocketAddress) other).command);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(command.toArray());
+    }
+}

--- a/src/test/java/io/fabric8/maven/docker/access/DockerConnectionDetectorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/DockerConnectionDetectorTest.java
@@ -27,9 +27,12 @@ class DockerConnectionDetectorTest {
             Assertions.assertEquals(dockerHost.replaceFirst("^tcp:/",""), detector.detectConnectionParameter(null, null).getUrl().replaceFirst("^https?:/", ""));
         } else if (System.getProperty("os.name").contains("Windows")) {
         	try {
-                Assertions.assertEquals("npipe:////./pipe/docker_engine", detector.detectConnectionParameter(null, null).getUrl());
+                String url = detector.detectConnectionParameter(null, null).getUrl();
+                // A real Docker/Podman named pipe wins if present; otherwise wslc is detected as a fallback.
+                Assertions.assertTrue("npipe:////./pipe/docker_engine".equals(url) || url.startsWith("wslc://"),
+                    "Unexpected detected docker host on Windows: " + url);
             } catch (IllegalArgumentException expectedIfNoUnixSocket) {
-        	    // expected if no unix socket
+        	    // expected if neither a named pipe nor wslc is available
             }
         } else {
             try {
@@ -45,13 +48,91 @@ class DockerConnectionDetectorTest {
         Class[] expectedProviders = new Class[] {
             DockerConnectionDetector.EnvDockerHostProvider.class,
             DockerConnectionDetector.UnixSocketDockerHostProvider.class,
-            DockerConnectionDetector.WindowsPipeDockerHostProvider.class
+            DockerConnectionDetector.WindowsPipeDockerHostProvider.class,
+            DockerConnectionDetector.WslcDockerHostProvider.class
         };
 
         int i = 0;
         for (DockerConnectionDetector.DockerHostProvider provider : detector.dockerHostProviders) {
             Assertions.assertEquals(expectedProviders[i++], provider.getClass());
         }
+    }
+
+    @Test
+    void testWslcProviderPriorityAndNonWindowsDetection() throws IOException {
+        DockerConnectionDetector.WslcDockerHostProvider provider = new DockerConnectionDetector.WslcDockerHostProvider();
+        // Below the docker_engine named pipe (50) so a real Docker/Podman endpoint always wins.
+        Assertions.assertEquals(45, provider.getPriority());
+        // On non-Windows the provider is inert (never probes for wslc).
+        if (!System.getProperty("os.name", "").toLowerCase().contains("win")) {
+            Assertions.assertNull(provider.getConnectionParameter(null));
+        }
+    }
+
+    @Test
+    void testWslcAvailabilityProbeBranches() {
+        // 'wslc version' exiting 0 -> available.
+        Assertions.assertTrue(providerWithProbe(fakeProcess(true, 0, false)).isWslcAvailable());
+        // Non-zero exit -> not available.
+        Assertions.assertFalse(providerWithProbe(fakeProcess(true, 3, false)).isWslcAvailable());
+        // Probe does not finish within the timeout -> not available (and gets force-killed).
+        Assertions.assertFalse(providerWithProbe(fakeProcess(false, 0, true)).isWslcAvailable());
+        // Spawning the probe fails (wslc not installed) -> not available.
+        Assertions.assertFalse(providerWithProbe(null).isWslcAvailable());
+    }
+
+    @Test
+    void testStartWslcVersionProbeRuns() {
+        // Exercise the real probe launcher. wslc is absent on the CI host, so starting it throws
+        // IOException; on a dev box with wslc installed it returns a live process we then kill.
+        DockerConnectionDetector.WslcDockerHostProvider provider = new DockerConnectionDetector.WslcDockerHostProvider();
+        Process probe = null;
+        boolean launchFailed = false;
+        try {
+            probe = provider.startWslcVersionProbe();
+        } catch (IOException expectedWhenWslcAbsent) {
+            // wslc executable not on PATH: the ProcessBuilder ran and start() failed, as intended.
+            launchFailed = true;
+        } finally {
+            if (probe != null) {
+                probe.destroyForcibly();
+            }
+            // The probe discards output to "NUL"; on non-Windows that is a real file, so clean it up.
+            java.io.File nul = new java.io.File("NUL");
+            if (nul.isFile()) {
+                nul.delete();
+            }
+        }
+        // Either wslc launched and returned a process, or it was absent and starting it failed with
+        // an IOException. Any other failure mode would already have thrown out of the block above.
+        Assertions.assertTrue(probe != null || launchFailed);
+    }
+
+    private static DockerConnectionDetector.WslcDockerHostProvider providerWithProbe(Process probe) {
+        return new DockerConnectionDetector.WslcDockerHostProvider() {
+            @Override
+            Process startWslcVersionProbe() throws IOException {
+                if (probe == null) {
+                    throw new IOException("wslc not installed");
+                }
+                return probe;
+            }
+        };
+    }
+
+    /** A canned {@link Process} for exercising the availability probe without spawning anything. */
+    private static Process fakeProcess(boolean finishesInTime, int exitValue, boolean aliveAfterTimeout) {
+        return new Process() {
+            @Override public java.io.OutputStream getOutputStream() { return null; }
+            @Override public java.io.InputStream getInputStream() { return null; }
+            @Override public java.io.InputStream getErrorStream() { return null; }
+            @Override public int waitFor() { return exitValue; }
+            @Override public boolean waitFor(long timeout, java.util.concurrent.TimeUnit unit) { return finishesInTime; }
+            @Override public int exitValue() { return exitValue; }
+            @Override public boolean isAlive() { return aliveAfterTimeout; }
+            @Override public void destroy() { /* no-op stub */ }
+            @Override public Process destroyForcibly() { return this; }
+        };
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/access/hc/wslc/WslcClientBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/wslc/WslcClientBuilderTest.java
@@ -1,0 +1,245 @@
+package io.fabric8.maven.docker.access.hc.wslc;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.maven.docker.util.Logger;
+
+class WslcClientBuilderTest {
+
+    @Test
+    void protocolIsWslc() {
+        Assertions.assertEquals("wslc", new WslcClientBuilder("wslc.exe", 1, null).getProtocol());
+    }
+
+    @Test
+    void buildsDialStdioCommandFromExecutable() {
+        WslcConnectionSocketFactory factory =
+            (WslcConnectionSocketFactory) new WslcClientBuilder("wslc.exe", 1, null).getConnectionSocketFactory();
+        SocketAddress address = factory.createSocketAddress("wslc.exe");
+
+        Assertions.assertTrue(address instanceof WslcSocketAddress);
+        Assertions.assertEquals(
+            Arrays.asList("wslc.exe", "system", "session", "run", "docker", "system", "dial-stdio"),
+            ((WslcSocketAddress) address).command());
+    }
+
+    @Test
+    void resolvesEmptyOrRootUrlPathConsistently() {
+        // wslc:// -> null/empty path, wslc:/// -> "/" path: all resolve identically (to WSLC_EXECUTABLE
+        // if set, otherwise the default). Assert consistency unconditionally, and the default only when
+        // the environment does not override it, so the test does not depend on WSLC_EXECUTABLE.
+        String fromNull = WslcClientBuilder.resolveExecutable(null);
+        Assertions.assertEquals(fromNull, WslcClientBuilder.resolveExecutable(""));
+        Assertions.assertEquals(fromNull, WslcClientBuilder.resolveExecutable("/"));
+        if (System.getenv("WSLC_EXECUTABLE") == null) {
+            Assertions.assertEquals(WslcClientBuilder.DEFAULT_WSLC_EXECUTABLE, fromNull);
+        }
+    }
+
+    @Test
+    void stripsLeadingSlashFromUrlPath() {
+        // wslc:///wslc.exe -> path "/wslc.exe"
+        Assertions.assertEquals("wslc.exe", WslcClientBuilder.resolveExecutable("/wslc.exe"));
+    }
+
+    @Test
+    void keepsAbsoluteWindowsExecutablePath() {
+        Assertions.assertEquals("C:\\Program Files\\WSL\\wslc.exe",
+            WslcClientBuilder.resolveExecutable("C:\\Program Files\\WSL\\wslc.exe"));
+    }
+
+    @Test
+    void createSocketReturnsUnconnectedProcessSocket() throws Exception {
+        ConnectionSocketFactory factory = new WslcClientBuilder("wslc.exe", 1, null).getConnectionSocketFactory();
+        Socket socket = factory.createSocket(null);
+        Assertions.assertTrue(socket instanceof WslcProcessSocket);
+        Assertions.assertFalse(socket.isConnected());
+        socket.close();
+    }
+
+    @Test
+    void autoDetectUrlIsValidUriResolvingToDefaultExecutable() {
+        // The auto-detected URL must parse as a URI (DockerAccessWithHcClient calls URI.create on it)
+        // and must NOT embed an executable in its path (that is resolved from WSLC_EXECUTABLE instead,
+        // so paths with spaces/backslashes never reach URI parsing).
+        URI uri = URI.create(WslcClientBuilder.AUTO_DETECT_URL);
+        Assertions.assertEquals("wslc", uri.getScheme());
+        String path = uri.getPath();
+        Assertions.assertTrue(path == null || path.isEmpty() || "/".equals(path),
+            "auto-detect URL must not embed an executable in its path, was: " + path);
+    }
+
+    @Test
+    void connectWithMissingExecutableThrowsIoException() {
+        WslcProcessSocket socket = new WslcProcessSocket(null);
+        IOException ex = Assertions.assertThrows(IOException.class, () ->
+            socket.connect(new WslcSocketAddress(Collections.singletonList("no-such-wslc-binary-xyz"))));
+        Assertions.assertTrue(ex.getMessage().contains("no-such-wslc-binary-xyz"), ex.getMessage());
+    }
+
+    @Test
+    void unconnectedSocketStateAndNoOpSetters() throws Exception {
+        WslcProcessSocket s = new WslcProcessSocket(null);
+
+        // Unconnected-state accessors
+        Assertions.assertFalse(s.isConnected());
+        Assertions.assertFalse(s.isClosed());
+        Assertions.assertFalse(s.isBound());
+        Assertions.assertFalse(s.isInputShutdown());
+        Assertions.assertFalse(s.isOutputShutdown());
+        Assertions.assertEquals(-1, s.getPort());
+        Assertions.assertEquals(-1, s.getLocalPort());
+        Assertions.assertNull(s.getInetAddress());
+        Assertions.assertNull(s.getLocalAddress());
+        Assertions.assertNull(s.getLocalSocketAddress());
+        Assertions.assertNull(s.getRemoteSocketAddress());
+        Assertions.assertNull(s.getChannel());
+        Assertions.assertEquals(0, s.getSoTimeout());
+        Assertions.assertTrue(s.getTcpNoDelay());
+        Assertions.assertTrue(s.getKeepAlive());
+        Assertions.assertTrue(s.toString().contains("unconnected"));
+
+        // Streams before connect
+        Assertions.assertThrows(SocketException.class, s::getInputStream);
+        Assertions.assertThrows(SocketException.class, s::getOutputStream);
+
+        // No-op setters must not throw
+        s.setSoTimeout(1000);
+        s.setTcpNoDelay(true);
+        s.setKeepAlive(true);
+        s.setReuseAddress(true);
+        s.setTrafficClass(10);
+        s.setSendBufferSize(1024);
+        s.setReceiveBufferSize(1024);
+        s.setPerformancePreferences(1, 2, 3);
+        s.shutdownInput();
+        s.shutdownOutput();
+        Assertions.assertTrue(s.isInputShutdown());
+        Assertions.assertTrue(s.isOutputShutdown());
+
+        // close() on an unconnected socket is safe and flips isClosed()
+        s.close();
+        Assertions.assertTrue(s.isClosed());
+    }
+
+    @Test
+    void socketRejectsUnsupportedAndInvalidOperations() {
+        WslcProcessSocket s = new WslcProcessSocket(null);
+        WslcSocketAddress negativeTimeoutAddress = new WslcSocketAddress(Collections.singletonList("x"));
+        InetSocketAddress wrongAddressType = new InetSocketAddress("localhost", 1);
+
+        Assertions.assertThrows(SocketException.class, () -> s.bind(null));
+        Assertions.assertThrows(SocketException.class, () -> s.sendUrgentData(1));
+        Assertions.assertThrows(UnsupportedOperationException.class, s::getSendBufferSize);
+        Assertions.assertThrows(UnsupportedOperationException.class, s::getReceiveBufferSize);
+        Assertions.assertThrows(UnsupportedOperationException.class, s::getTrafficClass);
+        Assertions.assertThrows(UnsupportedOperationException.class, s::getReuseAddress);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> s.setSendBufferSize(0));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> s.setReceiveBufferSize(0));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> s.setTrafficClass(-1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> s.setTrafficClass(256));
+
+        // connect() argument validation: negative timeout and wrong address type are both rejected.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> s.connect(negativeTimeoutAddress, -1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> s.connect(wrongAddressType, 0));
+    }
+
+    @Test
+    void socketAddressEqualityHashCodeAndToString() {
+        WslcSocketAddress a = new WslcSocketAddress(Arrays.asList("wslc.exe", "dial-stdio"));
+        WslcSocketAddress b = new WslcSocketAddress(Arrays.asList("wslc.exe", "dial-stdio"));
+        WslcSocketAddress c = new WslcSocketAddress(Collections.singletonList("other"));
+
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertNotEquals(a, c);
+        Assertions.assertNotEquals(a, new Object());
+        Assertions.assertTrue(a.toString().contains("dial-stdio"));
+    }
+
+    @Test
+    void connectWithLoggerLogsBridgeAndReportsAddress() throws Exception {
+        // A logger present exercises the debug-log branches and the connected toString().
+        RecordingLogger logger = new RecordingLogger();
+        WslcProcessSocket socket = new WslcProcessSocket(logger);
+        WslcSocketAddress address = new WslcSocketAddress(Collections.singletonList("sort"));
+        try {
+            socket.connect(address);
+        } catch (IOException e) {
+            Assumptions.abort("'sort' not available on this host: " + e.getMessage());
+        }
+        try {
+            Assertions.assertTrue(socket.isConnected());
+            Assertions.assertTrue(socket.toString().contains("sort"), socket.toString());
+            Assertions.assertTrue(logger.debugged, "expected a debug log for the opened bridge");
+        } finally {
+            socket.close();
+        }
+    }
+
+    @Test
+    void roundTripsBytesThroughBridgeProcess() throws Exception {
+        // 'sort' (present on Windows and Unix) echoes a single stdin line back on stdout once stdin
+        // is closed, so it exercises the whole process-backed socket: connect, write, read, close.
+        WslcProcessSocket socket = new WslcProcessSocket(null);
+        try {
+            socket.connect(new WslcSocketAddress(Collections.singletonList("sort")));
+        } catch (IOException e) {
+            // 'sort' is present on standard Windows and Linux hosts; skip rather than fail if absent.
+            Assumptions.abort("'sort' not available on this host: " + e.getMessage());
+        }
+        Assertions.assertTrue(socket.isConnected());
+
+        try (OutputStream out = socket.getOutputStream()) {
+            out.write("ping\n".getBytes(StandardCharsets.US_ASCII));
+        } // closing the stream half-closes stdin so 'sort' flushes and exits
+
+        String echoed;
+        try (InputStream in = socket.getInputStream()) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            byte[] buf = new byte[256];
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                bos.write(buf, 0, n);
+            }
+            echoed = new String(bos.toByteArray(), StandardCharsets.US_ASCII);
+        }
+        Assertions.assertTrue(echoed.contains("ping"), "echoed=" + echoed);
+
+        socket.close();
+        Assertions.assertTrue(socket.isClosed());
+    }
+
+    /** Minimal {@link Logger} that only records whether debug() was called. */
+    private static final class RecordingLogger implements Logger {
+        volatile boolean debugged;
+
+        @Override public void debug(String format, Object... params) { debugged = true; }
+        @Override public void info(String format, Object... params) { /* no-op stub */ }
+        @Override public void verbose(LogVerboseCategory category, String format, Object... params) { /* no-op stub */ }
+        @Override public void warn(String format, Object... params) { /* no-op stub */ }
+        @Override public void error(String format, Object... params) { /* no-op stub */ }
+        @Override public String errorMessage(String message) { return message; }
+        @Override public boolean isDebugEnabled() { return true; }
+        @Override public boolean isVerboseEnabled() { return false; }
+        @Override public void progressStart() { /* no-op stub */ }
+        @Override public void progressUpdate(String layerId, String status, String progressMessage) { /* no-op stub */ }
+        @Override public void progressFinished() { /* no-op stub */ }
+    }
+}


### PR DESCRIPTION
WSL Containers (wslc, shipping with WSL 2.9.x+) exposes neither a Windows named pipe nor a TCP port; its Docker daemon is only reachable through a stdio bridge (`wslc system session run docker system dial-stdio`). Add a new `wslc://` Docker host transport, mirroring the existing unix:// and npipe:// transports:

- WslcProcessSocket: a Socket backed by the bridge child process, so Apache HttpClient (incl. hijacked exec/attach/log streams) drives it normally.
- WslcConnectionSocketFactory / WslcClientBuilder + `wslc` scheme wiring in DockerAccessWithHcClient.
- WslcDockerHostProvider: auto-detects wslc as a fallback (priority 45, below the docker_engine named pipe), so an existing Docker Desktop / Podman endpoint always wins.
- WSLC_EXECUTABLE env override for non-default wslc locations.
- Unit tests and <dockerHost> documentation.

Fixes #1928