### PR TITLE
Add unit tests for AnsiLogger progress, file output and formatting

### DIFF
--- a/src/test/java/io/fabric8/maven/docker/util/AnsiLoggerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/util/AnsiLoggerTest.java
@@ -18,21 +18,56 @@ package io.fabric8.maven.docker.util;
 
 
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.apache.maven.monitor.logging.DefaultLog;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.fusesource.jansi.Ansi;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import java.io.FileNotFoundException;
-import java.nio.file.Path;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
 
 /**
  * @author roland
  * @since 07/10/16
  */
+@ExtendWith(SystemStubsExtension.class)
 class AnsiLoggerTest {
+
+    @SystemStub
+    private SystemOut systemOut;
+
+    @TempDir
+    private Path tempDir;
+
+    // AnsiLogger's constructor calls Ansi.setEnabled(), which is global state shared by every test
+    // in the JVM, so it has to be put back the way it was found.
+    private boolean ansiRestore;
+
+    @BeforeEach
+    void rememberAnsiState() {
+        ansiRestore = Ansi.isEnabled();
+    }
+
+    @AfterEach
+    void restoreAnsiState() {
+        Ansi.setEnabled(ansiRestore);
+    }
 
     @Test
     void logOutputInitializationFailureUsesMavenLogger(@TempDir Path temporaryDirectory) {
@@ -209,6 +244,356 @@ class AnsiLoggerTest {
                      testLog.getMessage());
     }
 
+
+    // ---------------------------------------------------------------------------------------------
+    // Progress bar
+    //
+    // These write straight to System.out, so they use QuietLog rather than TestLog: TestLog delegates
+    // to a ConsoleLogger, which would print "[INFO] ..." into the very stream being captured.
+
+    @Test
+    void progressStartWritesNothingItself() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>");
+
+        logger.progressStart();
+
+        Assertions.assertEquals("", systemOut.getText());
+    }
+
+    @Test
+    void progressUpdateAnsiPrintsColouredLineForNewLayer() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>");
+        logger.progressStart();
+
+        logger.progressUpdate("l1", "Downloading", "[===>   ]");
+
+        String expected = Ansi.ansi()
+            .fg(AnsiLogger.COLOR_PROGRESS_ID).a("l1").reset().a(": ")
+            .fg(AnsiLogger.COLOR_PROGRESS_STATUS).a("Downloading ")
+            .fg(AnsiLogger.COLOR_PROGRESS_BAR).a("[===>   ]").toString();
+        Assertions.assertEquals(expected + System.lineSeparator(), systemOut.getText());
+    }
+
+    @Test
+    void progressUpdateAnsiMovesTheCursorForAKnownLayer() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>");
+        logger.progressStart();
+        logger.progressUpdate("l1", "Downloading", "[===>   ]");
+        systemOut.clear();
+
+        // Second update for the same layer: the line already exists, so the cursor is moved up over
+        // it, the line is redrawn and the cursor moved back down again.
+        logger.progressUpdate("l1", "Extracting", "[=====> ]");
+
+        String output = systemOut.getText();
+        Assertions.assertTrue(output.startsWith(Ansi.ansi().cursorUp(1).eraseLine(Ansi.Erase.ALL).toString()),
+            "Expected the cursor to be moved up over the existing line, but got: " + output);
+        Assertions.assertTrue(output.endsWith(Ansi.ansi().cursorDown(0).toString()),
+            "Expected the cursor to be moved back down, but got: " + output);
+    }
+
+    @Test
+    void progressUpdateAnsiTreatsAMissingProgressMessageAsEmpty() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>");
+        logger.progressStart();
+
+        logger.progressUpdate("l1", "Extracting", null);
+
+        String expected = Ansi.ansi()
+            .fg(AnsiLogger.COLOR_PROGRESS_ID).a("l1").reset().a(": ")
+            .fg(AnsiLogger.COLOR_PROGRESS_STATUS).a("Extracting  ")
+            .fg(AnsiLogger.COLOR_PROGRESS_BAR).a("").toString();
+        Assertions.assertEquals(expected + System.lineSeparator(), systemOut.getText());
+    }
+
+    @Test
+    void progressFinishedAnsiResetsTheColour() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>");
+        logger.progressStart();
+        systemOut.clear();
+
+        logger.progressFinished();
+
+        Assertions.assertEquals(Ansi.ansi().reset().toString(), systemOut.getText());
+    }
+
+    @Test
+    void progressUpdateWithoutAnsiPrintsAHashPerPeriod() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), false, null, false, "T>");
+        logger.progressStart();
+
+        // Only the first update of each period prints, so two updates still produce a single hash.
+        logger.progressUpdate("l1", "Downloading", "ignored");
+        logger.progressUpdate("l1", "Downloading", "ignored");
+
+        Assertions.assertEquals("#", systemOut.getText());
+    }
+
+    @Test
+    void progressUpdateWithoutAnsiWrapsTheLine() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), false, null, false, "T>");
+        logger.progressStart();
+
+        // A hash every 80 updates, a line break every 80 hashes: 6401 updates is one past the wrap.
+        for (int i = 0; i <= 6400; i++) {
+            logger.progressUpdate("l1", "Downloading", "ignored");
+        }
+
+        String output = systemOut.getText();
+        Assertions.assertEquals(81, output.chars().filter(c -> c == '#').count());
+        Assertions.assertEquals(1, output.chars().filter(c -> c == '\n').count());
+    }
+
+    @Test
+    void progressFinishedWithoutAnsiEndsTheLine() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), false, null, false, "T>");
+        logger.progressStart();
+        systemOut.clear();
+
+        logger.progressFinished();
+
+        Assertions.assertEquals(System.lineSeparator(), systemOut.getText());
+    }
+
+    @Test
+    void progressIsSuppressedInBatchMode() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, true, "T>");
+
+        logger.progressStart();
+        logger.progressUpdate("l1", "Downloading", "[===>   ]");
+        logger.progressFinished();
+
+        Assertions.assertEquals("", systemOut.getText());
+    }
+
+    @Test
+    void progressIsSuppressedWhenInfoIsDisabled() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(false), true, null, false, "T>");
+
+        logger.progressStart();
+        logger.progressUpdate("l1", "Downloading", "[===>   ]");
+        logger.progressFinished();
+
+        Assertions.assertEquals("", systemOut.getText());
+    }
+
+    @Test
+    void progressUpdateIgnoresAnEmptyLayerId() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>");
+        logger.progressStart();
+
+        logger.progressUpdate("", "Downloading", "[===>   ]");
+        logger.progressUpdate(null, "Downloading", "[===>   ]");
+
+        Assertions.assertEquals("", systemOut.getText());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Output file
+
+    @Test
+    void writesPlainMessagesToTheOutputFile() throws IOException {
+        File outputFile = tempDir.resolve("build.log").toFile();
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>", outputFile);
+
+        logger.info("Info %s", "message");
+        logger.warn("Warn message");
+        logger.error("Error message");
+        // PrintWriter buffers, so nothing reaches the file until the logger is closed.
+        logger.close();
+
+        // Neither the prefix nor the colouring is applied on the way to the file.
+        Assertions.assertEquals(Arrays.asList("Info message", "Warn message", "Error message"),
+            Files.readAllLines(outputFile.toPath()));
+    }
+
+    @Test
+    void anOutputFileForcesBatchMode() throws IOException {
+        File outputFile = tempDir.resolve("build.log").toFile();
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>", outputFile);
+
+        logger.progressStart();
+        logger.progressUpdate("l1", "Downloading", "[===>   ]");
+        logger.progressFinished();
+        logger.close();
+
+        Assertions.assertEquals("", systemOut.getText());
+    }
+
+    @Test
+    void debugAndVerboseAlsoGoToTheOutputFile() throws IOException {
+        File outputFile = tempDir.resolve("build.log").toFile();
+        AnsiLogger logger = new AnsiLogger(new QuietLog(true, true), true, "all", false, "T>", outputFile);
+
+        logger.debug("Debug message");
+        logger.verbose(Logger.LogVerboseCategory.BUILD, "Verbose message");
+        logger.close();
+
+        Assertions.assertEquals(Arrays.asList("Debug message", "Verbose message"),
+            Files.readAllLines(outputFile.toPath()));
+    }
+
+    @Test
+    void nothingIsWrittenToTheOutputFileWhenTheLevelIsDisabled() throws IOException {
+        File outputFile = tempDir.resolve("build.log").toFile();
+        AnsiLogger logger = new AnsiLogger(new QuietLog(false), true, null, false, "T>", outputFile);
+
+        logger.info("Info message");
+        logger.close();
+
+        Assertions.assertEquals(Collections.emptyList(), Files.readAllLines(outputFile.toPath()));
+    }
+
+    @Test
+    void closeIsSafeWithoutAnOutputFile() {
+        AnsiLogger logger = new AnsiLogger(new QuietLog(), true, null, false, "T>");
+
+        Assertions.assertDoesNotThrow(logger::close);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Delegation, formatting and verbosity
+
+    @Test
+    void debugIsSuppressedWhenDisabled() {
+        TestLog testLog = new TestLog();
+
+        new AnsiLogger(testLog, true, null, false, "T>").debug("Not logged");
+
+        Assertions.assertEquals(null, testLog.getMessage());
+    }
+
+    @Test
+    void errorMessageIsColouredWithoutThePrefix() {
+        AnsiLogger logger = new AnsiLogger(new TestLog(), true, null, false, "T>");
+        Ansi ansi = new Ansi();
+
+        String message = logger.errorMessage("Boom");
+
+        Assertions.assertEquals(ansi.fg(AnsiLogger.COLOR_ERROR).a("Boom").reset().toString(), message);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "NIL, false",
+        "false, false",
+        "'', true",
+        "true, true",
+        "all, true",
+        "build, true"
+    }, nullValues = "NIL")
+    void isVerboseEnabledReflectsTheConfiguration(String verbose, boolean expected) {
+        AnsiLogger logger = new AnsiLogger(new TestLog(), false, verbose, false, "T>");
+
+        Assertions.assertEquals(expected, logger.isVerboseEnabled());
+    }
+
+    @Test
+    void aSingleThrowableParameterIsAppendedToTheMessage() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, false, null, false, "T>");
+
+        logger.info("Failed", new IllegalStateException("boom"));
+
+        Assertions.assertEquals("T>Failed: java.lang.IllegalStateException: boom", testLog.getMessage());
+    }
+
+    @Test
+    void theShorterConstructorsApplyTheDefaults() {
+        TestLog threeArgs = new TestLog();
+        TestLog fourArgs = new TestLog();
+
+        // Neither overload takes a prefix, so both fall back to the default one.
+        new AnsiLogger(threeArgs, false, null).info("Three");
+        new AnsiLogger(fourArgs, false, null, false).info("Four");
+
+        Assertions.assertEquals("DOCKER> Three", threeArgs.getMessage());
+        Assertions.assertEquals("DOCKER> Four", fourArgs.getMessage());
+    }
+
+    @Test
+    void anUnknownEmphasisColourIsDropped() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, false, null, false, "T>");
+
+        // "/" is not a colour id, so the emphasis contributes no colour at all.
+        logger.info("Unknown [[/]]colour[[/]] ids are ignored");
+
+        Assertions.assertEquals("T>Unknown colour ids are ignored", testLog.getMessage());
+    }
+
+    @Test
+    void severalParametersAreFormattedIntoTheMessage() {
+        TestLog testLog = new TestLog();
+        AnsiLogger logger = new AnsiLogger(testLog, false, null, false, "T>");
+
+        logger.info("%s-%s", "a", "b");
+
+        Assertions.assertEquals("T>a-b", testLog.getMessage());
+    }
+
+    /**
+     * A log that records nothing and, unlike {@link TestLog}, never writes to System.out - which
+     * matters for the tests that capture what AnsiLogger itself prints there.
+     */
+    private static class QuietLog extends DefaultLog {
+        private final boolean infoEnabled;
+        private final boolean debugEnabled;
+
+        QuietLog() {
+            this(true, false);
+        }
+
+        QuietLog(boolean infoEnabled) {
+            this(infoEnabled, false);
+        }
+
+        QuietLog(boolean infoEnabled, boolean debugEnabled) {
+            super(new ConsoleLogger());
+            this.infoEnabled = infoEnabled;
+            this.debugEnabled = debugEnabled;
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return debugEnabled;
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return infoEnabled;
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return infoEnabled;
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return infoEnabled;
+        }
+
+        @Override
+        public void debug(CharSequence content) {
+            // Deliberately silent
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            // Deliberately silent
+        }
+
+        @Override
+        public void warn(CharSequence content) {
+            // Deliberately silent
+        }
+
+        @Override
+        public void error(CharSequence content) {
+            // Deliberately silent
+        }
+    }
 
     private class TestLog extends DefaultLog {
         private String message;


### PR DESCRIPTION
`AnsiLogger` sat at **58.8%** line coverage — the progress bar, the output-file mode and several formatting branches had no tests at all, despite the class having no external dependencies (no Docker, no network, no Maven lifecycle) and being entirely deterministic to test.

**Tests only; no production change.**

## What is now covered

| Area | Tests |
|---|---|
| **Progress bar, ANSI** | new layer prints the coloured line; a repeated layer moves the cursor up, redraws and moves back down; a missing progress message renders as empty; `progressFinished` emits the reset |
| **Progress bar, non-ANSI** | one `#` per period; the line wrap after 80 hashes (6401 updates); `progressFinished` ends the line |
| **Progress suppression** | batch mode, info disabled, empty/null layer id — all produce no output |
| **Output file** | messages are written plain (no prefix, no colour); an output file forces batch mode; debug and verbose also land in the file; a disabled level writes nothing; `close()` is safe with and without a file |
| **Formatting / delegation** | single `Throwable` parameter appended; several parameters via `String.format`; unknown emphasis colour dropped; `errorMessage` coloured without the prefix; `isVerboseEnabled` parameterised; debug suppressed when disabled; the two shorter constructors |

## Test scaffolding worth reviewing

Two things needed care:

- **`Ansi.setEnabled()` is global state.** The `AnsiLogger` constructor always writes it, and surefire runs the whole suite in a single JVM, so it is saved in `@BeforeEach` and restored in `@AfterEach` — the same approach `LogOutputSpecTest` already uses locally.
- **The existing `TestLog` cannot be used for the progress tests.** They capture `System.out`, and `TestLog` delegates to a `ConsoleLogger` that prints `[INFO] ...` into that very stream. They use a silent `QuietLog` instead, which also makes it easy to vary `isInfoEnabled()`/`isDebugEnabled()`.

Expected ANSI output is built with the jansi builder rather than hard-coded escapes (`cursorUp`/`eraseLine` output is version-dependent), and line ends use `System.lineSeparator()` so the tests hold on Windows too.

## Result

```
./mvnw -Pjacoco -Dtest=AnsiLoggerTest test      # Temurin 21
→ AnsiLogger: 58.8% → 97% line, 92% branch

./mvnw clean install
→ Tests run: 1005, Failures: 0, Errors: 0, Skipped: 6  —  BUILD SUCCESS
```

The suite was run both on its own and as part of the full build, to confirm the `Ansi`/`System.out` handling leaks nothing into other tests.

## Deliberately left uncovered

- The `FileNotFoundException` branch of the constructor (`e.printStackTrace()`): reaching it means writing a stack trace to stderr, and it leaves the logger unusable — `pw` stays `null` while `outputFile` does not, so the next log call NPEs. Covering one line did not seem worth exercising a broken state.
- `checkBackwardVersionValues`: unreachable dead code (no caller anywhere in the tree), which #1954 removes.

## Noticed while writing these, not changed here

- `progressUpdate` before `progressStart` throws NPE: the `ThreadLocal`s have no `initialValue`. Callers in the plugin always start first, so it does not bite in practice.
- `progressFinished` removes `imageLines` but not `updateCount`, unlike `progressStart` which removes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
