### PR TITLE
Fall back to the current timestamp when a log line has an unparseable timestamp (#1428)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
   - Make container log streaming (`<wait><log>` and log following) resilient to transient stream disconnects by reconnecting and resuming instead of aborting, fixing flaky log-wait timeouts (e.g. `jnr ... Bad file descriptor` on macOS CI)
   - Add opt-in `<buildAllPlatforms>` buildx option to build all platforms during docker:build, warming the builder cache so a later docker:push reuses it ([#1866](https://github.com/fabric8io/docker-maven-plugin/issues/1866))
   - Normalize empty `<args>` build argument values (e.g. from a property that resolves to an empty value) to an empty string instead of failing the build ([#1858](https://github.com/fabric8io/docker-maven-plugin/issues/1858))
+  - Fall back to the current timestamp instead of crashing the log-follow thread when a container log line has an unparseable timestamp (e.g. `Error` written on stderr) ([#1428](https://github.com/fabric8io/docker-maven-plugin/issues/1428))
 
 * **0.48.1 (2026-02-07)**:
   - Use wait config if no Docker Compose healthcheck ([1771](https://github.com/fabric8io/docker-maven-plugin/issues/1771))

--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -272,7 +273,12 @@ public class LogRequestor extends Thread implements LogGetHandle {
                                          txt,(int) (txt.toCharArray())[0],(int) (txt.toCharArray())[1]));
             throw new LogCallback.DoneException();
         }
-        ZonedDateTime ts = TimestampFactory.createTimestamp(matcher.group("timestamp"));
+        ZonedDateTime ts;
+        try {
+            ts = TimestampFactory.createTimestamp(matcher.group("timestamp"));
+        } catch (DateTimeParseException ex) {
+            ts = TimestampFactory.createTimestamp();
+        }
         String logTxt = matcher.group("entry");
         this.lastTimestamp = ts;
         callback.log(type, ts, logTxt);

--- a/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/log/LogRequestorTest.java
@@ -256,6 +256,26 @@ class LogRequestorTest {
     }
 
     @Test
+    void testUnparseableTimestampFallsBackAndDoesNotKillStream() throws Exception {
+        final Streams type = Streams.STDERR;
+        final String entry = "the build failed";
+        // Docker can emit a line whose timestamp position is not an ISO-8601 value (e.g. "Error" on stderr).
+        // frameToBuffer injects the line verbatim, so the LOG_LINE timestamp group ("Error") cannot be parsed.
+        final ByteBuffer buf = frameToBuffer(type, "Error " + entry);
+        final InputStream inputStream = new ByteArrayInputStream(buf.array());
+        setupMocks(inputStream);
+
+        final LogRequestor logRequestor = new LogRequestor(client, urlBuilder, containerId, callback);
+
+        // The unparseable timestamp must not kill the log-follow thread (#1428): run() completes normally and
+        // the line is still delivered, with the current timestamp substituted for the one that failed to parse.
+        Assertions.assertDoesNotThrow(logRequestor::run);
+
+        Mockito.verify(callback).log(Mockito.eq(type.type), Mockito.any(ZonedDateTime.class), Mockito.eq(entry));
+        Mockito.verify(callback, Mockito.never()).error(Mockito.anyString());
+    }
+
+    @Test
     void runCanHandleIOException() throws Exception {
         final IOExceptionStream stream = new IOExceptionStream();
         setupMocks(stream);
@@ -396,10 +416,16 @@ class LogRequestorTest {
      * Create a bytebuffer for a single string message. A timestamp will be added.
      */
     private static ByteBuffer messageToBuffer(Streams stream, String message) throws IOException {
-        String logMessage = logMessage(message);
+        return frameToBuffer(stream, logMessage(message));
+    }
 
+    /**
+     * Frame an already-complete log line (timestamp prefix included) into a docker stream frame,
+     * without prepending a timestamp. Used to inject a line whose timestamp cannot be parsed.
+     */
+    private static ByteBuffer frameToBuffer(Streams stream, String logLine) throws IOException {
         CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
-        ByteBuffer payload = encoder.encode(CharBuffer.wrap(logMessage.toCharArray()));
+        ByteBuffer payload = encoder.encode(CharBuffer.wrap(logLine.toCharArray()));
         assert payload.order() == ByteOrder.BIG_ENDIAN;
         int length = payload.limit();
 


### PR DESCRIPTION
### What

Revives #1429 (by @jbennett2091), rebased onto current `master` with the test rewritten for the current JUnit 5 / Mockito test setup.

Fixes #1428.

### Why

When Docker emits a log line whose timestamp position is not an ISO-8601 value, `TimestampFactory.createTimestamp(...)` throws `DateTimeParseException`. That exception propagates out of the asynchronous log-follow thread (`LogRequestor.run()`) and **kills it**, so `<wait><log>` / log following silently stops (and a log-wait can then time out).

The concrete case from #1428 (postgres) is a stderr line where `Error` ends up in the timestamp position:

```
Exception in thread "Thread-6" java.time.format.DateTimeParseException: Text 'Error' could not be parsed at index 0
    at ...TimestampFactory.createTimestamp(TimestampFactory.java:46)
    at ...LogRequestor.callLogCallback(...)
    at ...LogRequestor.run(...)
```

### What this PR does

Wrap the timestamp parsing in `LogRequestor.callLogCallback` in a `try/catch` and fall back to the current timestamp, so a single unparseable line no longer aborts the whole stream. The line is still delivered to the callback; only its timestamp is substituted.

Added a regression test `testUnparseableTimestampFallsBackAndDoesNotKillStream` that feeds a frame whose timestamp (`Error`) cannot be parsed and asserts that `run()` completes normally, the line is still logged, and no error is reported. The test fails without the fix (reproducing the exact `Text 'Error' could not be parsed` from #1428) and passes with it.

`doc/changelog.md` is updated.

### On the review feedback from #1429

The original PR got two points from @rhuss: (1) a reservation about using the current timestamp, since there can be considerable drift between local time and the Docker host time, and (2) the deeper question of *why* extraction fails in the first place — the line matched `LOG_LINE` in an undesired way, so maybe the regexp should be adapted.

This PR intentionally keeps only the minimal safety net. The fallback timestamp is applied **only** to a line that cannot be parsed at all (which today kills the follow thread), so there is no usable timestamp to preserve anyway; substituting the current time affects just that one line's displayed time, which is strictly better than the entire log-follow thread dying. It deliberately does **not** touch the `LOG_LINE` regexp, because the right handling depends on the concrete offending formats and would be a larger change.

### Deferred — happy to implement if you'd like it

To directly serve @rhuss's question about the root cause, the fallback path could also emit a **WARN log containing the offending line** whenever it triggers, so mis-parsed formats surface instead of being silently substituted. This was left out on purpose to keep this change small (doing it well means deciding on log level / avoiding log spam for repeating lines, threading the offending value + reason through, and covering it with tests). Happy to add the warning log — or to adapt the regexp for concrete formats — if maintainers would prefer that direction.
