### PR TITLE
Avoid container name conflicts after image rebuilds

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -145,7 +145,7 @@ public class RunService {
         RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
         String imageName = imageConfig.getName();
 
-        Collection<Container> existingContainers = queryService.getContainersForImage(imageName, true);
+        Collection<Container> existingContainers = queryService.listContainers(true);
         String containerName = ContainerNamingUtil
                 .formatContainerName(imageConfig, defaultContainerNamePattern, buildTimestamp, existingContainers);
 

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -262,6 +262,30 @@ class RunServiceTest {
     }
 
     @Test
+    void createContainerUsesNamesFromAllExistingContainers(@Mock Container existingContainer, @Mock PortMapping portMapping)
+        throws DockerAccessException {
+
+        Mockito.doReturn("reproduce-container-name-conflict-1").when(existingContainer).getName();
+        Mockito.doReturn(Collections.singletonList(existingContainer)).when(queryService).listContainers(true);
+        Mockito.doReturn("containerId")
+            .when(docker).createContainer(Mockito.any(ContainerCreateConfig.class), Mockito.anyString());
+
+        ImageConfiguration imageConfiguration = new ImageConfiguration.Builder()
+            .name("localhost/reproduce-container-name-conflict:latest")
+            .runConfig(new RunImageConfiguration())
+            .build();
+
+        String containerId = runService.createContainer(imageConfiguration, portMapping, null, properties,
+            getBaseDirectory(), "%n-%i", new Date());
+
+        Assertions.assertEquals("containerId", containerId);
+        Mockito.verify(docker).createContainer(Mockito.any(ContainerCreateConfig.class),
+            Mockito.eq("reproduce-container-name-conflict-2"));
+        Mockito.verify(queryService).listContainers(true);
+        Mockito.verify(queryService, Mockito.never()).getContainersForImage(Mockito.anyString(), Mockito.anyBoolean());
+    }
+
+    @Test
     void testStopModeWithKill() throws DockerAccessException, ExecException {
         long start = System.currentTimeMillis();
         runService.stopContainer(container, createImageConfigWithStopMode(), false, false);


### PR DESCRIPTION
## Summary

- consider all existing container names when resolving `%i`
- avoid reusing an occupied name after rebuilding an image
- add a regression test for selecting the next available index

## Root cause

Container name selection only queried containers created from the current image. Rebuilding the image changed its image ID, so containers created from the previous image were omitted even though Docker container names are globally unique.

## Testing

- `mise exec java@temurin-11.0.31+11 -- ./mvnw -DskipITs -Dtest=RunServiceTest test`
- `mise exec java@temurin-11.0.31+11 -- ./mvnw -DskipITs test` (977 tests, 6 skipped)

Closes #1896

Signed-off-by: Marukome0743 <jambalaya.pyoncafe@gmail.com>