### PR TITLE
Increase <wait> budgets for buildx and postgres ITs on slow macOS CI

### DIFF
--- a/it/buildx-driver-opt/pom.xml
+++ b/it/buildx-driver-opt/pom.xml
@@ -49,7 +49,7 @@
                   <log>Hello World</log>
                   <kill>5000</kill>
                   <shutdown>1000</shutdown>
-                  <time>5000</time>
+                  <time>30000</time>
                 </wait>
               </run>
             </image>

--- a/it/buildx-target/pom.xml
+++ b/it/buildx-target/pom.xml
@@ -33,7 +33,7 @@
               <run>
                 <wait>
                   <log>base</log>
-                  <time>5000</time>
+                  <time>30000</time>
                 </wait>
               </run>
             </image>

--- a/it/buildx/pom.xml
+++ b/it/buildx/pom.xml
@@ -48,7 +48,7 @@
                   <log>Hello World</log>
                   <kill>5000</kill>
                   <shutdown>1000</shutdown>
-                  <time>5000</time>
+                  <time>30000</time>
                 </wait>
               </run>
             </image>

--- a/it/dockerfile-target/pom.xml
+++ b/it/dockerfile-target/pom.xml
@@ -27,7 +27,7 @@
               <run>
                 <wait>
                   <log>base</log>
-                  <time>5000</time>
+                  <time>30000</time>
                 </wait>
               </run>
             </image>

--- a/it/properties/pom.xml
+++ b/it/properties/pom.xml
@@ -26,7 +26,7 @@
     <postgres.docker.name>postgres:16.3-alpine</postgres.docker.name>
     <postgres.docker.ports.1>${itest.postgres.port}:5432</postgres.docker.ports.1>
     <postgres.docker.wait.log>PostgreSQL init process complete</postgres.docker.wait.log>
-    <postgres.docker.wait.time>10000</postgres.docker.wait.time>
+    <postgres.docker.wait.time>60000</postgres.docker.wait.time>
   </properties>
 
   <build>


### PR DESCRIPTION
### Why

On the Intel macOS runners (`macos-26-intel`), Docker runs inside a Lima/QEMU VM **without hardware-accelerated (nested) virtualization**, so container startup and log output are consistently slower than on native Linux — and noticeably slower on **Docker 27.5.1** than on 26.1.4. Two boundary integration tests exceed their short `<wait>` budgets **only** in that combination (they pass on macOS Docker 26.1.4 and on all Linux versions):

| IT | budget | macOS 26.1.4 | macOS 27.5.1 | Linux |
|---|---|---|---|---|
| `dmp-it-buildx` "hello-world" | `<time>5000</time>` | 2933 ms ✅ | **5349 ms ⛔ (timeout)** | ~500 ms |
| `dmp-it-properties` postgres | `wait.time` 10000 | — | **10125 ms ⛔** | — |

Evidence: run [28998630671](https://github.com/fabric8io/docker-maven-plugin/actions/runs/28998630671) (branch `logwait-reconnect`) — `MacOS (v27.5.1)` fails at `dmp-it-buildx` with *"Timeout after 5349 ms while waiting on log out 'Hello World'"*, while `MacOS (v26.1.4)` and every Linux job pass. The failure reproduces on `fix-1797-follow` too (which touches no runtime code), so it is **environmental, not a code bug / not branch-specific**.

### Change

The `<wait>` returns as soon as the expected log line appears, so a larger budget is **free for the fast (passing) case** and only helps the slow macOS/QEMU one. Raise the tight budgets, following the same approach already taken in #1930 (multi-assembly):

- `buildx` / `buildx-driver-opt` / `buildx-target` / `dockerfile-target`: `<time>` **5000 → 30000**
- `properties` (postgres): `wait.time` **10000 → 60000**

Only the affected `it/*/pom.xml` files are touched.

### Verification

Verified on a fork e2e run on `macos-26-intel` with Docker `27.5.1` (the failing combination): the buildx and postgres integration tests now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
