### PR TITLE
Remove unused private methods, fields and local variables (Sonar S1144/S1068/S1481)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/util/AnsiLogger.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AnsiLogger.java
@@ -360,16 +360,6 @@ public class AnsiLogger implements Logger, Closeable {
         this.isVerbose = true;
     }
 
-    private Boolean checkBackwardVersionValues(String verbose) {
-        if (verbose.isEmpty()) {
-            return Boolean.TRUE;
-        }
-        if (verbose.equalsIgnoreCase("true") || verbose.equalsIgnoreCase("false")) {
-            return Boolean.parseBoolean(verbose.toLowerCase());
-        }
-        return null;
-    }
-
     private List<LogVerboseCategory> getVerboseModesFromString(String groups) {
         List<LogVerboseCategory> ret = new ArrayList<>();
         for (String group : groups.split(",")) {

--- a/src/test/java/integration/DockerAccessIT.java
+++ b/src/test/java/integration/DockerAccessIT.java
@@ -148,8 +148,7 @@ class DockerAccessIT {
     private void testExecContainer() throws DockerAccessException {
         Arguments arguments = new Arguments();
         arguments.setExec(Lists.newArrayList("echo", "test", "echo"));
-        String execContainerId = dockerClient.createExecContainer(this.containerId, arguments);
-        //assertThat(dockerClient.startExecContainer(execContainerId), is("test echo"));
+        dockerClient.createExecContainer(this.containerId, arguments);
     }
 
     private void testStopContainer() throws DockerAccessException {

--- a/src/test/java/integration/DockerAccessWinIT.java
+++ b/src/test/java/integration/DockerAccessWinIT.java
@@ -146,8 +146,7 @@ class DockerAccessWinIT {
     private void testExecContainer() throws DockerAccessException {
         Arguments arguments = new Arguments();
         arguments.setExec(Lists.newArrayList("echo", "test", "echo"));
-        String execContainerId = dockerClient.createExecContainer(this.containerId, arguments);
-        //assertThat(dockerClient.startExecContainer(execContainerId), is("test echo"));
+        dockerClient.createExecContainer(this.containerId, arguments);
     }
 
     private void testStopContainer() throws DockerAccessException {

--- a/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
+++ b/src/test/java/io/fabric8/maven/docker/BuildMojoTest.java
@@ -515,13 +515,6 @@ class BuildMojoTest extends MojoTestBase {
             .platforms(Arrays.asList(platforms));
     }
 
-    private BuildXConfiguration getBuildXConfiguration(String configFile, String... platforms) {
-        return new BuildXConfiguration.Builder()
-            .configFile(configFile)
-            .platforms(Arrays.asList(platforms))
-            .build();
-    }
-
     private ImageConfiguration singleBuildXImageWithConfiguration(String configFile) {
         return singleImageConfiguration(
             getBuildXPlatforms(TWO_BUILDX_PLATFORMS).configFile(configFile).build(), null);

--- a/src/test/java/io/fabric8/maven/docker/PushMojoBuildXTest.java
+++ b/src/test/java/io/fabric8/maven/docker/PushMojoBuildXTest.java
@@ -133,17 +133,6 @@ class PushMojoBuildXTest {
     }
   }
 
-  private void verifyNoDockerConfigAddedToBuildX() throws MojoExecutionException {
-    assertEquals(1, defaultExecMockedConstruction.constructed().size());
-    BuildXService.DefaultExec defaultExec = defaultExecMockedConstruction.constructed().get(0);
-    verify(defaultExec).process(Arrays.asList("docker", "buildx", "create",
-        "--driver", "docker-container", "--name", "testbuilder", "--node", "testnode"));
-    verify(defaultExec).process(Arrays.asList("docker", "buildx", "build",
-        "--progress=plain", "--builder", "testbuilder", "--platform", "linux/amd64,linux/arm64",
-        "--tag", "test.example.org/testuser/sample-test-image:latest",
-        expectedDockerStateDir.resolve("build").toFile().getAbsolutePath(), "--push"));
-  }
-
   private void verifyDockerConfigOptionAddedToBuildX() throws MojoExecutionException {
     assertEquals(1, defaultExecMockedConstruction.constructed().size());
     BuildXService.DefaultExec defaultExec = defaultExecMockedConstruction.constructed().get(0);

--- a/src/test/java/io/fabric8/maven/docker/service/BuildServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildServiceTest.java
@@ -307,9 +307,6 @@ class BuildServiceTest {
     void testTagImage() throws DockerAccessException, MojoExecutionException {
         // Given
         givenAnImageConfiguration(Boolean.FALSE.toString());
-        final BuildService.BuildContext buildContext = new BuildService.BuildContext.Builder()
-            .mojoParameters(mojoParameters)
-            .build();
 
         // When
         whenBuildImage(false, true);

--- a/src/test/java/io/fabric8/maven/docker/service/ContainerTrackerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/ContainerTrackerTest.java
@@ -55,7 +55,7 @@ class ContainerTrackerTest {
             { "2", "name2", "alias2", null, null, null, "label2", "true" }
         };
 
-        List<ContainerTracker.ContainerShutdownDescriptor> descs = registerAtTracker(data);
+        registerAtTracker(data);
 
         ContainerTracker.ContainerShutdownDescriptor desc = tracker.removeContainer("1");
         verifyDescriptor(data[0], desc);
@@ -76,7 +76,7 @@ class ContainerTrackerTest {
             { "3", "name3", null, null, null, null, "label2", "true" }
         };
 
-        List<ContainerTracker.ContainerShutdownDescriptor> descs = registerAtTracker(data);
+        registerAtTracker(data);
 
         Collection<ContainerTracker.ContainerShutdownDescriptor> removed = tracker.removeShutdownDescriptors(getPomLabel("label1"));
         Assertions.assertEquals(2, removed.size());
@@ -100,7 +100,7 @@ class ContainerTrackerTest {
             { "3", "name3", null, null, null, null, "label2", "false" }
         };
 
-        List<ContainerTracker.ContainerShutdownDescriptor> descs = registerAtTracker(data);
+        registerAtTracker(data);
         Collection<ContainerTracker.ContainerShutdownDescriptor> removed = tracker.removeShutdownDescriptors(null);
 
         Assertions.assertEquals(3, removed.size());

--- a/src/test/java/io/fabric8/maven/docker/service/LoadImageTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/LoadImageTest.java
@@ -47,13 +47,10 @@ class LoadImageTest {
     @Mock
     private RegistryService registryService;
 
-    private String dockerArchive;
-
     @Test
     void testLoadImage() throws DockerAccessException, MojoExecutionException {
         givenMojoParameters();
         givenAnImageConfiguration();
-        givenDockerArchive("test.tar");
         whenBuildImage();
         thenImageIsBuilt();
     }
@@ -62,10 +59,6 @@ class LoadImageTest {
         Mockito.doReturn(project).when(params).getProject();
         Mockito.doReturn(new File("/maven-project")).when(project).getBasedir();
         Mockito.doReturn("src/main/docker").when(params).getSourceDirectory();
-    }
-
-    private void givenDockerArchive(String s) {
-        dockerArchive = s;
     }
 
     private void givenAnImageConfiguration() {

--- a/src/test/java/io/fabric8/maven/docker/service/VolumeServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/VolumeServiceTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
  */
 @ExtendWith(MockitoExtension.class)
 class VolumeServiceTest {
-   private VolumeCreateConfig volumeConfig;
 
    @Mock
    private DockerAccess docker;


### PR DESCRIPTION
Second of the dead-code cleanups (after #1953, which removed unused imports). This one removes actual dead members: `java:S1144` (unused private methods), `java:S1068` (unused private fields) and `java:S1481` (unused local variables), plus the two commented-out assertions that made a variable dead in the first place.

## Contents

| File | Removed |
|---|---|
| `util/AnsiLogger.java` | unused private `checkBackwardVersionValues(...)` |
| `BuildMojoTest.java` | unused private `getBuildXConfiguration(...)` |
| `PushMojoBuildXTest.java` | unused private `verifyNoDockerConfigAddedToBuildX()` |
| `VolumeServiceTest.java` | unused `volumeConfig` field |
| `LoadImageTest.java` | unused `dockerArchive` field + its write-only setter and the call to it |
| `BuildServiceTest.java` | unused `buildContext` local |
| `ContainerTrackerTest.java` | unused `descs` local ×3 |
| `DockerAccessIT.java` / `DockerAccessWinIT.java` | unused `execContainerId` local + the commented-out assertion that used it |

`AnsiLogger#checkBackwardVersionValues` is the only production change; it has no callers — `checkVerboseLoggingEnabled` handles the `""`/`true`/`false` cases inline.

## Calls with side effects are preserved

Where the value was unused but the call was not, only the assignment is dropped:

```java
-        List<ContainerTracker.ContainerShutdownDescriptor> descs = registerAtTracker(data);
+        registerAtTracker(data);
```

```java
-        String execContainerId = dockerClient.createExecContainer(this.containerId, arguments);
-        //assertThat(dockerClient.startExecContainer(execContainerId), is("test echo"));
+        dockerClient.createExecContainer(this.containerId, arguments);
```

`LoadImageTest#givenDockerArchive` is the one place where a call goes away too: it only assigned to the dead field and asserted nothing, and the archive name the test actually depends on is set in `givenAnImageConfiguration()` via `.dockerArchive("test.tar")`.

## Verification

```
./mvnw clean install     # Temurin 21
→ Tests run: 976, Failures: 0, Errors: 0, Skipped: 6  —  BUILD SUCCESS
```

Same test count as `master`.

## Follow-up (separate PR)

Commented-out code (`java:S125`) elsewhere in the tree — that one needs case-by-case judgement, since some blocks carry explanatory context (e.g. the redirect-strategy TODO in `HttpClientBuilder`), so it is deliberately left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
