### PR TITLE
Re-interrupt the current thread when catching InterruptedException (Sonar S2142)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -250,6 +250,7 @@ public class StartMojo extends AbstractDockerMojo {
             try {
                 executorService.awaitTermination(10, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 log.warn("ExecutorService did not shutdown normally.");
                 executorService.shutdownNow();
             }

--- a/src/main/java/io/fabric8/maven/docker/access/util/ExternalCommand.java
+++ b/src/main/java/io/fabric8/maven/docker/access/util/ExternalCommand.java
@@ -80,6 +80,9 @@ public abstract class ExternalCommand {
             executor.shutdown();
             executor.awaitTermination(10, TimeUnit.SECONDS);
         } catch (IllegalThreadStateException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             process.destroy();
             statusCode = -1;
         }

--- a/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/JibBuildService.java
@@ -76,6 +76,9 @@ public class JibBuildService {
             JibServiceUtil.buildContainer(containerBuilder,
                     TarImage.at(dockerTarArchive.toPath()).named(imageConfig.getName()), log);
             log.info(" %s successfully built", dockerTarArchive.getAbsolutePath());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new MojoExecutionException("Error when building JIB image", ex);
         } catch (Exception ex) {
             throw new MojoExecutionException("Error when building JIB image", ex);
         }

--- a/src/main/java/io/fabric8/maven/docker/service/WatchService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/WatchService.java
@@ -107,6 +107,7 @@ public class WatchService {
             }
             wait();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.warn("Interrupted");
         } finally {
             if (executor != null) {


### PR DESCRIPTION
## Problem

SonarCloud reports `java:S2142` (*Either re-interrupt this method or rethrow the InterruptedException*) in four places that catch `InterruptedException` (directly or through a wider catch) but never restore the thread's interrupt status. Swallowing the interrupt can leave a cancelled Maven build blocked instead of unwinding promptly.

## Change

Call `Thread.currentThread().interrupt()` before continuing, in:

- `JibBuildService.build(...)` — the JIB build was caught by a broad `catch (Exception)`; a dedicated `catch (InterruptedException)` now re-interrupts, then rethrows as before.
- `WatchService` — the watch `wait()` loop.
- `StartMojo.shutdownExecutorService(...)` — executor `awaitTermination`.
- `ExternalCommand.checkProcessExit(...)` — re-interrupt only for the `InterruptedException` arm of the multi-catch.

No functional change beyond restoring the interrupt flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ✅ Local verification

Built and tested locally before opening this PR — Amazon Linux 2023 with Amazon Corretto **JDK 17** (the same major version the SonarCloud CI uses), via the project's Maven wrapper:

```
./mvnw -o -Dtest=JibBuildServiceTest,WatchServiceTest,StartMojoTest test
→ Tests run: 12, Failures: 0, Errors: 0 (1 unrelated skipped)  —  BUILD SUCCESS
```

The change only restores the thread interrupt flag; the touched classes compile and their tests stay green.
