### PR TITLE
chore: Preparations for Release/0.49.0

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,16 @@
   - Normalize empty `<args>` build argument values (e.g. from a property that resolves to an empty value) to an empty string instead of failing the build ([#1858](https://github.com/fabric8io/docker-maven-plugin/issues/1858))
   - Fall back to the current timestamp instead of crashing the log-follow thread when a container log line has an unparseable timestamp (e.g. `Error` written on stderr) ([#1428](https://github.com/fabric8io/docker-maven-plugin/issues/1428))
   - Pass externally-resolved build args (`docker.buildArg.*` system/Maven properties and other `BuildArgResolver` sources) to buildx `build` and `push`, so buildx honours them like the classic build path instead of only `<build><args>` ([#1901](https://github.com/fabric8io/docker-maven-plugin/issues/1901))
+  - Add a `wslc://` Docker transport so images can be built against a WSL Containers daemon, which exposes no Windows named pipe or TCP port and is reachable only via a stdio bridge, including auto-detection below the Docker/Podman named pipe ([#1928](https://github.com/fabric8io/docker-maven-plugin/issues/1928))
+  - Add support for the `--target` parameter in the build phase, for both classic and buildx builds ([#1908](https://github.com/fabric8io/docker-maven-plugin/pull/1908))
+  - Add `docker.ecr.endpoint` system property so ECR authentication can be pointed at a VPC endpoint instead of the default `api.ecr.<region>.amazonaws.com` host ([#1872](https://github.com/fabric8io/docker-maven-plugin/issues/1872))
+  - Keep the default value for a repeated build argument in multistage builds ([#1910](https://github.com/fabric8io/docker-maven-plugin/pull/1910))
+  - Only apply a Docker Compose wait config to a service when its alias matches the image configuration alias ([#1902](https://github.com/fabric8io/docker-maven-plugin/pull/1902))
+  - Avoid container name conflicts after an image is rebuilt ([#1958](https://github.com/fabric8io/docker-maven-plugin/pull/1958))
+  - Harden ECR authentication: validate the decoded credential split instead of throwing `ArrayIndexOutOfBoundsException` on input without a colon, and replace the shared `SimpleDateFormat` with a thread-safe `DateTimeFormatter`
+  - Use an ephemeral random password for the in-memory Docker TLS `KeyStore` instead of a hard-coded one
+  - Various Sonar-flagged reliability fixes in the socket, log-streaming and file-handling paths, including closing sockets and readers via try-with-resources and re-interrupting the current thread when catching `InterruptedException`
+  - Bump Jnr JFFI to v1.3.15
 
 * **0.48.1 (2026-02-07)**:
   - Use wait config if no Docker Compose healthcheck ([1771](https://github.com/fabric8io/docker-maven-plugin/issues/1771))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,4 +1,4 @@
-* **0.49-SNAPSHOT**:
+* **0.49.0 (2026-08-09)**:
   - Fix `docker.save.aliases`: a non-existent alias in the list was silently ignored instead of failing the save with a clear error
   - Make container log streaming (`<wait><log>` and log following) resilient to transient stream disconnects by reconnecting and resuming instead of aborting, fixing flaky log-wait timeouts (e.g. `jnr ... Bad file descriptor` on macOS CI)
   - Honour the `<follow>` configuration element (in addition to the `docker.follow` system property) for `docker:start`, `docker:run` and `docker:watch` ([#1797](https://github.com/fabric8io/docker-maven-plugin/issues/1797))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,5 @@
+* **0.50-SNAPSHOT**:
+
 * **0.49.0 (2026-08-09)**:
   - Fix `docker.save.aliases`: a non-existent alias in the list was silently ignored instead of failing the save with a clear error
   - Make container log streaming (`<wait><log>` and log following) resilient to transient stream disconnects by reconnecting and resuming instead of aborting, fixing flaky log-wait timeouts (e.g. `jnr ... Bad file descriptor` on macOS CI)

--- a/it/build-pom-packaging/pom.xml
+++ b/it/build-pom-packaging/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-build-pom-packaging</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>pom</packaging>
 
   <description>Docker Maven Plugin Integration Test - pom packaging and plugin which use dependencies collections</description>

--- a/it/build-pom-packaging/pom.xml
+++ b/it/build-pom-packaging/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-build-pom-packaging</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <description>Docker Maven Plugin Integration Test - pom packaging and plugin which use dependencies collections</description>

--- a/it/builder/app-image/pom.xml
+++ b/it/builder/app-image/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-builder-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmp-it-builder-app-image</artifactId>

--- a/it/builder/app-image/pom.xml
+++ b/it/builder/app-image/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-builder-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
   </parent>
 
   <artifactId>dmp-it-builder-app-image</artifactId>

--- a/it/builder/app/pom.xml
+++ b/it/builder/app/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-builder-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
   </parent>
 
   <artifactId>dmp-it-builder-app</artifactId>

--- a/it/builder/app/pom.xml
+++ b/it/builder/app/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-builder-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmp-it-builder-app</artifactId>

--- a/it/builder/builder-image/pom.xml
+++ b/it/builder/builder-image/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-builder-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
   </parent>
 
   <artifactId>dmp-it-builder-builder-image</artifactId>

--- a/it/builder/builder-image/pom.xml
+++ b/it/builder/builder-image/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-builder-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
   </parent>
 
   <artifactId>dmp-it-builder-builder-image</artifactId>

--- a/it/builder/pom.xml
+++ b/it/builder/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/builder/pom.xml
+++ b/it/builder/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-contextdir/pom.xml
+++ b/it/buildx-contextdir/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-contextdir/pom.xml
+++ b/it/buildx-contextdir/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-dependencyset/pom.xml
+++ b/it/buildx-dependencyset/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-dependencyset/pom.xml
+++ b/it/buildx-dependencyset/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-dockerfile-secret/pom.xml
+++ b/it/buildx-dockerfile-secret/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-dockerfile-secret/pom.xml
+++ b/it/buildx-dockerfile-secret/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-dockerfile/pom.xml
+++ b/it/buildx-dockerfile/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-dockerfile/pom.xml
+++ b/it/buildx-dockerfile/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-dockerfile_and_contextdir/pom.xml
+++ b/it/buildx-dockerfile_and_contextdir/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-dockerfile_and_contextdir/pom.xml
+++ b/it/buildx-dockerfile_and_contextdir/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-driver-opt/pom.xml
+++ b/it/buildx-driver-opt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-driver-opt/pom.xml
+++ b/it/buildx-driver-opt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-push/pom.xml
+++ b/it/buildx-push/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-push/pom.xml
+++ b/it/buildx-push/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-target/pom.xml
+++ b/it/buildx-target/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx-target/pom.xml
+++ b/it/buildx-target/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx/pom.xml
+++ b/it/buildx/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/buildx/pom.xml
+++ b/it/buildx/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/docker-compose-dependon/pom.xml
+++ b/it/docker-compose-dependon/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-docker-compose-dependon</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
 
   <build>
     <plugins>

--- a/it/docker-compose-dependon/pom.xml
+++ b/it/docker-compose-dependon/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-docker-compose-dependon</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/docker-compose/pom.xml
+++ b/it/docker-compose/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-docker-compose</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/it/docker-compose/pom.xml
+++ b/it/docker-compose/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-docker-compose</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/it/dockerfile-base-as-arg-buildconfig/pom.xml
+++ b/it/dockerfile-base-as-arg-buildconfig/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-dockerfile-base-as-arg-buildconfig</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <name>dmp-it-dockerfile-base-as-arg-buildconfig</name>
 
   <build>

--- a/it/dockerfile-base-as-arg-buildconfig/pom.xml
+++ b/it/dockerfile-base-as-arg-buildconfig/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-dockerfile-base-as-arg-buildconfig</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <name>dmp-it-dockerfile-base-as-arg-buildconfig</name>
 
   <build>

--- a/it/dockerfile-base-as-arg/pom.xml
+++ b/it/dockerfile-base-as-arg/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-dockerfile-base-as-arg</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>war</packaging>
   <name>dmp-it-dockerfile</name>
 

--- a/it/dockerfile-base-as-arg/pom.xml
+++ b/it/dockerfile-base-as-arg/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-dockerfile-base-as-arg</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>dmp-it-dockerfile</name>
 

--- a/it/dockerfile-push-build-arg-from/pom.xml
+++ b/it/dockerfile-push-build-arg-from/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dockerfile-push-build-arg-from</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <name>dmp-it-dockerfile-build-arg-from</name>
 
   <properties>

--- a/it/dockerfile-push-build-arg-from/pom.xml
+++ b/it/dockerfile-push-build-arg-from/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dockerfile-push-build-arg-from</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <name>dmp-it-dockerfile-build-arg-from</name>
 
   <properties>

--- a/it/dockerfile-target/pom.xml
+++ b/it/dockerfile-target/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/dockerfile-target/pom.xml
+++ b/it/dockerfile-target/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/dockerfile/pom.xml
+++ b/it/dockerfile/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dockerfile</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>war</packaging>
   <name>dmp-it-dockerfile</name>
 

--- a/it/dockerfile/pom.xml
+++ b/it/dockerfile/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dockerfile</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>dmp-it-dockerfile</name>
 

--- a/it/dockerignore/pom.xml
+++ b/it/dockerignore/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-dockerignore</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/it/dockerignore/pom.xml
+++ b/it/dockerignore/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-dockerignore</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>docker-build</packaging>
 
   <build>

--- a/it/graceful-container-removal/pom.xml
+++ b/it/graceful-container-removal/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/graceful-container-removal/pom.xml
+++ b/it/graceful-container-removal/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/it/healthcheck/pom.xml
+++ b/it/healthcheck/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-healthcheck</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/healthcheck/pom.xml
+++ b/it/healthcheck/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-healthcheck</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
 
   <build>
     <plugins>

--- a/it/helloworld/pom.xml
+++ b/it/helloworld/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-helloworld</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>dmp-it-helloworld</name>
 

--- a/it/helloworld/pom.xml
+++ b/it/helloworld/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-helloworld</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>jar</packaging>
   <name>dmp-it-helloworld</name>
 

--- a/it/log/pom.xml
+++ b/it/log/pom.xml
@@ -13,13 +13,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.fabric8</groupId>
   <artifactId>dmp-it-log</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/log/pom.xml
+++ b/it/log/pom.xml
@@ -13,13 +13,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.fabric8</groupId>
   <artifactId>dmp-it-log</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
 
   <build>
     <plugins>

--- a/it/multi-assembly/pom.xml
+++ b/it/multi-assembly/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-multi-assembly</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <description>Docker Maven Plugin Integration Test with Spring Boot with Multiple Layers</description>

--- a/it/multi-assembly/pom.xml
+++ b/it/multi-assembly/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-multi-assembly</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>jar</packaging>
 
   <description>Docker Maven Plugin Integration Test with Spring Boot with Multiple Layers</description>

--- a/it/net/pom.xml
+++ b/it/net/pom.xml
@@ -16,12 +16,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-net</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <build>
     <plugins>
       <plugin>

--- a/it/net/pom.xml
+++ b/it/net/pom.xml
@@ -16,12 +16,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-net</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <build>
     <plugins>
       <plugin>

--- a/it/platform-run/pom.xml
+++ b/it/platform-run/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-platform-run</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
 
   <build>
     <plugins>

--- a/it/platform-run/pom.xml
+++ b/it/platform-run/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-platform-run</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -15,7 +15,7 @@
 
   <groupId>io.fabric8.dmp.itests</groupId>
   <artifactId>dmp-it-parent</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -15,7 +15,7 @@
 
   <groupId>io.fabric8.dmp.itests</groupId>
   <artifactId>dmp-it-parent</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/it/properties/pom.xml
+++ b/it/properties/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-properties</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>docker-build</packaging>
 
   <properties>

--- a/it/properties/pom.xml
+++ b/it/properties/pom.xml
@@ -10,12 +10,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-properties</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>docker-build</packaging>
 
   <properties>

--- a/it/run-java/pom.xml
+++ b/it/run-java/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.fabric8.dmp.itests</groupId>
   <artifactId>dmp-it-run-java</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <build>

--- a/it/run-java/pom.xml
+++ b/it/run-java/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.fabric8.dmp.itests</groupId>
   <artifactId>dmp-it-run-java</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>jar</packaging>
 
   <build>

--- a/it/smallest/pom.xml
+++ b/it/smallest/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>fabric8io</groupId>
   <artifactId>dmp-it-smallest</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
 
   <build>
     <plugins>

--- a/it/smallest/pom.xml
+++ b/it/smallest/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>fabric8io</groupId>
   <artifactId>dmp-it-smallest</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/spring-boot-with-jib/pom.xml
+++ b/it/spring-boot-with-jib/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-spring-boot-jib</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>jar</packaging>
 
   <description>Docker Maven Plugin Integration test with Spring Boot With Build Mode JIB</description>

--- a/it/spring-boot-with-jib/pom.xml
+++ b/it/spring-boot-with-jib/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-spring-boot-jib</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <description>Docker Maven Plugin Integration test with Spring Boot With Build Mode JIB</description>

--- a/it/volume/pom.xml
+++ b/it/volume/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-volume</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
 
   <build>
     <plugins>

--- a/it/volume/pom.xml
+++ b/it/volume/pom.xml
@@ -15,12 +15,12 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>dmp-it-volume</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
 
   <build>
     <plugins>

--- a/it/windows-build/pom.xml
+++ b/it/windows-build/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>fabric8io</groupId>
   <artifactId>dmp-it-windows-build</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
 
   <profiles>
     <profile>

--- a/it/windows-build/pom.xml
+++ b/it/windows-build/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>fabric8io</groupId>
   <artifactId>dmp-it-windows-build</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
 
   <profiles>
     <profile>

--- a/it/zero-config/pom.xml
+++ b/it/zero-config/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.fabric8.dmp.itests</groupId>
   <artifactId>dmp-it-zero-config</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/it/zero-config/pom.xml
+++ b/it/zero-config/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>io.fabric8.dmp.itests</groupId>
     <artifactId>dmp-it-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>io.fabric8.dmp.itests</groupId>
   <artifactId>dmp-it-zero-config</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>io.fabric8.dmp</groupId>
   <artifactId>parent</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>io.fabric8.dmp</groupId>
   <artifactId>parent</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.49.0</version>
+  <version>0.50-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>docker-maven-plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.49-SNAPSHOT</version>
+  <version>0.49.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>docker-maven-plugin</name>
@@ -80,7 +80,7 @@
     <maven.version>3.8.8</maven.version>
     <minimum.maven.version>3.3.9</minimum.maven.version>
     <mockito.version>4.11.0</mockito.version>
-    <project.build.outputTimestamp>2026-02-07T16:06:37Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-08-09T15:42:48Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire.version>3.5.3</surefire.version>
     <system-stubs.version>2.0.3</system-stubs.version>

--- a/samples/build-cache/app/pom.xml
+++ b/samples/build-cache/app/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples.build-cache</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
   </parent>
 
   <artifactId>app</artifactId>

--- a/samples/build-cache/app/pom.xml
+++ b/samples/build-cache/app/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples.build-cache</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
   </parent>
 
   <artifactId>app</artifactId>

--- a/samples/build-cache/image/pom.xml
+++ b/samples/build-cache/image/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples.build-cache</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
   </parent>
 
   <artifactId>image</artifactId>

--- a/samples/build-cache/image/pom.xml
+++ b/samples/build-cache/image/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples.build-cache</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
   </parent>
 
   <artifactId>image</artifactId>

--- a/samples/build-cache/pom.xml
+++ b/samples/build-cache/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/build-cache/pom.xml
+++ b/samples/build-cache/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/cargo-jolokia/pom.xml
+++ b/samples/cargo-jolokia/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/cargo-jolokia/pom.xml
+++ b/samples/cargo-jolokia/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/copy-from-container/pom.xml
+++ b/samples/copy-from-container/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/copy-from-container/pom.xml
+++ b/samples/copy-from-container/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/custom-net/pom.xml
+++ b/samples/custom-net/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/data-jolokia/pom.xml
+++ b/samples/data-jolokia/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/data-jolokia/pom.xml
+++ b/samples/data-jolokia/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/docker-compose/pom.xml
+++ b/samples/docker-compose/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/docker-compose/pom.xml
+++ b/samples/docker-compose/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/dockerfile/pom.xml
+++ b/samples/dockerfile/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/dockerfile/pom.xml
+++ b/samples/dockerfile/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/dockerignore/pom.xml
+++ b/samples/dockerignore/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/dockerignore/pom.xml
+++ b/samples/dockerignore/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/healthcheck/pom.xml
+++ b/samples/healthcheck/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/healthcheck/pom.xml
+++ b/samples/healthcheck/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/helloworld/pom.xml
+++ b/samples/helloworld/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/helloworld/pom.xml
+++ b/samples/helloworld/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/log/pom.xml
+++ b/samples/log/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/log/pom.xml
+++ b/samples/log/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/multi-architecture/pom.xml
+++ b/samples/multi-architecture/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/multi-architecture/pom.xml
+++ b/samples/multi-architecture/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/multi-assembly/pom.xml
+++ b/samples/multi-assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/multi-assembly/pom.xml
+++ b/samples/multi-assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/multi-wait/pom.xml
+++ b/samples/multi-wait/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/multi-wait/pom.xml
+++ b/samples/multi-wait/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/net/pom.xml
+++ b/samples/net/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/net/pom.xml
+++ b/samples/net/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>io.fabric8.dmp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>io.fabric8.dmp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -41,7 +41,7 @@
   </modules>
 
   <properties>
-    <latest-released-version>0.48.1</latest-released-version>
+    <latest-released-version>0.49.0</latest-released-version>
   </properties>
 
   <build>

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/properties/pom.xml
+++ b/samples/properties/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/run-java/pom.xml
+++ b/samples/run-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/run-java/pom.xml
+++ b/samples/run-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/smallest/pom.xml
+++ b/samples/smallest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/smallest/pom.xml
+++ b/samples/smallest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/spring-boot-with-jib/pom.xml
+++ b/samples/spring-boot-with-jib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/spring-boot-with-jib/pom.xml
+++ b/samples/spring-boot-with-jib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/volume/pom.xml
+++ b/samples/volume/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/volume/pom.xml
+++ b/samples/volume/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/zero-config/pom.xml
+++ b/samples/zero-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49-SNAPSHOT</version>
+    <version>0.49.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/samples/zero-config/pom.xml
+++ b/samples/zero-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>dmp-sample-parent</artifactId>
-    <version>0.49.0</version>
+    <version>0.50-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Description

This PR prepares the project for releasing **v0.49.0**.

### Commit 1: Backfill changelog
Nine user-facing changes had landed on `master` since `v0.48.1` without a changelog entry. Backfilled so the release notes are complete:

- `wslc://` transport ([#1928](https://github.com/fabric8io/docker-maven-plugin/pull/1928))
- `--target` parameter support ([#1908](https://github.com/fabric8io/docker-maven-plugin/pull/1908))
- `docker.ecr.endpoint` for VPC endpoints ([#1913](https://github.com/fabric8io/docker-maven-plugin/pull/1913))
- Repeated build arg default in multistage builds ([#1910](https://github.com/fabric8io/docker-maven-plugin/pull/1910))
- Compose wait config alias match ([#1902](https://github.com/fabric8io/docker-maven-plugin/pull/1902))
- Container name conflicts after rebuild ([#1958](https://github.com/fabric8io/docker-maven-plugin/pull/1958))
- ECR auth hardening and ephemeral in-memory KeyStore password
- Jnr JFFI bump to v1.3.15

### Commit 2: Update project for release
- Update project version to **0.49.0** in all `pom.xml` files.
- Update versions in **it/** and **samples/** directories from **0.49-SNAPSHOT** → **0.49.0**.
- Update **doc/changelog.md** with the `0.49.0 (2026-08-09)` release header.
- Set **&lt;latest-released-version&gt;** in `samples/pom.xml` to **0.49.0**.

### Commit 3: Prepare next development iteration
- Update project version to **0.50-SNAPSHOT** in all `pom.xml` files.
- Update versions in **it/** and **samples/** directories from **0.49.0** → **0.50-SNAPSHOT**.
- Add new changelog section for **0.50-SNAPSHOT**.

### Verification
- `mvn -B -DskipTests package` → BUILD SUCCESS
- All 8 CI workflows green on the base commit `fbc53d30`
- `samples/pom.xml` correctly retains `<latest-released-version>0.49.0</latest-released-version>` while its parent version moves to `0.50-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
