### PR TITLE
Increase multi-assembly log wait timeout

### DIFF
--- a/it/multi-assembly/pom.xml
+++ b/it/multi-assembly/pom.xml
@@ -97,7 +97,7 @@
               <run>
                 <wait>
                   <log>Hello from Spring Boot!</log>
-                  <time>30000</time>
+                  <time>60000</time>
                 </wait>
               </run>
             </image>


### PR DESCRIPTION
## Summary
- increase the dmp-multi-assembly log wait timeout from 30s to 60s
- reduce macOS/Lima E2E flakiness where Spring Boot startup/log delivery can approach the old 30s limit

## Root cause
The macOS E2E job intermittently timed out waiting for `Hello from Spring Boot!` from the `dmp-multi-assembly` container. Successful runs showed this sample can take roughly 23s before the log is observed, leaving little margin under the previous 30s timeout.

## Validation
- Confirmed diff is limited to `it/multi-assembly/pom.xml` changing `30000` to `60000`
- Attempted `./mvnw -pl it/multi-assembly -DskipTests validate`, but this environment has no Java/Javac and `JAVA_HOME` is not defined
