### PR TITLE
Document that the in-memory KeyStore password is not a secret (Sonar S6437)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/KeyStoreUtil.java
+++ b/src/main/java/io/fabric8/maven/docker/access/KeyStoreUtil.java
@@ -21,6 +21,11 @@ import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
  */
 public class KeyStoreUtil {
 
+    // Alias and protection password for the private key entry of the KeyStore built below. This
+    // KeyStore is created in memory and never persisted, so this fixed value is not a secret; it is
+    // only used to store and immediately read back the key within the same JVM. Not a credential.
+    private static final String DOCKER_KEY_ENTRY = "docker"; // NOSONAR - not a secret, in-memory KeyStore only
+
     static {
         if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
             Security.addProvider(new BouncyCastleProvider());
@@ -43,7 +48,7 @@ public class KeyStoreUtil {
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         keyStore.load(null);
 
-        keyStore.setKeyEntry("docker", privKey, "docker".toCharArray(), certs);
+        keyStore.setKeyEntry(DOCKER_KEY_ENTRY, privKey, DOCKER_KEY_ENTRY.toCharArray(), certs);
         addCA(keyStore, certPath + "/ca.pem");
         return keyStore;
     }


### PR DESCRIPTION
## Problem

SonarCloud raises a **BLOCKER vulnerability** `java:S6437` on `KeyStoreUtil.createDockerKeyStore`: *"Revoke and change this password, as it is compromised."*

This is a **false positive**. The `"docker"` value is the protection password for a private-key entry in a `KeyStore` that is:

- created in memory from the user's own Docker TLS `key.pem`/`cert.pem`,
- never written to disk or transmitted,
- only used to store and immediately read the key back within the same JVM.

It is not a credential and there is nothing to revoke.

## Change

Extract the value to a named constant with an explanatory comment and a `// NOSONAR` marker so the false positive is suppressed and the intent is documented. No behavioural change.

(A project-side "Won't Fix" in SonarCloud would also work but requires fabric8io project admin rights, so this is handled in code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ✅ Local verification

Built and tested locally before opening this PR — Amazon Linux 2023 with Amazon Corretto **JDK 17** (the same major version the SonarCloud CI uses), via the project's Maven wrapper:

```
./mvnw -o -Dtest=KeyStoreUtilTest test
→ Tests run: 5, Failures: 0, Errors: 0, Skipped: 0  —  BUILD SUCCESS
```

The keystore is still built identically (same alias and password value, now via a named constant), so the existing tests pass unchanged.
