### PR TITLE
Remove commented-out code, keeping the context it carried (Sonar java:S125)

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -348,7 +348,6 @@ public class StartMojo extends AbstractDockerMojo {
             final ImageConfiguration imageConfig = (ImageConfiguration) resolvable;
 
             // Still to check: How to work with linking, volumes, etc ....
-            //String imageName = new ImageName(imageConfig.getName()).getFullNameWithTag(registry);
             RegistryService registryService = hub.getRegistryService();
 
             pullImage(registryService, imageConfig, pullRegistry);

--- a/src/main/java/io/fabric8/maven/docker/access/hc/HcChunkedResponseHandlerWrapper.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/HcChunkedResponseHandlerWrapper.java
@@ -21,25 +21,17 @@ public class HcChunkedResponseHandlerWrapper implements ResponseHandler<Object> 
     @Override
     public Object handleResponse(HttpResponse response) throws IOException {
         try (InputStream stream = response.getEntity().getContent()) {
-            // In the previous version of this file the following if() was as follows. The methode isJson() checks
-            // by header (not by body):
-            //      if(isJson(response)) {
-            //          EntityStreamReaderUtil.processJsonStream(handler, stream);
-            //      }
+            // A previous version of this file only detected JSON by the Content-Type header, which is not enough:
+            // when the Podman daemon is used, the POST /build response is JSON with HTTP status 200 as expected, but
+            // carries no "Content-Type: application/json" header - no Content-Type header at all. Seen in Podman 3.4.2.
             //
-            // In case the Podman daemon is used, the POST /build response is JSON and the HTTP status code is 200
-            // as expected, but there is no header "Content-Type = application/json" nor "Content-Type" at all. Seen in
-            // Podman 3.4.2. But the docker-maven-plugin relies on that JSON-body. In BuildJsonResponseHandler.process():
-            //      if (json.has("error")) {
-            //          ...
-            //          throw new DockerAccessException();
-            //      ...
+            // The plugin relies on that JSON body: BuildJsonResponseHandler.process() raises a DockerAccessException
+            // for an "error" entry. Missing the body means no error is detected and the Maven build carries on even
+            // though the image failed to build.
             //
-            // If no error is detected, the Maven-build goes on despite there was a problem building the
-            // image!
-            // If the header indicates application/json Content-Type, stream the response to the handler.
-            // If there is no Content-Type header it tries to detect if the body is JSON. If so, the handler is called
-            // with a buffered response.
+            // Hence: if the header indicates application/json, stream the response to the handler. If there is no
+            // Content-Type header at all, detect whether the body is JSON and, if so, call the handler with a
+            // buffered response.
             if (isJsonCheckedByHeader(response)) {
                 EntityStreamReaderUtil.processJsonStream(handler, stream);
             } else if (isMissingContentType(response)) {

--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyConfigurationSource.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyConfigurationSource.java
@@ -90,7 +90,8 @@ public class DockerAssemblyConfigurationSource implements AssemblerConfiguration
 
     @Override
     public String getFinalName() {
-        //return params.getProject().getBuild().getFinalName();
+        // Deliberately not the project's build finalName: the assembly has to be rooted at the
+        // build context root so that its entries end up at the top level of the Docker build archive.
         return ".";
     }
 

--- a/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/compose/DockerComposeConfigHandler.java
@@ -158,7 +158,6 @@ public class DockerComposeConfigHandler implements ExternalConfigHandler {
                 false,
                 session,
                 null);
-        //request.setEscapeString("$");
         return readerFilter.filter(request);
     }
 

--- a/src/main/java/io/fabric8/maven/docker/model/ContainerDetails.java
+++ b/src/main/java/io/fabric8/maven/docker/model/ContainerDetails.java
@@ -60,7 +60,7 @@ public class ContainerDetails implements Container {
 
     @Override
     public String getImage() {
-        // ID: json.getString("Image");
+        // The top level "Image" holds the image id, Config.Image the image name
         return json.getAsJsonObject(CONFIG).get(IMAGE).getAsString();
     }
 

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyManagerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyManagerTest.java
@@ -375,12 +375,6 @@ class DockerAssemblyManagerTest {
         File tarArchive = assemblyManager.createDockerTarArchive("test_image", mojoParams, buildImageConfiguration, logger, null);
         Assertions.assertNotNull(tarArchive);
 
-        /*
-            tarArchiver.addFile(new File("target/test_image/build/Dockerfile").getAbsoluteFile(), "Dockerfile");
-
-            List<ArchivedFileSet> archivedFileSets = new ArrayList<>();
-            tarArchiver.addArchivedFileSet(withCapture(archivedFileSets));
-         */
         List<ArchivedFileSet> archivedFileSets = getArchivedFileSetsToVerify( "target/test_image/build/Dockerfile", "Dockerfile", 2);
         Assertions.assertEquals(new File("target/test_image/build/first.tar").getAbsoluteFile(), archivedFileSets.get(0).getArchive());
         Assertions.assertEquals("first/", archivedFileSets.get(0).getPrefix());

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -1003,9 +1003,6 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
     }
 
     private List<ImageConfiguration> resolveImage(ImageConfiguration image, final Properties properties) {
-        //MavenProject project = mock(MavenProject.class);
-        //when(project.getProperties()).thenReturn(properties);
-
         Mockito.doReturn(properties).when(project).getProperties();
         Mockito.lenient().doReturn(new File("./")).when(project).getBasedir();
 

--- a/src/test/java/io/fabric8/maven/docker/service/VolumeServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/VolumeServiceTest.java
@@ -29,13 +29,6 @@ class VolumeServiceTest {
    @Mock
    private DockerAccess docker;
 
-   /*
-    * methods to test
-    *
-    * volumeService.createVolumeConfig(volumeName, driver, driverOpts, labels);
-    * volumeService.removeVolume(volumeName);
-    */
-
    private Map<String, String > withMap(String what) {
       Map<String, String> map = new HashMap<>();
       map.put(what + "Key1", "value1");

--- a/src/test/java/io/fabric8/maven/docker/util/WaitUtilTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/WaitUtilTest.java
@@ -221,7 +221,6 @@ class WaitUtilTest {
             return true;
         } catch (IOException exp) {
             System.err.println("Port " + port + " already in use, tying next ...");
-            // exp.printStackTrace();
             // next try ....
         }
         return false;


### PR DESCRIPTION
Third of the dead-code cleanups (after #1953 unused imports and #1954 unused private members). This one addresses `java:S125` — commented-out code.

Comments only; no behaviour change.

## Removed as stale

These snippets cannot be revived, or have already been replaced by equivalent code:

| File | Why it is dead |
|---|---|
| `model/ContainerDetails.java` | `json.getString("Image")` predates the Gson migration — `JsonObject` has no such method |
| `StartMojo.java` | `ImageName#getFullNameWithTag(String)` no longer exists; registry resolution is handled by `pullImage(...)` below it |
| `config/handler/compose/DockerComposeConfigHandler.java` | an escape-string setting that was never adopted |
| `DockerAssemblyManagerTest.java` | JMockit `withCapture(...)` leftovers from the Mockito migration; `getArchivedFileSetsToVerify(...)` already asserts the same thing |
| `PropertyConfigHandlerTest.java` | `mock`/`when` lines replaced by the `@Mock` field; the static imports are gone, so they would not even compile |
| `VolumeServiceTest.java` | a "methods to test" checklist — one entry (`createVolumeConfig(...)`) is not a method of `VolumeService` at all, the other (`removeVolume`) is covered by `testRemoveVolume()` |
| `util/WaitUtilTest.java` | a debug-only `exp.printStackTrace()` (the `// next try ....` control-flow note is kept) |

## Reworded rather than deleted

Two blocks carried information that deleting the code lines would have destroyed, so they became prose:

- **`DockerAssemblyConfigurationSource#getFinalName`** — the commented-out `params.getProject().getBuild().getFinalName()` was the only record that returning `"."` is a deliberate choice (the assembly must be rooted at the build context root). Restoring it would change the archive layout, so it is documented instead.
- **`HcChunkedResponseHandlerWrapper#handleResponse`** — the quoted before/after snippets explain why JSON is detected by body as well as by header (Podman 3.4.2 returns a JSON `POST /build` response with no `Content-Type` at all, and missing it means a failed build is silently ignored). `HcChunkedResponseHandlerWrapperTest` explicitly points readers at this comment, so the explanation has to stay — only the quoted code formatting is gone.

## Not included

`DockerAssemblyManagerTest` around the `AllFilesExecCustomizer` assertion is deliberately left alone. Its TODO asks for a production change — `AllFilesExecCustomizer` instantiates `new TarArchiver()` directly, so the mocked archiver never sees `addResource(...)`, and reviving the assertion means routing it through `archiverManager.getArchiver("tar")`. That is beyond a comment cleanup.

The redirect-strategy TODO in `HttpClientBuilder` is handled separately, together with the issue it actually refers to.

## Verification

```
./mvnw clean install     # Temurin 21
→ Tests run: 976, Failures: 0, Errors: 0, Skipped: 6  —  BUILD SUCCESS
```

Same test count as `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
