### PR TITLE
Migrate the Dockerfile ITs and sample to Jakarta EE 11 and verify the servlet answers

### DIFF
--- a/it/dockerfile-base-as-arg/pom.xml
+++ b/it/dockerfile-base-as-arg/pom.xml
@@ -34,9 +34,10 @@
       <version>2.22.0</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -65,8 +66,17 @@
               </build>
               <run>
                 <ports>
-                  <port>8080:8080</port>
+                  <port>jetty.port:8080</port>
                 </ports>
+                <wait>
+                  <!-- Fails with 404 unless the WAR is actually deployed and the servlet answers -->
+                  <http>
+                    <url>http://${docker.host.address}:${jetty.port}/</url>
+                    <method>GET</method>
+                    <status>200</status>
+                  </http>
+                  <time>60000</time>
+                </wait>
               </run>
             </image>
           </images>

--- a/it/dockerfile-base-as-arg/src/main/docker/Dockerfile
+++ b/it/dockerfile-base-as-arg/src/main/docker/Dockerfile
@@ -9,6 +9,10 @@ LABEL PROJECT_NAME=hello-world \
 # Arbitrary files can be added
 ADD ${file} /
 
+# Jetty 12 enables no deployer by default, so webapps/ would never be scanned.
+# ee11-deploy pulls in the deployment scanner plus the Jakarta EE 11 web app support.
+RUN java -jar "$JETTY_HOME/start.jar" --add-modules=ee11-deploy
+
 # In maven/ the files as specified in the <assembly> section is stored
 # and need to be added manually
 COPY maven/ /var/lib/jetty/webapps/

--- a/it/dockerfile-base-as-arg/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
+++ b/it/dockerfile-base-as-arg/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
@@ -4,10 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FileUtils;
 

--- a/it/dockerfile-base-as-arg/src/main/webapp/WEB-INF/web.xml
+++ b/it/dockerfile-base-as-arg/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="6.1" xmlns="https://jakarta.ee/xml/ns/jakartaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
 
   <servlet>
     <display-name>HelloWold</display-name>

--- a/it/dockerfile/pom.xml
+++ b/it/dockerfile/pom.xml
@@ -34,9 +34,10 @@
       <version>2.22.0</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -65,8 +66,17 @@
               </build>
               <run>
                 <ports>
-                  <port>8080:8080</port>
+                  <port>jetty.port:8080</port>
                 </ports>
+                <wait>
+                  <!-- Fails with 404 unless the WAR is actually deployed and the servlet answers -->
+                  <http>
+                    <url>http://${docker.host.address}:${jetty.port}/</url>
+                    <method>GET</method>
+                    <status>200</status>
+                  </http>
+                  <time>60000</time>
+                </wait>
               </run>
             </image>
           </images>

--- a/it/dockerfile/src/main/docker/Dockerfile
+++ b/it/dockerfile/src/main/docker/Dockerfile
@@ -8,6 +8,10 @@ LABEL PROJECT_NAME=hello-world \
 # Arbitrary files can be added
 ADD ${file} /
 
+# Jetty 12 enables no deployer by default, so webapps/ would never be scanned.
+# ee11-deploy pulls in the deployment scanner plus the Jakarta EE 11 web app support.
+RUN java -jar "$JETTY_HOME/start.jar" --add-modules=ee11-deploy
+
 # In maven/ the files as specified in the <assembly> section is stored
 # and need to be added manually
 COPY maven/ /var/lib/jetty/webapps/

--- a/it/dockerfile/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
+++ b/it/dockerfile/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
@@ -4,10 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FileUtils;
 

--- a/it/dockerfile/src/main/webapp/WEB-INF/web.xml
+++ b/it/dockerfile/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="6.1" xmlns="https://jakarta.ee/xml/ns/jakartaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
 
   <servlet>
     <display-name>HelloWold</display-name>

--- a/samples/dockerfile/pom.xml
+++ b/samples/dockerfile/pom.xml
@@ -33,9 +33,10 @@
       <version>2.22.0</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/samples/dockerfile/src/main/docker/Dockerfile
+++ b/samples/dockerfile/src/main/docker/Dockerfile
@@ -8,6 +8,10 @@ LABEL PROJECT_NAME=hello-world \
 # Arbitrary files can be added
 ADD ${file} /
 
+# Jetty 12 enables no deployer by default, so webapps/ would never be scanned.
+# ee11-deploy pulls in the deployment scanner plus the Jakarta EE 11 web app support.
+RUN java -jar "$JETTY_HOME/start.jar" --add-modules=ee11-deploy
+
 # In maven/ the files as specified in the <assembly> section is stored
 # and need to be added manually
 COPY maven/ /var/lib/jetty/webapps/

--- a/samples/dockerfile/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
+++ b/samples/dockerfile/src/main/java/io/fabric8/dmp/samples/dockerfile/HelloWorldServlet.java
@@ -4,10 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FileUtils;
 

--- a/samples/dockerfile/src/main/webapp/WEB-INF/web.xml
+++ b/samples/dockerfile/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="6.1" xmlns="https://jakarta.ee/xml/ns/jakartaee"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
 
   <servlet>
     <display-name>HelloWold</display-name>


### PR DESCRIPTION
### What

The `it/dockerfile`, `it/dockerfile-base-as-arg` and `samples/dockerfile` modules build a WAR into a `jetty` container. The servlet in there has silently stopped being served — `GET /` returns Jetty's own 404 page:

```
--- HTTP status: 404
<h2>Error 404 - Not Found.</h2>
<p>No context on this server matched or handled this request.</p>
<p>Contexts known to this server are:</p>
<table class="contexts">...<tbody>
</tbody></table>
```

Note the empty context table: the WAR is present but nothing deployed it.

### Why

Two independent causes had to come together.

**1. Jetty 12 enables no deployer module at all.** The container's start command showed only the bare server modules — no `jetty-deploy.xml`, no EE environment:

```
... /usr/local/jetty/etc/jetty-bytebufferpool.xml /usr/local/jetty/etc/jetty-http-config.xml
    /usr/local/jetty/etc/jetty-scheduler.xml /usr/local/jetty/etc/jetty-threadpool.xml
    /usr/local/jetty/etc/jetty.xml /usr/local/jetty/etc/jetty-http.xml
```

`/var/lib/jetty/webapps/ROOT.war` was sitting there untouched and was never even scanned.

**2. The application was written against `javax.servlet` 3.1.** Jetty 12 keeps the EE environments strictly apart, and `javax` is a frozen namespace, so this is the moment to move forward rather than pin the old one.

### How

* Enable `ee11-deploy` in each Dockerfile, which transitively brings in the deployment scanner and the Jakarta EE 11 web application support.
* Move the servlet imports, the dependency and `web.xml` to Jakarta EE 11 / Servlet 6.1 — the very API version the `jetty` image already ships (`/usr/local/jetty/lib/jakarta.servlet-api-6.1.0.jar`).
* Mark the servlet API `provided`: the container supplies it, so it no longer needs to be packaged into the WAR.

### Why it went unnoticed, and what stops it recurring

The ITs only built the image, started the container and stopped it again — **the servlet was never requested**, so a 404 could not fail anything.

Both ITs now wait for `GET /` to answer 200, which the 404 above does not:

```xml
<wait>
  <http>
    <url>http://${docker.host.address}:${jetty.port}/</url>
    <method>GET</method>
    <status>200</status>
  </http>
  <time>60000</time>
</wait>
```

The fixed `8080:8080` host port is replaced by a dynamically assigned one bound to a property, matching how the other modules wire up their wait URLs.

`samples/dockerfile` gets the same three fixes for consistency, but no wait — it defines no goals and is not part of the IT reactor.

### Verification (Docker 29.7.2)

**Before** — container from the pre-change image:

```
--- HTTP status: 404
--- webapps dir ---
-rw-r--r-- 1 root root 628749 Aug 12 12:14 ROOT.war
```

**After** — same command against the fixed image:

```
--- HTTP status: 200
--- body ---
Hello World !!!
--- welcome.txt in image ---
Hello World !!!
```

The body is exactly the content of `/welcome.txt`, i.e. what `HelloWorldServlet` reads and writes back. The Jetty log now shows the deployment actually happening:

```
oejd.DeploymentScanner: Deployment monitoring of [/var/lib/jetty/webapps] at intervals 0s
oejsh.ContextHandler: Started oeje11w.WebAppContext@...{ROOT,/,...,a=AVAILABLE}{file:///var/lib/jetty/webapps/ROOT.war}
```

and the start command now carries the EE 11 environment:

```
... --env ee11 -cp /usr/local/jetty/lib/jakarta.servlet-api-6.1.0.jar
    -cp /usr/local/jetty/lib/jetty-ee11-servlet-12.1.12.jar
    -cp /usr/local/jetty/lib/jetty-ee11-webapp-12.1.12.jar
    /usr/local/jetty/etc/jetty-ee11-webapp.xml /usr/local/jetty/etc/jetty-ee11-deploy.xml
```

Both integration tests pass end to end with the new wait in place:

```
DOCKER> [fabric8:dmp-it-dockerfile] "dockerfile": Waiting on url http://localhost:44741/ with method GET for status 200.
DOCKER> [fabric8:dmp-it-dockerfile] "dockerfile": Waited on url http://localhost:44741/ 20846 ms
DOCKER> [fabric8:dmp-it-dockerfile] "dockerfile": Stop and removed container 1081e904dce8 after 0 ms
```

`samples/dockerfile` was checked to still package cleanly.

No changelog entry: this touches only `it/` and `samples/`, not the plugin itself.
