### PR TITLE
Update commons-io in the Dockerfile ITs and sample

### DIFF
--- a/it/dockerfile-base-as-arg/pom.xml
+++ b/it/dockerfile-base-as-arg/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/it/dockerfile/pom.xml
+++ b/it/dockerfile/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/samples/dockerfile/pom.xml
+++ b/samples/dockerfile/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Picks up what dependabot proposed in #1829 — `commons-io` 2.7 is affected by CVE-2024-47554 — and runs it through CI, which that PR never got: its branch has no workflow runs at all, so there was nothing to judge it by.

Two differences from #1829:

- **All three copies, not one.** 2.7 is pinned in `it/dockerfile`, `it/dockerfile-base-as-arg` and `samples/dockerfile`; #1829 only touched the first. Updating one would leave two identical copies behind on the vulnerable version.
- **2.22.0 rather than 2.14.0**, which was simply the current release when #1829 was opened two years ago.

## Why this is low risk

All three modules carry the same servlet, and its entire use of the library is one call:

```java
// HelloWorldServlet.java
String txt = FileUtils.readFileToString(new File("/welcome.txt"), Charset.defaultCharset());
```

That is the charset-taking overload, so none of the deprecated no-charset methods removed later in the 2.x line apply. None of this ships with the plugin either — it is integration-test and sample code, so nothing here reaches users' builds.

## Verified against Docker 29.6.2

```
cd it/ && mvn clean install -pl dockerfile,dockerfile-base-as-arg

[INFO] dmp-it-dockerfile .................................. SUCCESS [02:25 min]
[INFO] dmp-it-dockerfile .................................. SUCCESS [ 21.841 s]
[INFO] BUILD SUCCESS
```

Both ITs build their image, start the container and stop it cleanly, and the war that goes into the image contains the new jar:

```
WEB-INF/lib/commons-io-2.22.0.jar
```

Worth noting that these ITs assert on the build/start/stop cycle rather than calling the servlet, so the `readFileToString` call itself is exercised only insofar as the app deploys and runs — the narrow API surface above is what makes that acceptable here.

If this looks right, #1829 can be closed in favour of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
