### PR TITLE
Add unit tests for ImageConfiguration#getDependencies and accessors

### DIFF
--- a/src/test/java/io/fabric8/maven/docker/config/ImageConfigurationTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/ImageConfigurationTest.java
@@ -1,0 +1,81 @@
+package io.fabric8.maven.docker.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ImageConfiguration}, focusing on {@link ImageConfiguration#getDependencies()}
+ * (and its per-source helpers) plus a few plain accessors that were previously uncovered.
+ */
+class ImageConfigurationTest {
+
+    @Test
+    void getDependenciesIsEmptyWithoutRunConfiguration() {
+        // No run configuration -> getRunConfiguration() falls back to RunImageConfiguration.DEFAULT,
+        // which has no volumes, links, container network or dependsOn.
+        ImageConfiguration config = new ImageConfiguration.Builder().name("test-image").build();
+
+        Assertions.assertTrue(config.getDependencies().isEmpty());
+    }
+
+    @Test
+    void getDependenciesCollectsVolumesLinksAndContainerNetwork() {
+        RunVolumeConfiguration volumes = new RunVolumeConfiguration.Builder()
+                .from(Arrays.asList("data-image", "config-image"))
+                .build();
+        RunImageConfiguration run = new RunImageConfiguration.Builder()
+                .volumes(volumes)
+                .links(Arrays.asList("db:database", "cache:redis"))
+                // "container:<name>" is a standard (non-custom) network that exposes a container alias.
+                .network(new NetworkConfig("container:shared"))
+                // dependsOn must be ignored while the network is not a custom one.
+                .dependsOn(Arrays.asList("ignored-when-not-custom"))
+                .build();
+        ImageConfiguration config = new ImageConfiguration.Builder().name("test-image").runConfig(run).build();
+
+        List<String> dependencies = config.getDependencies();
+
+        // Order matches getDependencies(): volumes, then link targets (part before the last colon),
+        // then the container network alias. dependsOn is excluded for non-custom networks.
+        Assertions.assertEquals(
+                Arrays.asList("data-image", "config-image", "db", "cache", "shared"),
+                dependencies);
+    }
+
+    @Test
+    void getDependenciesUsesDependsOnAndIgnoresLinksForCustomNetwork() {
+        RunImageConfiguration run = new RunImageConfiguration.Builder()
+                // An unknown network name is treated as a custom network.
+                .network(new NetworkConfig("my-custom-net"))
+                // Links are only considered for non-custom networks, so these must be ignored.
+                .links(Arrays.asList("db:database"))
+                .dependsOn(Arrays.asList("svc-a", "svc-b"))
+                .build();
+        ImageConfiguration config = new ImageConfiguration.Builder().name("test-image").runConfig(run).build();
+
+        // Only dependsOn contributes; a custom network has no container alias.
+        Assertions.assertEquals(Arrays.asList("svc-a", "svc-b"), config.getDependencies());
+    }
+
+    @Test
+    void setAliasUpdatesAlias() {
+        ImageConfiguration config = new ImageConfiguration();
+
+        config.setAlias("my-alias");
+
+        Assertions.assertEquals("my-alias", config.getAlias());
+    }
+
+    @Test
+    void toStringContainsNameAndAlias() {
+        ImageConfiguration config = new ImageConfiguration.Builder()
+                .name("my-image")
+                .alias("my-alias")
+                .build();
+
+        Assertions.assertEquals("ImageConfiguration {name='my-image', alias='my-alias'}", config.toString());
+    }
+}


### PR DESCRIPTION
## What

Adds a dedicated unit test class `ImageConfigurationTest` covering logic in `ImageConfiguration` that was previously not exercised by any test.

**Tests only — no production code change.**

## Why

Part of an incremental effort to raise SonarCloud coverage. `ImageConfiguration` sat at ~61.7% line coverage with `getDependencies()` and its helpers entirely uncovered, even though it is pure, side-effect-free logic that is easy to test deterministically (no Docker daemon, network, filesystem or Maven lifecycle needed).

## Covered

- `getDependencies()` and its per-source helpers `addVolumes` / `addLinks` / `addContainerNetwork` / `addDependsOn`, across both branches:
  - **non-custom network** → volumes + link targets + container-network alias are collected; `dependsOn` is ignored.
  - **custom network** → `dependsOn` is collected; links are ignored and there is no container alias.
  - **no run configuration** (falls back to `RunImageConfiguration.DEFAULT`) → empty dependency list.
- `setAlias` / `getAlias`
- `toString`

These are exactly the lines SonarCloud reported as uncovered; the new tests take `ImageConfiguration` from ~61.7% to ~100% line coverage.

## Verification

Built and tested locally with Temurin JDK 17 via the Maven wrapper:

```
./mvnw -Pjacoco -Dtest=ImageConfigurationTest test
→ Tests run: 5, Failures: 0, Errors: 0, Skipped: 0  —  BUILD SUCCESS
```

The JaCoCo report confirms every previously-uncovered line in `ImageConfiguration#getDependencies()`, `setAlias` and `toString` is now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
