### PR TITLE
Update JaCoCo to 0.8.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@
       <id>jacoco</id>
 
       <properties>
-        <jacoco.version>0.7.9</jacoco.version>
+        <jacoco.version>0.8.15</jacoco.version>
       </properties>
 
       <dependencies>


### PR DESCRIPTION

## Summary
- Update JaCoCo from 0.7.9 to 0.8.15.
- Keep offline instrumentation, report generation, Sonar configuration, and CI Java versions unchanged.
- Continue using the same `jacoco.version` property for both `jacoco-maven-plugin` and `org.jacoco.agent:runtime`.

## Compatibility
This is a dependency-only update. The project continues to target Java 8 bytecode, while coverage builds were verified on Temurin 11 and 17. Public APIs, plugin configuration, and the supported Java range are unchanged.

## Verification
- `mise exec java@temurin-11 -- ./mvnw -B -C -V -ntp clean install -Pjacoco` — 970 tests, 0 failures, 0 errors, 6 skipped
- `mise exec java@temurin-17 -- ./mvnw -B -C -V -ntp clean install -Pjacoco` — 970 tests, 0 failures, 0 errors, 6 skipped
- JaCoCo 0.8.15 restored the instrumented classes and analyzed 307 classes
- `target/jacoco.exec`, HTML/XML coverage reports, and the plugin JAR were generated successfully

## Scope
Only the `jacoco.version` property in `pom.xml` is changed. Java CI matrix changes and migration to `maven.compiler.release` are intentionally left for separate follow-up work.

Signed-off-by: Marukome0743 <jambalaya.pyoncafe@gmail.com>
