### PR TITLE
Replace direct stack trace output with managed error handling

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
+++ b/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java
@@ -429,7 +429,6 @@ public class DockerAssemblyManager {
         } catch (IOException e) {
             throw new MojoExecutionException("Cannot create archive " + archive, e);
         } catch (RuntimeException e) {
-            e.printStackTrace();
             throw e;
         }
     }

--- a/src/main/java/io/fabric8/maven/docker/util/AnsiLogger.java
+++ b/src/main/java/io/fabric8/maven/docker/util/AnsiLogger.java
@@ -84,7 +84,7 @@ public class AnsiLogger implements Logger, Closeable {
         try {
             initializePrintWriter();
         } catch (FileNotFoundException e) {
-            e.printStackTrace();
+            log.error(prefix + "Cannot write log output to " + outputFile, e);
         }
     }
 

--- a/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyManagerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/assembly/DockerAssemblyManagerTest.java
@@ -243,6 +243,25 @@ class DockerAssemblyManagerTest {
         verifyArchiveManager();
     }
 
+    @Test
+    void archiveCreationPropagatesRuntimeException() throws IOException, NoSuchArchiverException {
+        MojoParameters mojoParams = mockMojoParams(mockMavenProject());
+        BuildImageConfiguration buildImageConfiguration = new BuildImageConfiguration.Builder()
+            .dockerFile(DockerAssemblyManagerTest.class.getResource("/docker/Dockerfile.test").getPath())
+            .build();
+        buildImageConfiguration.initAndValidate(logger);
+        RuntimeException failure = new IllegalStateException("Archive creation failed");
+
+        Mockito.doReturn(tarArchiver).when(archiverManager).getArchiver("tar");
+        Mockito.doThrow(failure).when(tarArchiver).createArchive();
+
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class,
+            () -> assemblyManager.createDockerTarArchive(
+                "test_image", mojoParams, buildImageConfiguration, logger, null));
+
+        Assertions.assertSame(failure, thrown);
+    }
+
     private void verifyArchiveManager() {
         List<FileSet> fileSets = getFileSetsToVerify(2);
         Assertions.assertEquals("build", fileSets.get(0).getDirectory().getName());

--- a/src/test/java/io/fabric8/maven/docker/util/AnsiLoggerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AnsiLoggerTest.java
@@ -23,12 +23,26 @@ import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.fusesource.jansi.Ansi;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
 
 /**
  * @author roland
  * @since 07/10/16
  */
 class AnsiLoggerTest {
+
+    @Test
+    void logOutputInitializationFailureUsesMavenLogger(@TempDir Path temporaryDirectory) {
+        TestLog testLog = new TestLog();
+
+        new AnsiLogger(testLog, false, null, false, "T>", temporaryDirectory.toFile());
+
+        Assertions.assertEquals("T>Cannot write log output to " + temporaryDirectory, testLog.getMessage());
+        Assertions.assertInstanceOf(FileNotFoundException.class, testLog.getThrowable());
+    }
 
     @Test
     void emphasizeDebug() {
@@ -198,6 +212,7 @@ class AnsiLoggerTest {
 
     private class TestLog extends DefaultLog {
         private String message;
+        private Throwable throwable;
 
         public TestLog() {
             super(new ConsoleLogger());
@@ -227,12 +242,24 @@ class AnsiLoggerTest {
             super.error(content);
         }
 
+        @Override
+        public void error(CharSequence content, Throwable error) {
+            this.message = content.toString();
+            this.throwable = error;
+            super.error(content, error);
+        }
+
         void reset() {
             message = null;
+            throwable = null;
         }
 
         public String getMessage() {
             return message;
+        }
+
+        public Throwable getThrowable() {
+            return throwable;
         }
     }
 


### PR DESCRIPTION

## Summary

- route AnsiLogger output-file initialization failures through Maven logging
- remove duplicate direct stack trace output before archive exceptions are rethrown
- add regression coverage for both failure paths

## Root cause

Two production exception handlers called printStackTrace() directly. This bypassed the managed Maven logging path and triggered Sonar java:S4507 security hotspots.

## Behavior

Output-file initialization still remains non-fatal, but the original FileNotFoundException is now passed to the Maven Log implementation. Archive creation runtime exceptions continue to propagate unchanged, without being printed a second time.

There are no public API or normal-path behavior changes.

## Verification

- mise exec java@temurin-11.0.31+11 -- ./mvnw -DskipITs -Dtest=AnsiLoggerTest,DockerAssemblyManagerTest test (28 tests, 0 failures)
- mise exec java@temurin-11.0.31+11 -- ./mvnw -DskipITs test (978 tests, 0 failures, 6 skipped)
