### PR TITLE
Document LogsMojo.waitForEver as a deliberate infinite block (Sonar S2189/S2142)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/LogsMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/LogsMojo.java
@@ -69,11 +69,15 @@ public class LogsMojo extends AbstractDockerMojo {
     }
 
     private synchronized void waitForEver() {
-        while (true) {
+        // Intentionally blocks forever so that "docker:logs" keeps following the container logs until
+        // the JVM is terminated; the log lines are delivered from other (dispatcher) threads. There is
+        // deliberately no end condition and interrupts must not stop the follow, so both SonarCloud
+        // findings on this loop (S2189 / S2142) are suppressed rather than "fixed" by changing behaviour.
+        while (true) { // NOSONAR - deliberate: follow logs until the process is killed
             try {
                 this.wait();
-            } catch (InterruptedException e) {
-                // sleep again
+            } catch (InterruptedException e) { // NOSONAR - keep following logs; do not stop on interrupt
+                // wait again
             }
         }
     }


### PR DESCRIPTION
## Problem

SonarCloud reports two bugs on `LogsMojo.waitForEver()`:

- `java:S2189` — *Add an end condition to this loop.*
- `java:S2142` — *Either re-interrupt this method or rethrow the InterruptedException.*

Both describe intentional behaviour. `docker:logs` follows the container logs until the JVM is terminated; the actual log lines are delivered from other (dispatcher) threads, and this method just parks the main thread. It deliberately has no end condition and deliberately keeps waiting across interrupts — adding an end condition or re-interrupting (which would make the `wait()` throw again and busy-spin) would break log following.

## Change

Suppress the two findings with `// NOSONAR` and document why the loop is intentional. No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ✅ Local verification

Built locally before opening this PR — Amazon Linux 2023 with Amazon Corretto **JDK 17** (the same major version the SonarCloud CI uses), via the project's Maven wrapper:

```
./mvnw -o test-compile
→ BUILD SUCCESS
```

This is a comment-only change (added `// NOSONAR` and documentation); there is no behaviour to unit-test, so a clean compile is the relevant check.
