### PR TITLE
Reject a registry or image name given as a URL (Closes #357)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 * **0.50-SNAPSHOT**:
   - Create the parent directory of `outputFile` and fail with an explicit message when it cannot be written, instead of swallowing the error and failing later with a `NullPointerException`; also make the progress bar usable without a preceding `progressStart()`
   - Do not fail `docker:stop` when the daemon is already removing the container itself, as it does for `<autoRemove>`; a conflict for any other reason (e.g. the container is still running) is still reported
+  - Reject a registry or image name given as a URL (e.g. `https://registry:8443`) with an explicit message, instead of failing later with a `Moved Permanently: 301` on push or a validation error that never mentions the scheme ([#357](https://github.com/fabric8io/docker-maven-plugin/issues/357))
 
 * **0.49.0 (2026-08-09)**:
   - Fix `docker.save.aliases`: a non-existent alias in the list was silently ignored instead of failing the save with a clear error

--- a/src/main/asciidoc/inc/_registry.adoc
+++ b/src/main/asciidoc/inc/_registry.adoc
@@ -12,6 +12,11 @@ plugin follows the same semantics, so if an image name is specified
 with a registry part, this registry is contacted. Authentication is
 explained in the next <<authentication,section>>.
 
+A registry is always given as a host with an optional port, never as a
+URL: use `nexus.example.com:8443`, not `https://nexus.example.com:8443`.
+A scheme would end up in the image name, which the daemon answers with a
+redirect that is not followed for push requests, so the plugin rejects it.
+
 There are some situations however where you want to have more
 flexibility for specifying a remote registry. This might be because
 you do not want to hard code a registry into `pom.xml` but

--- a/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/AbstractDockerMojo.java
@@ -39,6 +39,7 @@ import io.fabric8.maven.docker.util.AnsiLogger;
 import io.fabric8.maven.docker.util.AuthConfigFactory;
 import io.fabric8.maven.docker.util.EnvUtil;
 import io.fabric8.maven.docker.util.GavLabel;
+import io.fabric8.maven.docker.util.ImageName;
 import io.fabric8.maven.docker.util.ImageNameFormatter;
 import io.fabric8.maven.docker.util.MojoParameters;
 import io.fabric8.maven.docker.util.NamePatternUtil;
@@ -357,6 +358,9 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements ConfigH
     }
 
     protected RegistryService.RegistryConfig getRegistryConfig(String specificRegistry) {
+        // Fail here rather than later with an unrelated-looking error from the daemon
+        ImageName.validateRegistry(specificRegistry);
+        ImageName.validateRegistry(registry);
         return new RegistryService.RegistryConfig.Builder()
                 .settings(settings)
                 .authConfig(authConfig != null ? authConfig.toMap() : null)

--- a/src/main/java/io/fabric8/maven/docker/access/hc/http/HttpClientBuilder.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/http/HttpClientBuilder.java
@@ -53,11 +53,10 @@ public class HttpClientBuilder implements ClientBuilder {
         org.apache.http.impl.client.HttpClientBuilder builder = HttpClients.custom();
         HttpClientConnectionManager manager = getPooledConnectionFactory(certPath, maxConnections);
         builder.setConnectionManager(manager);
-        // TODO: For push-redirects working for 301, the redirect strategy should be relaxed (see #351)
-        // However not sure whether we should do it right now and whether this is correct, since normally
-        // a 301 should only occur when the image name is invalid (e.g. containing "//" in which case a redirect
-        // happens to the URL with a single "/")
-        // builder.setRedirectStrategy(new LaxRedirectStrategy());
+        // The redirect strategy is deliberately left at the default, which does not follow redirects for
+        // POST: a 301 on push means the image name is malformed (a "//" from a registry configured as a
+        // URL), so following it would paper over a configuration error. ImageName rejects such names with
+        // an explicit message instead.
 
         // TODO: Tune client if needed (e.g. add pooling factoring .....
         // But I think, that's not really required.

--- a/src/main/java/io/fabric8/maven/docker/util/ImageName.java
+++ b/src/main/java/io/fabric8/maven/docker/util/ImageName.java
@@ -234,9 +234,29 @@ public class ImageName {
         new ImageName(image);
     }
 
+    /**
+     * Validate a configured registry. A registry is a host with an optional port, not a URL; configuring it
+     * as one lets the scheme leak into the image name, which the daemon answers with a redirect that is not
+     * followed for POST requests, so a push fails with a "Moved Permanently" that gives no hint about the cause.
+     *
+     * @param registry registry to validate, may be null
+     * @throws IllegalArgumentException if the registry contains a URL scheme
+     */
+    public static void validateRegistry(String registry) {
+        if (registry != null && URL_SCHEME_REGEXP.matcher(registry).find()) {
+            throw new IllegalArgumentException(
+                String.format("Configuration error: registry '%s' must not contain a URL scheme. " +
+                              "Use the host[:port] form instead, e.g. '%s'.",
+                              registry, URL_SCHEME_REGEXP.matcher(registry).replaceFirst("")));
+        }
+    }
+
     // Validate parts and throw an IllegalArgumentException if a part is not valid
     private void doValidate() {
         List<String> errors = new ArrayList<>();
+        if (URL_SCHEME_REGEXP.matcher(getFullName()).find()) {
+            errors.add("name must not contain a URL scheme, use the 'host[:port]/repository[:tag]' form instead");
+        }
         // Strip off user from repository name
         String image = user != null ? repository.substring(user.length() + 1) : repository;
         Object[] checks = new Object[] {
@@ -322,4 +342,9 @@ public class ImageName {
     private final Pattern TAG_REGEXP = Pattern.compile("^[\\w][\\w.-]{0,127}$");
 
     private final Pattern DIGEST_REGEXP = Pattern.compile("^sha256:[a-z0-9]{32,}$");
+
+    // Not part of Docker's own patterns: catches the common mistake of configuring a registry or image
+    // name as a URL. Without this the resulting name still fails validation, but only with the generic
+    // per-part messages, which never mention the scheme that actually caused it.
+    private static final Pattern URL_SCHEME_REGEXP = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*://");
 }

--- a/src/test/java/io/fabric8/maven/docker/util/ImageNameTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/ImageNameTest.java
@@ -159,10 +159,39 @@ class ImageNameTest {
         "fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar",
         "repo:fo$z$", "repo:Foo@3cc", "repo:Foo$3", "repo:Foo*3", "repo:Fo^3", "repo:Foo!3",
         "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..",
-        "-busybox:test", "-test/busybox:test", "-index:5000/busybox:test"
+        "-busybox:test", "-test/busybox:test", "-index:5000/busybox:test",
+        // #357: a registry configured as a URL leaks the scheme into the image name
+        "https://index:5000/busybox", "http://index:5000/busybox:test", "https://index:5000/user/busybox"
     })
     void invalidName(String illegal) {
         Assertions.assertThrows(IllegalArgumentException.class, () -> new ImageName(illegal));
+    }
+
+    @Test
+    void nameWithUrlSchemeReportsTheScheme() {
+        // #357: without this the name is rejected too, but only with the generic per-part messages,
+        // which never mention that the URL scheme is what broke it.
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
+            () -> new ImageName("https://nexus.example.com:8443/user/test"));
+
+        Assertions.assertTrue(exception.getMessage().contains("must not contain a URL scheme"),
+            "Expected a hint about the URL scheme, but got: " + exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "https://nexus.example.com:8443", "http://localhost:5000" })
+    void validateRegistryRejectsUrl(String registry) {
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
+            () -> ImageName.validateRegistry(registry));
+
+        Assertions.assertTrue(exception.getMessage().contains("must not contain a URL scheme"),
+            "Expected a hint about the URL scheme, but got: " + exception.getMessage());
+    }
+
+    @Test
+    void validateRegistryAcceptsHostAndNull() {
+        Assertions.assertDoesNotThrow(() -> ImageName.validateRegistry("nexus.example.com:8443"));
+        Assertions.assertDoesNotThrow(() -> ImageName.validateRegistry(null));
     }
 
     @Test


### PR DESCRIPTION
Closes #357

Companion to #1955: that PR removes commented-out code, this one resolves the single TODO in the tree that pointed at an issue — and the issue it pointed at.

## The TODO and the issue

`HttpClientBuilder` has carried this since 2016:

```java
// TODO: For push-redirects working for 301, the redirect strategy should be relaxed (see #351)
// However not sure whether we should do it right now and whether this is correct, since normally
// a 301 should only occur when the image name is invalid (e.g. containing "//" in which case a redirect
// happens to the URL with a single "/")
// builder.setRedirectStrategy(new LaxRedirectStrategy());
```

`#351` is "Separate registry handling for pull and push", closed in January 2016 and never about redirects. The issue this describes is **#357**, still open: a user configured `<registry>https://…</registry>`, the scheme ended up in the image name, and the push failed with `(Moved Permanently: 301)`. The diagnosis there was "don't put the scheme in the registry name", confirmed by a second user — but nothing in the plugin ever says so.

## Why not relax the redirect strategy

The TODO doubted itself for the right reason. A 301 on push means the name is malformed, so following the redirect would paper over a configuration error rather than fix anything. `LaxRedirectStrategy` also makes POST/PUT follow redirects, which can carry registry credentials to whatever host the redirect points at. The default strategy stays; the commented-out call is replaced by a note saying why.

## What this changes instead

Make the actual mistake visible:

- `ImageName` reports the scheme explicitly rather than only the per-part pattern mismatches it happens to produce (`registry part 'https:'`, `image part 'foo:5000/bar'`, `user part ''` — none of which mention the scheme).
- Configured registries (`<registry>`, `<pushRegistry>`, `<pullRegistry>`, `-Ddocker.registry`) are validated in `getRegistryConfig(...)`, so this fails before any daemon call. They were not validated anywhere before.

Docker's own validation patterns are copied verbatim from `distribution/reference` and are left untouched — the scheme check is a separate pattern beside them.

## Verified against Docker 29.6.2

`docker:push` with `<registry>https://nexus.example.com:8443</registry>`:

**Before** — the daemon rejects the name it was handed, with no hint about the cause (current daemons return this where the 2015 report saw the 301):

```
[ERROR] DOCKER> Unable to check image [https://nexus.example.com:8443/user/test:1.0.1] :
        {"message":"invalid reference format"} (Bad Request: 400)
```

**After** — fails immediately, before contacting the daemon:

```
[ERROR] Configuration error: registry 'https://nexus.example.com:8443' must not contain a URL scheme.
        Use the host[:port] form instead, e.g. 'nexus.example.com:8443'.
```

Tests added to `ImageNameTest` for both the name and the registry path, plus a note in the registry docs.

```
./mvnw clean install     # Temurin 21
→ Tests run: 983, Failures: 0, Errors: 0, Skipped: 6  —  BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
