### PR TITLE
Pin Buildx 0.20.0 for Docker 27 macOS E2E

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -96,7 +96,13 @@ jobs:
         uses: docker/setup-docker-action@v5
         with:
           version: ${{ matrix.docker }}
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx for Docker 27
+        if: matrix.docker == 'v27.5.1'
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.20.0
+      - name: Set up latest Docker Buildx
+        if: matrix.docker != 'v27.5.1'
         run: |
           brew install docker-buildx
           mkdir -p ~/.docker/cli-plugins


### PR DESCRIPTION
## What changed

Pin Docker Buildx to v0.20.0 for the macOS Docker 27.5.1 E2E job. The Docker 26.1.4 job continues to install the latest Homebrew Buildx release as before.

## Why

The failing macOS job combined Docker Engine 27.5.1 with Homebrew Buildx v0.35.0. Docker Engine 27.5.1 was released with Buildx v0.20.0, so the CI job was using a substantially newer Buildx client than the version packaged for that Engine release.

The observed failure occurred in the Buildx/BuildKit communication path after the image tarball had been exported:

```text
ERROR: failed to build: failed to solve: Unavailable: error reading from server: EOF
```

Pinning only the Docker 27.5.1 matrix entry restores Docker's officially packaged version pairing while leaving the passing Docker 26.1.4 path unchanged.

Failure: https://github.com/fabric8io/docker-maven-plugin/actions/runs/29305949994/job/86999288271

## Validation

With this change, the previously failing **macOS Docker 27.5.1 E2E job passes on this PR** — the matrix entry that reproduced the EOF failure now completes cleanly with Buildx pinned to v0.20.0.

To check this beyond a single run, the affected Buildx integration-test sequence was exercised repeatedly on `macos-26-intel` runners with Docker 27.5.1, across three `workflow_dispatch` experiments:

| Run | Buildx | Attempts | Passed | Notes |
|---|---|---|---|---|
| [29313232976](https://github.com/JamBalaya56562/docker-maven-plugin/actions/runs/29313232976) | v0.20.0 | 3 | **3 / 3** | initial multi-runner check |
| [29315489306](https://github.com/JamBalaya56562/docker-maven-plugin/actions/runs/29315489306) | v0.20.0 | 5 | **5 / 5** | A/B comparison vs v0.35.0 |
| [29315489306](https://github.com/JamBalaya56562/docker-maven-plugin/actions/runs/29315489306) | v0.35.0 | 5 | 4 / 5 | the one failure was in the `Set up Docker v27.5.1` step — a Lima/QEMU guest-agent VM-startup flake (`guest agent events closed unexpectedly ... EOF`) *before* the Buildx tests ran, unrelated to the Buildx/BuildKit `failed to solve ... EOF` this PR targets |
| [29322016693](https://github.com/JamBalaya56562/docker-maven-plugin/actions/runs/29322016693) | v0.20.0 | 10 | **10 / 10** | focused v0.20.0 stress run |

**Buildx v0.20.0: 18 / 18 attempts passed, 0 failures** across the three runs. The single v0.35.0 failure was an unrelated CI-infrastructure flake, so the A/B run did not itself reproduce the Buildx EOF on v0.35.0.

The change is low-risk and targeted: it only pins the Docker 27.5.1 matrix entry to Docker's officially packaged Buildx (v0.20.0), restores the supported pairing, and leaves the passing Docker 26.1.4 path unchanged. The consistently green v0.20.0 runs above, together with the previously failing macOS 27.5.1 job now passing on this PR, support the pin.
