### PR TITLE
Synchronize NamedPipe setSendBufferSize/close to match Socket (Sonar S3551/S2886)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/access/hc/win/NamedPipe.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/win/NamedPipe.java
@@ -107,7 +107,7 @@ final class NamedPipe extends AbstractPlainSocket {
     }
 
     @Override
-    public void setSendBufferSize(int size) throws SocketException {
+    public synchronized void setSendBufferSize(int size) throws SocketException {
         if (size <= 0) {
             throw new IllegalArgumentException("Send buffer size must be positive: " + size);
         }
@@ -164,7 +164,7 @@ final class NamedPipe extends AbstractPlainSocket {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         if (isClosed()) {
             return;
         }


### PR DESCRIPTION
## Problem

The Windows named-pipe transport `NamedPipe` has the same inconsistency as `UnixSocket`: `setSendBufferSize` and `close()` dropped the `synchronized` modifier that `java.net.Socket` declares and that the sibling overrides `getSendBufferSize`, `setReceiveBufferSize` and `getReceiveBufferSize` already use. SonarCloud flags this as `java:S3551` (and `java:S2886` for `setSendBufferSize` vs the synchronized `getSendBufferSize`).

## Change

Add `synchronized` to `setSendBufferSize` and `close()` so the locking matches `java.net.Socket` and the already-synchronized siblings in this class. This is the Windows counterpart to #1942.

## Verification

Built and tested locally before opening this PR — Amazon Linux 2023 with Amazon Corretto **JDK 17** (the same major version the SonarCloud CI uses), via the project's Maven wrapper: the change compiles and `io.fabric8.maven.docker.access.hc.**` passes (42 tests). The named-pipe transport itself only runs on Windows (exercised there by the integration tests), so this is a modifier-only change with no behavioural effect on other platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
