### PR TITLE
Pass externally-resolved build args to buildx build and push (#1901)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -5,6 +5,7 @@
   - Add opt-in `<buildAllPlatforms>` buildx option to build all platforms during docker:build, warming the builder cache so a later docker:push reuses it ([#1866](https://github.com/fabric8io/docker-maven-plugin/issues/1866))
   - Normalize empty `<args>` build argument values (e.g. from a property that resolves to an empty value) to an empty string instead of failing the build ([#1858](https://github.com/fabric8io/docker-maven-plugin/issues/1858))
   - Fall back to the current timestamp instead of crashing the log-follow thread when a container log line has an unparseable timestamp (e.g. `Error` written on stderr) ([#1428](https://github.com/fabric8io/docker-maven-plugin/issues/1428))
+  - Pass externally-resolved build args (`docker.buildArg.*` system/Maven properties and other `BuildArgResolver` sources) to buildx `build` and `push`, so buildx honours them like the classic build path instead of only `<build><args>` ([#1901](https://github.com/fabric8io/docker-maven-plugin/issues/1901))
 
 * **0.48.1 (2026-02-07)**:
   - Use wait config if no Docker Compose healthcheck ([1771](https://github.com/fabric8io/docker-maven-plugin/issues/1771))

--- a/src/main/java/io/fabric8/maven/docker/BuildMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/BuildMojo.java
@@ -105,7 +105,7 @@ public class BuildMojo extends AbstractDockerMojo {
             if (imageConfig.isBuildX()) {
                 BuildArgResolver buildArgResolver = new BuildArgResolver(log);
                 Map<String, String> buildArgsFromExternalSources = buildArgResolver.resolveBuildArgs(buildContext);
-                hub.getBuildXService().build(createProjectPaths(), imageConfig, null, createCompleteAuthConfigList(false, imageConfig, getRegistryConfig(pullRegistry), createMojoParameters(), buildArgsFromExternalSources), buildArchiveFile);
+                hub.getBuildXService().build(createProjectPaths(), imageConfig, null, createCompleteAuthConfigList(false, imageConfig, getRegistryConfig(pullRegistry), createMojoParameters(), buildArgsFromExternalSources), buildArchiveFile, buildArgsFromExternalSources);
             } else {
                 buildService.buildImage(imageConfig, pullManager, buildContext, buildArchiveFile);
                 if (!skipTag && !imageConfig.getBuildConfiguration().skipTag()) {

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -58,17 +58,17 @@ public class BuildXService {
         this.exec = exec;
     }
 
-    public void build(ProjectPaths projectPaths, ImageConfiguration imageConfig, String  configuredRegistry, AuthConfigList authConfig, File buildArchive) throws MojoExecutionException {
-        useBuilder(projectPaths, imageConfig,  configuredRegistry, authConfig, buildArchive, this::buildAndLoadSinglePlatform);
+    public void build(ProjectPaths projectPaths, ImageConfiguration imageConfig, String  configuredRegistry, AuthConfigList authConfig, File buildArchive, Map<String, String> buildArgs) throws MojoExecutionException {
+        useBuilder(projectPaths, imageConfig,  configuredRegistry, authConfig, buildArgs, buildArchive, this::buildAndLoadSinglePlatform);
     }
 
-    public void push(ProjectPaths projectPaths, ImageConfiguration imageConfig, String configuredRegistry, AuthConfigList authConfig) throws MojoExecutionException {
+    public void push(ProjectPaths projectPaths, ImageConfiguration imageConfig, String configuredRegistry, AuthConfigList authConfig, Map<String, String> buildArgs) throws MojoExecutionException {
         BuildDirs buildDirs = new BuildDirs(projectPaths, imageConfig.getName());
         File archive = new File(buildDirs.getTemporaryRootDirectory(), "docker-build.tar");
-        useBuilder(projectPaths, imageConfig, configuredRegistry, authConfig, archive, this::pushMultiPlatform);
+        useBuilder(projectPaths, imageConfig, configuredRegistry, authConfig, buildArgs, archive, this::pushMultiPlatform);
     }
 
-    protected <C> void useBuilder(ProjectPaths projectPaths, ImageConfiguration imageConfig, String configuredRegistry, AuthConfigList authConfig, C context, Builder<C> builder) throws MojoExecutionException {
+    protected <C> void useBuilder(ProjectPaths projectPaths, ImageConfiguration imageConfig, String configuredRegistry, AuthConfigList authConfig, Map<String, String> buildArgs, C context, Builder<C> builder) throws MojoExecutionException {
         BuildDirs buildDirs = new BuildDirs(projectPaths, imageConfig.getName());
 
         Path configPath = getDockerStateDir(imageConfig.getBuildConfiguration(),  buildDirs);
@@ -82,7 +82,7 @@ public class BuildXService {
         Path configJson = configPath.resolve("config.json");
         try {
             createConfigJson(configJson, authConfig);
-            builder.useBuilder(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, context);
+            builder.useBuilder(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, buildArgs, context);
         } finally {
             removeConfigJson(configJson);
         }
@@ -120,7 +120,7 @@ public class BuildXService {
         }
     }
 
-    protected void buildAndLoadSinglePlatform(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String configuredRegistry, File buildArchive) throws MojoExecutionException {
+    protected void buildAndLoadSinglePlatform(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String configuredRegistry, Map<String, String> buildArgs, File buildArchive) throws MojoExecutionException {
         List<String> platforms = imageConfig.getBuildConfiguration().getBuildX().getPlatforms();
         String nativePlatform = dockerAccess.getNativePlatform();
 
@@ -130,29 +130,29 @@ public class BuildXService {
         // and only warms the build cache; the native platform is then (re)built with --load below.
         if (imageConfig.getBuildConfiguration().getBuildX().isBuildAllPlatforms() && platforms.size() > 1) {
             logger.info("Building all configured platforms %s to populate the build cache", String.join(",", platforms));
-            buildX(buildX, builderName, buildDirs, imageConfig, configuredRegistry, platforms, buildArchive, null);
+            buildX(buildX, builderName, buildDirs, imageConfig, configuredRegistry, buildArgs, platforms, buildArchive, null);
         }
 
         // build and load the single-platform image by re-building, image should be cached and build should be quick
         if (platforms.size() == 1) {
-            buildX(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, platforms, buildArchive, "--load");
+            buildX(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, buildArgs, platforms, buildArchive, "--load");
         } else if (platforms.isEmpty() || platforms.contains(nativePlatform)) {
-            buildX(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, Collections.singletonList(nativePlatform), buildArchive, "--load");
+            buildX(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, buildArgs, Collections.singletonList(nativePlatform), buildArchive, "--load");
         } else  {
             logger.info("More than one platform specified not including native %s, no image built", nativePlatform);
         }
     }
 
-    protected void pushMultiPlatform(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String configuredRegistry, File buildArchive) throws MojoExecutionException {
+    protected void pushMultiPlatform(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String configuredRegistry, Map<String, String> buildArgs, File buildArchive) throws MojoExecutionException {
         // build and push all images.  The native platform may be re-built, image should be cached and build should be quick
         List<String> platforms = new ArrayList<>(imageConfig.getBuildConfiguration().getBuildX().getPlatforms());
         if (platforms.isEmpty()) {
             platforms.add(dockerAccess.getNativePlatform());
         }
-        buildX(buildX, builderName, buildDirs, imageConfig, configuredRegistry, platforms, buildArchive, "--push");
+        buildX(buildX, builderName, buildDirs, imageConfig, configuredRegistry, buildArgs, platforms, buildArchive, "--push");
     }
 
-    protected void buildX(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String  configuredRegistry, List<String> platforms, File buildArchive, String extraParam)
+    protected void buildX(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String  configuredRegistry, Map<String, String> buildArgs, List<String> platforms, File buildArchive, String extraParam)
         throws MojoExecutionException {
 
         BuildImageConfiguration buildConfiguration = imageConfig.getBuildConfiguration();
@@ -168,7 +168,7 @@ public class BuildXService {
             });
         }
 
-        Map<String, String> args = buildConfiguration.getArgs();
+        Map<String, String> args = BuildService.prepareBuildArgs(buildArgs, buildConfiguration);
         if (args != null) {
             args.forEach((key, value) -> {
                 cmdLine.add("--build-arg");
@@ -345,7 +345,7 @@ public class BuildXService {
     }
 
     interface Builder<C> {
-        void useBuilder(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String configuredRegistry, C context) throws MojoExecutionException;
+        void useBuilder(List<String> buildX, String builderName, BuildDirs buildDirs, ImageConfiguration imageConfig, String configuredRegistry, Map<String, String> buildArgs, C context) throws MojoExecutionException;
     }
 
     public interface Exec {

--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -81,7 +81,7 @@ public class RegistryService {
             AuthConfigList authConfigListForBuildXPush = createCompleteAuthConfigList(true, imageConfig, registryConfig, buildContext.getMojoParameters(), buildArgsFromExternalSources);
 
             if (imageConfig.isBuildX()) {
-                buildXService.push(projectPaths, imageConfig, configuredRegistry, authConfigListForBuildXPush);
+                buildXService.push(projectPaths, imageConfig, configuredRegistry, authConfigListForBuildXPush, buildArgsFromExternalSources);
             } else {
                 dockerPush(retries, skipTag, buildConfig, name, configuredRegistry, authConfigForLegacyPush);
             }

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -409,7 +409,7 @@ class BuildMojoTest extends MojoTestBase {
     private void thenAuthMatches(AuthConfig authConfig) throws MojoExecutionException {
         ArgumentCaptor<AuthConfigList> authConfigList = ArgumentCaptor.forClass(AuthConfigList.class);
         Mockito.verify(serviceHub.getBuildXService()).build(
-                Mockito.any(), Mockito.any(), Mockito.any(), authConfigList.capture(), Mockito.any());
+                Mockito.any(), Mockito.any(), Mockito.any(), authConfigList.capture(), Mockito.any(), Mockito.any());
 
         Assertions.assertEquals(authConfig.toJson(), authConfigList.getValue().toJson());
     }
@@ -417,7 +417,7 @@ class BuildMojoTest extends MojoTestBase {
     private void thenAuthContainsRegistry(String expectedRegistry) throws MojoExecutionException {
         ArgumentCaptor<AuthConfigList> authConfigList = ArgumentCaptor.forClass(AuthConfigList.class);
         Mockito.verify(serviceHub.getBuildXService()).build(
-                Mockito.any(), Mockito.any(), Mockito.any(), authConfigList.capture(), Mockito.any());
+                Mockito.any(), Mockito.any(), Mockito.any(), authConfigList.capture(), Mockito.any(), Mockito.any());
 
         Assertions.assertTrue(authConfigList.getValue().toJson().contains(expectedRegistry));
     }

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceTest.java
@@ -107,7 +107,7 @@ class BuildXServiceTest {
     void testBuildNativePlatform() throws Exception {
         givenAnImageConfiguration(NATIVE);
         mockBuildX();
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
         verifyBuildXPlatforms(NATIVE);
     }
 
@@ -115,7 +115,7 @@ class BuildXServiceTest {
     void testBuildForeignPlatform() throws Exception {
         givenAnImageConfiguration(FOREIGN1);
         mockBuildX();
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
         verifyBuildXPlatforms(FOREIGN1);
     }
 
@@ -123,7 +123,7 @@ class BuildXServiceTest {
     void testBuildNativePlatformWithForeign() throws Exception {
         givenAnImageConfiguration(NATIVE, FOREIGN1);
         mockBuildX();
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
         verifyBuildXPlatforms(NATIVE);
     }
 
@@ -134,7 +134,7 @@ class BuildXServiceTest {
         buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> buildImage.network("host"));
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         //Then
         verifyBuildXArgumentPresentInExec("--network=host");
@@ -147,7 +147,7 @@ class BuildXServiceTest {
         buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> buildImage.noCache(true));
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         //Then
         verifyBuildXArgumentPresentInExec("--no-cache");
@@ -160,7 +160,7 @@ class BuildXServiceTest {
         buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> buildX.cacheFrom(null));
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         //Then
         verifyBuildXArgumentNotPresentInExec("--cache-from");
@@ -173,7 +173,7 @@ class BuildXServiceTest {
         buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> buildX.cacheFrom("cacheFromSpec"));
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         //Then
         verifyBuildXArgumentPresentInExec("--cache-from=cacheFromSpec");
@@ -186,7 +186,7 @@ class BuildXServiceTest {
         buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> buildX.cacheTo(null));
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         //Then
         verifyBuildXArgumentNotPresentInExec("--cache-to");
@@ -199,7 +199,7 @@ class BuildXServiceTest {
         buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> buildX.cacheTo("cacheToSpec"));
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         //Then
         verifyBuildXArgumentPresentInExec("--cache-to=cacheToSpec");
@@ -212,7 +212,7 @@ class BuildXServiceTest {
         buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> {});
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         //Then
         verifyBuildXArgumentNotPresentInExec("--target");
@@ -225,10 +225,34 @@ class BuildXServiceTest {
         buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> buildImage.target("my-stage"));
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         //Then
         verifyBuildXArgumentPresentInExec("--target=my-stage");
+    }
+
+    @Test
+    void testBuildXPassesExternalBuildArgs() throws Exception {
+        // #1901: build args resolved from external sources (docker.buildArg.* / Maven properties, proxy settings, ...)
+        // must reach buildx, not only <build><args>. Here the config has no <args>; the arg comes solely via the map.
+        buildConfigUsingBuildx(temporaryFolder, (buildX, buildImage) -> { });
+
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive,
+            Collections.singletonMap("MY_FILE_NAME", "myfile"));
+
+        verifyBuildXArgumentPresentInExec("--build-arg", "MY_FILE_NAME=myfile");
+    }
+
+    @Test
+    void testBuildXMergesExternalAndConfigBuildArgs() throws Exception {
+        // Config <args> and externally-resolved args must both reach buildx, mirroring the classic (non-buildx) path.
+        buildConfigUsingBuildx(temporaryFolder,
+            (buildX, buildImage) -> buildImage.args(Collections.singletonMap("FOO", "bar")));
+
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive,
+            Collections.singletonMap("MY_FILE_NAME", "myfile"));
+
+        verifyBuildXArgumentPresentInExec("FOO=bar", "MY_FILE_NAME=myfile");
     }
 
     private void buildConfigUsingBuildx(File temporaryFolder, BiConsumer<BuildXConfiguration.Builder, BuildImageConfiguration.Builder> spec) {
@@ -255,14 +279,14 @@ class BuildXServiceTest {
             .build());
         mockBuildX();
 
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         // first: all platforms are built with no output (neither --load nor --push) to warm the cache
         Mockito.verify(buildx).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.argThat(l -> Arrays.asList(NATIVE, FOREIGN1).equals(l)), Mockito.any(), Mockito.isNull());
+            Mockito.any(), Mockito.argThat(l -> Arrays.asList(NATIVE, FOREIGN1).equals(l)), Mockito.any(), Mockito.isNull());
         // then: the native platform is (re)built and loaded for local use / integration tests
         Mockito.verify(buildx).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.argThat(l -> Collections.singletonList(NATIVE).equals(l)), Mockito.any(), Mockito.eq("--load"));
+            Mockito.any(), Mockito.argThat(l -> Collections.singletonList(NATIVE).equals(l)), Mockito.any(), Mockito.eq("--load"));
     }
 
     @Test
@@ -271,9 +295,9 @@ class BuildXServiceTest {
         givenAnImageConfiguration(NATIVE, FOREIGN1);
         mockBuildX();
 
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
-        Mockito.verify(buildx, Mockito.times(1)).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+        Mockito.verify(buildx, Mockito.times(1)).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
         verifyBuildXPlatforms(NATIVE);
     }
@@ -281,8 +305,8 @@ class BuildXServiceTest {
     @Test
     void testBuildForeignPlatforms() throws Exception {
         givenAnImageConfiguration(FOREIGN1, FOREIGN2);
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
-        Mockito.verify(buildx, Mockito.times(0)).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
+        Mockito.verify(buildx, Mockito.times(0)).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
                                                         Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     }
 
@@ -298,11 +322,11 @@ class BuildXServiceTest {
             .build());
 
         // When
-        buildx.useBuilder(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, builder);
+        buildx.useBuilder(projectPaths, imageConfig, configuredRegistry, authConfigList, Collections.emptyMap(), buildArchive, builder);
 
         // Then
         ArgumentCaptor<List<String>> buildXArgCaptor = ArgumentCaptor.forClass(List.class);
-        Mockito.verify(builder).useBuilder(buildXArgCaptor.capture(), anyString(), any(), eq(imageConfig), eq(configuredRegistry), eq(buildArchive));
+        Mockito.verify(builder).useBuilder(buildXArgCaptor.capture(), anyString(), any(), eq(imageConfig), eq(configuredRegistry), any(), eq(buildArchive));
         assertEquals(Arrays.asList("docker", "--config", temporaryFolder.getAbsolutePath(), "buildx"), buildXArgCaptor.getValue());
     }
 
@@ -327,7 +351,7 @@ class BuildXServiceTest {
             givenAnImageConfiguration("linux/arm46", "linux/amd64");
 
             // When
-            buildx.useBuilder(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, builder);
+            buildx.useBuilder(projectPaths, imageConfig, configuredRegistry, authConfigList, Collections.emptyMap(), buildArchive, builder);
 
             // Then
             assertTrue(configDirPath.resolve("cli-plugins").toFile().exists());
@@ -352,7 +376,7 @@ class BuildXServiceTest {
         });
 
         // When
-        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive);
+        buildx.build(projectPaths, imageConfig, configuredRegistry, authConfigList, buildArchive, Collections.emptyMap());
 
         String[] fullTags = tags.stream()
                 .map(tag -> new ImageName(imageConfig.getName(), tag).getFullName(configuredRegistry))
@@ -384,14 +408,14 @@ class BuildXServiceTest {
     }
 
     private void mockBuildX() throws Exception {
-        Mockito.doNothing().when(buildx).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+        Mockito.doNothing().when(buildx).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
                                                 Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     }
 
     private void verifyBuildXPlatforms(String... platforms) throws Exception {
         final List<String> expect = Arrays.asList(platforms);
         Mockito.verify(buildx).buildX(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-                                      Mockito.argThat(l -> expect.equals(l)), Mockito.any(), Mockito.any());
+                                      Mockito.any(), Mockito.argThat(l -> expect.equals(l)), Mockito.any(), Mockito.any());
     }
 
     private void verifyBuildXArgumentPresentInExec(String... args) throws Exception{

--- a/src/test/java/io/fabric8/maven/docker/service/RegistryServicePushImagesBuildXTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RegistryServicePushImagesBuildXTest.java
@@ -128,7 +128,7 @@ class RegistryServicePushImagesBuildXTest {
 
   private void verifyBuildXServiceInvokedWithAuthConfigListSize(int expectedSize) throws MojoExecutionException {
     ArgumentCaptor<AuthConfigList> authConfigListArgumentCaptor = ArgumentCaptor.forClass(AuthConfigList.class);
-    verify(buildXService).push(any(), any(), anyString(), authConfigListArgumentCaptor.capture());
+    verify(buildXService).push(any(), any(), anyString(), authConfigListArgumentCaptor.capture(), any());
     assertEquals(expectedSize, authConfigListArgumentCaptor.getValue().size());
   }
 


### PR DESCRIPTION
### What

Fixes #1901.

When a build uses **buildx**, build args resolved from external sources are silently dropped — only the literal `<build><args>` config reaches the build. The classic (non-buildx) build path passes the full merged set, so the two paths behave differently.

Concretely, `docker.buildArg.MY_ARG` (and other `BuildArgResolver` sources: Maven/project properties, `~/.docker/config.json` proxy settings, build-context args) never reach buildx. The reporter confirmed the divergence: setting the same key via both the property and `<args>` throws `Multiple entries with same key`, proving the external arg is resolved but never handed to buildx.

### Root cause

`BuildMojo.proceedWithDockerBuild` already resolves `buildArgResolver.resolveBuildArgs(buildContext)` for the buildx branch, but passes it only into the auth-config list — never into `BuildXService.build(...)`. `RegistryService.pushImages` does the same for the push path. `BuildXService.buildX` then builds `--build-arg` flags from `buildConfiguration.getArgs()` alone.

### Fix

Thread the already-resolved build-arg map from both call sites (`BuildMojo` for build, `RegistryService` for push) down through `BuildXService` to `buildX`, and merge it with the config `<args>` via the existing `BuildService.prepareBuildArgs(...)` — the very same helper the classic path uses. buildx now honours external build args exactly like the classic build path (config `<args>` still win on a genuine key clash, which throws, matching current classic-path behaviour).

Both the buildx **build** and **push** paths are fixed (they share `buildX`).

### Tests

- `testBuildXPassesExternalBuildArgs` — a `<build>` with no `<args>`; an external arg must still be emitted as `--build-arg` (directly reproduces #1901).
- `testBuildXMergesExternalAndConfigBuildArgs` — config `<args>` and external args must both reach buildx.

Both fail without the fix (the external arg is absent from the buildx command line) and pass with it. Existing `BuildXServiceTest` / `BuildMojoTest` / `RegistryService*Test` were updated for the new method arity and remain green.

`doc/changelog.md` updated.
