### PR TITLE
Allow pushing images without build configuration

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -51,7 +51,7 @@ public class RegistryService {
     /**
      * Push a set of images to a registry
      *
-     * @param imageConfigs images to push (but only if they have a build configuration)
+     * @param imageConfigs images to push
      * @param retries how often to retry
      * @param registryConfig a global registry configuration
      * @param skipTag flag to skip pushing tagged images
@@ -62,7 +62,10 @@ public class RegistryService {
                            int retries, RegistryConfig registryConfig, boolean skipTag, BuildService.BuildContext buildContext) throws DockerAccessException, MojoExecutionException {
         for (ImageConfiguration imageConfig : imageConfigs) {
             BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
-            if (buildConfig == null || buildConfig.skipPush()) {
+            if (buildConfig == null) {
+                buildConfig = new BuildImageConfiguration.Builder().build();
+            }
+            if (buildConfig.skipPush()) {
                 log.info("%s : Skipped pushing", imageConfig.getDescription());
                 continue;
             }
@@ -78,9 +81,9 @@ public class RegistryService {
             BuildArgResolver buildArgResolver = new BuildArgResolver(log);
             Map<String, String> buildArgsFromExternalSources = buildArgResolver.resolveBuildArgs(buildContext);
             AuthConfig authConfigForLegacyPush = createAuthConfig(true, imageName.getUser(), configuredRegistry, registryConfig);
-            AuthConfigList authConfigListForBuildXPush = createCompleteAuthConfigList(true, imageConfig, registryConfig, buildContext.getMojoParameters(), buildArgsFromExternalSources);
 
-            if (imageConfig.isBuildX()) {
+            if (buildConfig.isBuildX()) {
+                AuthConfigList authConfigListForBuildXPush = createCompleteAuthConfigList(true, imageConfig, registryConfig, buildContext.getMojoParameters(), buildArgsFromExternalSources);
                 buildXService.push(projectPaths, imageConfig, configuredRegistry, authConfigListForBuildXPush, buildArgsFromExternalSources);
             } else {
                 dockerPush(retries, skipTag, buildConfig, name, configuredRegistry, authConfigForLegacyPush);

--- a/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RegistryServiceTest.java
@@ -337,10 +337,11 @@ class RegistryServiceTest {
     @Test
     void pushImageWithoutBuildConfig() throws DockerAccessException {
         givenAnImageConfigurationWithoutBuildConfig("user/test:1.0.1");
+        givenBuildContext();
 
         whenPushImage();
 
-        thenImageHasNotBeenPushed();
+        thenImageHasBeenPushed();
         thenNoExceptionThrown();
     }
 


### PR DESCRIPTION

## Summary

- allow `docker:push` to push images without a `<build>` configuration
- preserve explicit `<skipPush>true</skipPush>` behavior
- avoid creating Buildx authentication data for legacy Docker pushes

## Root cause

`RegistryService.pushImages` treated a missing build configuration the same as `skipPush=true`, so externally built images were silently skipped.

## Impact

Users can now push an already-built image by configuring only its image name. Existing build, Buildx, registry authentication, tag, and explicit skip behavior remain unchanged.

## Verification

- `mise exec java@temurin-11 -- ./mvnw -B -C -V -ntp -Dtest=RegistryServiceTest test`
- `mise exec java@temurin-11 -- ./mvnw -B -C -V -ntp install -Pjacoco` (970 tests, 0 failures, 6 skipped)

Signed-off-by: Marukome0743 <jambalaya.pyoncafe@gmail.com>

Fixes #1916
