### PR TITLE
Replace the abandoned fabric8 base image in ITs and samples

### DIFF
--- a/it/build-pom-packaging/pom.xml
+++ b/it/build-pom-packaging/pom.xml
@@ -36,7 +36,7 @@
             <image>
               <name>dmp-pom-packaging</name>
               <build>
-                <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+                <from>eclipse-temurin:17-jre-alpine</from>
                 <assemblies>
                   <assembly>
                     <descriptorRef>dependencies</descriptorRef>

--- a/it/multi-assembly/pom.xml
+++ b/it/multi-assembly/pom.xml
@@ -76,7 +76,7 @@
             <image>
               <name>${docker.user}/dmp-multi-assembly</name>
               <build>
-                <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+                <from>eclipse-temurin:17-jre-alpine</from>
                 <assemblies>
                   <assembly>
                     <descriptorRef>dependencies</descriptorRef>

--- a/it/spring-boot-with-jib/pom.xml
+++ b/it/spring-boot-with-jib/pom.xml
@@ -79,7 +79,7 @@
             <image>
               <name>${docker.user}/spring-boot-dmp-it-jib</name>
               <build>
-                <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+                <from>eclipse-temurin:17-jre-alpine</from>
                 <assembly>
                   <descriptorRef>artifact</descriptorRef>
                 </assembly>

--- a/samples/multi-assembly/README.md
+++ b/samples/multi-assembly/README.md
@@ -10,7 +10,7 @@ You can compile project as usual by issuing a simple `mvn clean install` command
 You can build images with multiple layers by adding multiple assemblies. Replace the existing assembly configuration:
 ```xml
 <build>
-    <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+    <from>eclipse-temurin:17-jre-alpine</from>
     <assembly>
         <descriptorRef>artifact-with-dependencies</descriptorRef>
         <targetDir>/app</targetDir>
@@ -21,7 +21,7 @@ You can build images with multiple layers by adding multiple assemblies. Replace
 with multiple assemblies:
 ```xml
 <build>
-    <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+    <from>eclipse-temurin:17-jre-alpine</from>
     <assemblies>
         <assembly>
             <descriptorRef>dependencies</descriptorRef>

--- a/samples/multi-assembly/pom.xml
+++ b/samples/multi-assembly/pom.xml
@@ -72,7 +72,7 @@
             <image>
               <name>${docker.user}/dmp-sample-multi-assembly</name>
               <build>
-                <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+                <from>eclipse-temurin:17-jre-alpine</from>
                 <assemblies>
                   <assembly>
                     <descriptorRef>dependencies</descriptorRef>

--- a/samples/spring-boot-with-jib/pom.xml
+++ b/samples/spring-boot-with-jib/pom.xml
@@ -74,7 +74,7 @@
             <image>
               <name>${docker.user}/spring-boot-dmp-sample-jib</name>
               <build>
-                <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+                <from>eclipse-temurin:17-jre-alpine</from>
                 <assembly>
                   <descriptorRef>artifact</descriptorRef>
                 </assembly>
@@ -116,7 +116,7 @@
                 <image>
                   <name>${docker.user}/spring-boot-dmp-sample-jib</name>
                   <build>
-                    <from>fabric8/java-centos-openjdk8-jdk:1.5.6</from>
+                    <from>eclipse-temurin:17-jre-alpine</from>
                     <assembly>
                       <name>my-project-assembly</name>
                       <inline>


### PR DESCRIPTION
`fabric8/java-centos-openjdk8-jdk:1.5.6` is used by three ITs and two samples. It is also what made the CI flake on my last two PRs — both runs died fetching exactly this image from Docker Hub:

- #1952 — `Get "https://registry-1.docker.io/v2/": context deadline exceeded`
- #1953 — `500 Internal Server Error … s3aws: RequestError … connection reset by peer`

That is not something a retry strategy fixes, and the image itself gives little reason to keep it:

| | `fabric8/java-centos-openjdk8-jdk:1.5.6` | `eclipse-temurin:17-jre-alpine` |
|---|---|---|
| Tag last built | **2019-04-06** | 2026-06-22 |
| Repository last updated | 2021-11-04 (abandoned) | actively maintained |
| Base OS | CentOS (**EOL**) | Alpine |
| Size | **162 MB** | **68 MB** |

## Why eclipse-temurin

This is where the repository has already been heading — `it/helloworld` uses `eclipse-temurin:21-jre-alpine`, and `it/buildx` and `samples/multi-architecture` use `azul/zulu-openjdk-alpine:17-jre`. These six references are the leftovers.

**17 rather than 21** because the ITs run Spring Boot 2.7.9 (`spring-boot-with-jib`) and 2.3.3 (`multi-assembly`); 17 is inside Spring Boot 2.7's supported range, 21 is not.

None of these images depend on the fabric8 conventions (`/deployments`, `run-java.sh`) — they set their own `<cmd>java -jar …</cmd>`, so all they need is `java` on the PATH. `build-pom-packaging` does not even start a container.

## Verified locally against Docker 29.6.2

```
cd it/ && mvn clean install -pl build-pom-packaging,spring-boot-with-jib,multi-assembly

[INFO] dmp-it-build-pom-packaging ......................... SUCCESS [01:49 min]
[INFO] dmp-multi-assembly ................................. SUCCESS [05:27 min]
[INFO] dmp-it-spring-boot-jib ............................. SUCCESS [03:38 min]
[INFO] BUILD SUCCESS
```

`multi-assembly` is the interesting one, since it actually runs the image — it built, started, matched its log and stopped cleanly on Java 17:

```
DOCKER> [fabric8/dmp-multi-assembly:latest]: Start container 7928f6ffc90d
DOCKER> Pattern 'Hello from Spring Boot!' matched for container 7928f6ffc90d
DOCKER> [fabric8/dmp-multi-assembly:latest]: Waited on log out 'Hello from Spring Boot!' 17104 ms
DOCKER> [fabric8/dmp-multi-assembly:latest]: Stop and removed container 7928f6ffc90d after 0 ms
```

So Spring Boot 2.3.3 on a 17 JRE is fine here in practice, and no per-module exception is needed.

## A note on the sample READMEs

`samples/multi-assembly/README.md` has the image in two `<build>` snippets that document the configuration — those are updated so the docs match the pom. The remaining occurrences are captured build/JIB output from an actual run; rewriting recorded output to show an image that never produced it would be inventing logs, so those are left as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
