### PR TITLE
Run SonarCloud analysis on Java 21 (SonarQube Cloud dropped Java 17)

### DIFF
--- a/.github/workflows/sonar-pr-analysis-publish.yml
+++ b/.github/workflows/sonar-pr-analysis-publish.yml
@@ -28,10 +28,10 @@ jobs:
       GITHUB_REPO: ${{ github.repository }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
-      - name: Setup Java 17 # Move Sonar analysis to Java 17
+      - name: Setup Java 21 # SonarQube Cloud requires Java 21+ to run the analysis
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Dump GitHub context
         run: echo '${{ toJSON(github.event) }}'

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - name: Setup Java 17 # Move Sonar analysis to Java 17
+      - name: Setup Java 21 # SonarQube Cloud requires Java 21+ to run the analysis
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Maven Sonar
         run: ./mvnw ${MAVEN_ARGS} -Pjacoco,sonar clean install


### PR DESCRIPTION
## Problem

The **Sonar Scanner** job on `master` (`.github/workflows/sonar.yml`) is failing:

```
The version of Java (17) used to run this analysis is deprecated, and SonarQube Cloud
no longer supports it. Please upgrade to Java 21 or later.
```

SonarQube Cloud [dropped Java 17 as a scanner runtime](https://community.sonarsource.com/t/reminder-upgrade-to-java-21-for-sonarqube-cloud-analysis-by-july-20-2026/185820) starting **2026-07-20** and now requires **Java 21+**. The Sonar workflows pin Java 17, so the analysis aborts before uploading.

### Side effect: a stale, red Quality Gate

Because the scanner never uploads, SonarCloud is frozen at its last successful analysis (**2026-07-18**), before recent fixes were merged. The Quality Gate therefore still reports a `new_security_rating = E` for a `java:S6437` finding in `KeyStoreUtil` that has **already been fixed on master**. Once the analysis runs again on Java 21, master is re-analysed and the gate should recover.

## Change

Bump the JVM that runs the analysis (`mvn -Pjacoco,sonar`) from **17 → 21** in the two workflows that perform the SonarCloud analysis:

- `.github/workflows/sonar.yml` (master push analysis)
- `.github/workflows/sonar-pr-analysis-publish.yml` (PR analysis)

## Scope / compatibility

This changes **only the JVM used to run the analysis in CI**. It does **not** change what Java version the plugin supports:

- The compile target stays **Java 8** (`maven-compiler-plugin` `source`/`target` = 8).
- The user-facing build/test matrix (Java 8 / 11) and the release JVM (11) are untouched.

`sonar-pr-request.yml` only builds/tests and does not run the `sonar` goal, so it is intentionally left as-is.

## Verification

A full build and test run passes locally on **Temurin 21**:

```
./mvnw -B -ntp -Pjacoco clean install    # on JDK 21
→ Tests run: 976, Failures: 0, Errors: 0, Skipped: 6  —  BUILD SUCCESS
```

Compiling `target 8` on JDK 21 works (only the expected "source/target value 8 is obsolete" warnings), and the test suite (incl. Mockito/`MockedStatic`) passes on 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
