### PR TITLE
Use AtomicReference for the abortable log request (fix Sonar S3077)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
+++ b/src/main/java/io/fabric8/maven/docker/access/log/LogRequestor.java
@@ -34,6 +34,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -56,8 +57,9 @@ public class LogRequestor extends Thread implements LogGetHandle {
     private DockerAccessException exception;
 
     // Remember for asynchronous handling so that the request can be aborted from the outside.
-    // Volatile because finish() reads/aborts it from another thread while run() reassigns it on each reconnect.
-    private volatile HttpUriRequest request;
+    // Held in an AtomicReference because finish() reads/aborts it from another thread while run()
+    // reassigns it on each reconnect; a volatile reference alone would not make that access thread-safe.
+    private final AtomicReference<HttpUriRequest> request = new AtomicReference<>();
 
     private final UrlBuilder urlBuilder;
 
@@ -95,8 +97,8 @@ public class LogRequestor extends Thread implements LogGetHandle {
     public void fetchLogs() {
         try {
             callback.open();
-            this.request = getLogRequest(false, null);
-            final HttpResponse response = client.execute(request);
+            this.request.set(getLogRequest(false, null));
+            final HttpResponse response = client.execute(this.request.get());
             parseResponse(response);
         } catch (LogCallback.DoneException e) {
             // Signifies we're finished with the log stream.
@@ -126,13 +128,13 @@ public class LogRequestor extends Thread implements LogGetHandle {
             ZonedDateTime progressMark = null;
             while (!stopped) {
                 try {
-                    this.request = getLogRequest(true, resumeSince());
+                    this.request.set(getLogRequest(true, resumeSince()));
                     // finish() may have run between the while-check and here; don't open a fresh
                     // connection that nobody will abort.
                     if (stopped) {
                         return;
                     }
-                    parseResponse(client.execute(request));
+                    parseResponse(client.execute(this.request.get()));
                     return;
                 } catch (IOException e) {
                     if (stopped) {
@@ -291,9 +293,9 @@ public class LogRequestor extends Thread implements LogGetHandle {
     @Override
     public void finish() {
         this.stopped = true;
-        if (request != null) {
-            request.abort();
-            request = null;
+        HttpUriRequest current = request.getAndSet(null);
+        if (current != null) {
+            current.abort();
         }
     }
 


### PR DESCRIPTION
## Problem

The SonarCloud analysis on `master` fails the quality gate with **Reliability Rating on New Code = B** (requires A). The only new-code bug is:

> `LogRequestor.java` — `java:S3077`: *Use a thread-safe type; adding "volatile" is not enough to make this field thread-safe.*

The recent follow-stream reconnect work introduced `private volatile HttpUriRequest request`, which `run()`/`fetchLogs()` reassign on each (re)connect while `finish()` aborts it from another thread. Marking the reference `volatile` only publishes the reference; it does not make access to the mutable request thread-safe, which is exactly what S3077 flags.

## Change

Replace the `volatile` field with an `AtomicReference<HttpUriRequest>`:

- reads/writes go through `get()` / `set()`
- `finish()` now clears-and-aborts atomically via `getAndSet(null)` (also removes the previous read-then-null race)

No behavioural change. `AtomicReference` is already used elsewhere in the codebase (`service/WatchService.java`).

## Result

Resolves the S3077 bug so the New Code Reliability Rating returns to A and the quality gate passes. Existing `LogRequestorTest` (reconnect/abort coverage) exercises this path via `run()`/`reconnectPolicy()` and needs no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ✅ Local verification

Built and tested locally before opening this PR — Amazon Linux 2023 with Amazon Corretto **JDK 17** (the same major version the SonarCloud CI uses), via the project's Maven wrapper:

```
./mvnw -o -Dtest=LogRequestorTest test
→ Tests run: 17, Failures: 0, Errors: 0, Skipped: 0  —  BUILD SUCCESS
```

`LogRequestorTest` exercises the asynchronous `run()`/reconnect and `finish()`/abort paths that use the changed `request` field, so it covers the refactor directly.
