### PR TITLE
fix: Update central-publishing-maven-plugin to 0.11.0 to fix release job failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
   <properties>
     <byte-buddy.version>1.12.10</byte-buddy.version>
-    <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     <guava.version>32.1.2-jre</guava.version>
     <httpclient.version>4.5.13</httpclient.version>
     <jib-core.version>0.27.3</jib-core.version>


### PR DESCRIPTION
## Description

Updates `central-publishing-maven-plugin` from **0.7.0** to **0.11.0**.

The v0.49.0 release run ([run 31326872248](https://github.com/fabric8io/docker-maven-plugin/actions/runs/31326872248)) uploaded its bundle successfully, then failed while polling for the deployment state:

```
[INFO] Uploaded bundle successfully, deployment name: Deployment,
       deploymentId: 377c8246-5eac-4681-99bc-50d4e12b8a48.
       Deployment will require manual publishing
[INFO] Waiting until Deployment 377c8246-... is validated
[ERROR] UnrecognizedPropertyException: Unrecognized field "warnings"
        (class DeploymentApiResponse, 6 known properties: "deploymentId",
        "purls", "cherryBomUrl", "errors", "deploymentState", "deploymentName")
```

## Root cause

The Central Portal status API now returns a `warnings` field. `DeploymentApiResponse` in the 0.7.0 publisher client declares exactly the six properties listed in the error and does not ignore unknown ones, so Jackson throws while deserializing the status response.

Comparing the class across plugin versions confirms the fix:

| Plugin | Fields on `DeploymentApiResponse` |
|---|---|
| 0.7.0 | `deploymentId`, `deploymentName`, `deploymentState`, `purls`, `errors`, `cherryBomUrl` |
| 0.11.0 | `deploymentId`, `deploymentName`, `deploymentState`, `purls`, `errors`, **`warnings`** |

0.7.0's six fields match the error message exactly; 0.11.0 carries `warnings`.

## Impact

The failure was confined to the post-upload status watch — the upload itself, and the artifacts, were unaffected. v0.49.0 was published from the Central Portal without needing a re-run and is live on Maven Central.

Without this bump, every release will red-fail after a successful upload, which makes a working release look broken.

## Notes

- Build-tooling only; no runtime or user-facing behaviour changes, so no changelog entry (consistent with how JaCoCo and similar build-plugin bumps are handled).
- 0.11.0 targets Java 8, so it remains compatible with the Java 11 used by `release.yml`.
- `mvn -B -Prelease validate` passes with the new version.
- `<autoPublish>false</autoPublish>` is unchanged — publishing still requires the manual step in the Central Portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
