### PR TITLE
Close Socket and FileReader via try-with-resources (Sonar S2095)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
+++ b/src/main/java/io/fabric8/maven/docker/access/ContainerCreateConfig.java
@@ -233,8 +233,7 @@ public class ContainerCreateConfig {
 
     private void addPropertiesFromFile(String envPropsFile, Properties envProps) {
         // External properties override internally specified properties
-        try {
-            FileReader reader = new FileReader(envPropsFile);
+        try (FileReader reader = new FileReader(envPropsFile)) {
             envProps.load(reader);
         } catch (FileNotFoundException e) {
             throw new IllegalArgumentException(String.format("Cannot find environment property file '%s'", envPropsFile));

--- a/src/main/java/io/fabric8/maven/docker/wait/TcpPortChecker.java
+++ b/src/main/java/io/fabric8/maven/docker/wait/TcpPortChecker.java
@@ -39,10 +39,8 @@ public class TcpPortChecker implements WaitChecker {
         while (iter.hasNext()) {
             InetSocketAddress address = iter.next();
 
-            try {
-                Socket s = new Socket();
+            try (Socket s = new Socket()) {
                 s.connect(address, TCP_PING_TIMEOUT);
-                s.close();
                 iter.remove();
             } catch (IOException e) {
                 // Ports isn't opened, yet. So don't remove from queue.


### PR DESCRIPTION
## Problem

SonarCloud reports `java:S2095` (resource not closed on all paths) in two places:

- `TcpPortChecker` opens `new Socket()` and calls `s.close()` only on the success path. When `connect()` throws — which is the *normal* "port not open yet" case during a wait — the socket is never closed, leaking a file descriptor on every poll of every not-yet-open port.
- `ContainerCreateConfig.addPropertiesFromFile(...)` opens a `FileReader` that is never closed.

## Change

Wrap both in try-with-resources so the resource is closed on every path. Behaviour is unchanged: in `TcpPortChecker`, `iter.remove()` still runs only when `connect()` succeeds; the existing `catch (IOException)` still handles the not-yet-open case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ✅ Local verification

Built and tested locally before opening this PR — Amazon Linux 2023 with Amazon Corretto **JDK 17** (the same major version the SonarCloud CI uses), via the project's Maven wrapper:

```
./mvnw -o -Dtest=ContainerCreateConfigTest test
→ Tests run: 15, Failures: 0, Errors: 0, Skipped: 0  —  BUILD SUCCESS
```

`ContainerCreateConfig` is covered directly; `TcpPortChecker` has no dedicated unit test, but the try-with-resources conversion compiles cleanly as part of the module and preserves the existing control flow (`iter.remove()` still runs only on a successful `connect()`).
