### PR TITLE
Do not fail a container removal the daemon has already started itself

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,6 @@
 * **0.50-SNAPSHOT**:
   - Create the parent directory of `outputFile` and fail with an explicit message when it cannot be written, instead of swallowing the error and failing later with a `NullPointerException`; also make the progress bar usable without a preceding `progressStart()`
+  - Do not fail `docker:stop` when the daemon is already removing the container itself, as it does for `<autoRemove>`; a conflict for any other reason (e.g. the container is still running) is still reported
 
 * **0.49.0 (2026-08-09)**:
   - Fix `docker.save.aliases`: a non-existent alias in the list was silently ignored instead of failing the save with a clear error

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -64,6 +64,7 @@ import io.fabric8.maven.docker.util.JsonFactory;
 import io.fabric8.maven.docker.util.Logger;
 import io.fabric8.maven.docker.util.TimestampFactory;
 
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -523,11 +524,32 @@ public class DockerAccessWithHcClient implements DockerAccess {
             throws DockerAccessException {
         String url = urlBuilder.removeContainer(containerId, removeVolumes);
         log.verbose(Logger.LogVerboseCategory.API, API_LOG_FORMAT_DELETE, url);
+        HttpBodyAndStatus response;
         try {
-            delegate.delete(url, HTTP_NO_CONTENT, HTTP_NOT_FOUND);
+            response = delegate.delete(url, new BodyAndStatusResponseHandler(),
+                                       HTTP_NO_CONTENT, HTTP_NOT_FOUND, HTTP_CONFLICT);
         } catch (IOException e) {
             throw new DockerAccessException(e, "Unable to remove container [%s]", containerId);
         }
+        if (response.getStatusCode() == HTTP_CONFLICT) {
+            if (!isRemovalAlreadyInProgress(response.getBody())) {
+                throw new DockerAccessException("Unable to remove container [%s] : %s", containerId, response.getBody());
+            }
+            log.debug("Container %s is already being removed by the daemon", containerId);
+        }
+    }
+
+    /**
+     * A removal that is already under way - which is what <code>&lt;autoRemove&gt;</code> starts as soon as the
+     * container stops - is answered with the very same 409 the daemon uses to refuse a removal outright, e.g.
+     * because the container is still running. The two can only be told apart by the message, and anything not
+     * recognised here keeps failing the way it always did.
+     *
+     * @param body the error message returned by the daemon, may be <code>null</code>
+     * @return whether the conflict means the container is on its way out anyway
+     */
+    private boolean isRemovalAlreadyInProgress(String body) {
+        return body != null && body.contains("is already in progress");
     }
 
     @Override

--- a/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
@@ -294,6 +294,64 @@ class DockerAccessWithHcClientTest {
         Assertions.assertTrue(imageTags.isEmpty());
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // Container removal
+    //
+    // A removal the daemon has already started itself - which is what <autoRemove> does as soon as the
+    // container stops - is answered with the very same 409 it uses to refuse a removal outright.
+
+    @Test
+    void removeContainerAcceptsThatTheContainerWasRemoved() throws IOException {
+        givenTheContainerRemovalAnswersWith(HTTP_NO_CONTENT, null);
+
+        Assertions.assertDoesNotThrow(() -> client.removeContainer("abc", false));
+
+        thenTheRemovalWasSentFor("abc", false);
+    }
+
+    @Test
+    void removeContainerAcceptsThatTheContainerIsAlreadyGone() throws IOException {
+        givenTheContainerRemovalAnswersWith(HTTP_NOT_FOUND, "{\"message\":\"No such container: abc\"}");
+
+        Assertions.assertDoesNotThrow(() -> client.removeContainer("abc", true));
+
+        thenTheRemovalWasSentFor("abc", true);
+    }
+
+    @Test
+    void removeContainerAcceptsThatTheDaemonIsAlreadyRemovingIt() throws IOException {
+        givenTheContainerRemovalAnswersWith(HTTP_CONFLICT,
+                "{\"message\":\"removal of container abc is already in progress\"}");
+
+        Assertions.assertDoesNotThrow(() -> client.removeContainer("abc", false));
+    }
+
+    @Test
+    void removeContainerFailsOnAConflictForAnyOtherReason() throws IOException {
+        givenTheContainerRemovalAnswersWith(HTTP_CONFLICT, "{\"message\":\"cannot remove container \\\"abc\\\": "
+                + "container is running: stop the container before removing or force remove\"}");
+
+        DockerAccessException exp =
+                Assertions.assertThrows(DockerAccessException.class, () -> client.removeContainer("abc", false));
+
+        Assertions.assertTrue(exp.getMessage().contains("Unable to remove container [abc]"), exp.getMessage());
+        Assertions.assertTrue(exp.getMessage().contains("container is running"), exp.getMessage());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void removeContainerFailsWhenTheRequestItselfFails() throws IOException {
+        Mockito.doThrow(new HttpResponseException(HTTP_INTERNAL_ERROR, "error"))
+                .when(mockDelegate)
+                .delete(Mockito.anyString(), Mockito.any(ResponseHandler.class),
+                        Mockito.eq(HTTP_NO_CONTENT), Mockito.eq(HTTP_NOT_FOUND), Mockito.eq(HTTP_CONFLICT));
+
+        DockerAccessException exp =
+                Assertions.assertThrows(DockerAccessException.class, () -> client.removeContainer("abc", false));
+
+        Assertions.assertTrue(exp.getMessage().contains("Unable to remove container [abc]"), exp.getMessage());
+    }
+
     private void givenAnImageName(String imageName) {
         this.imageName = imageName;
     }
@@ -399,6 +457,25 @@ class DockerAccessWithHcClientTest {
         Mockito.doReturn(new ApacheHttpClientDelegate.HttpBodyAndStatus(HTTP_OK, "body"))
                 .when(mockDelegate)
                 .delete(Mockito.anyString(), Mockito.any(ResponseHandler.class), Mockito.eq(HTTP_OK), Mockito.eq(HTTP_NOT_FOUND));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenTheContainerRemovalAnswersWith(int statusCode, String body) throws IOException {
+        Mockito.doReturn(new ApacheHttpClientDelegate.HttpBodyAndStatus(statusCode, body))
+                .when(mockDelegate)
+                .delete(Mockito.anyString(), Mockito.any(ResponseHandler.class),
+                        Mockito.eq(HTTP_NO_CONTENT), Mockito.eq(HTTP_NOT_FOUND), Mockito.eq(HTTP_CONFLICT));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void thenTheRemovalWasSentFor(String containerId, boolean removeVolumes) throws IOException {
+        ArgumentCaptor<String> urlCapture = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(mockDelegate)
+                .delete(urlCapture.capture(), Mockito.any(ResponseHandler.class),
+                        Mockito.eq(HTTP_NO_CONTENT), Mockito.eq(HTTP_NOT_FOUND), Mockito.eq(HTTP_CONFLICT));
+
+        String expectedUrl = String.format("%s/v1.40/containers/%s?v=%s", BASE_URL, containerId, removeVolumes ? "1" : "0");
+        Assertions.assertEquals(expectedUrl, urlCapture.getValue());
     }
 
     private void thenImageWasNotPushed() {


### PR DESCRIPTION
### What

`docker:stop` can fail with a 409 while the container is being removed perfectly fine:

```
DOCKER> [busybox:latest]: Start container 4b19ff13038a
--- docker:stop (stop-docker) ---
DOCKER> [busybox:latest]: Stop and removed container 4b19ff13038a after 0 ms   <- the stop succeeded
[ERROR] DOCKER> (Unable to remove container [4b19ff13038a] :
        {"message":"removal of container 4b19ff13038a is already in progress"} (Conflict: 409))
```

That is the `graceful-container-removal` integration test, from [this macOS CI job](https://github.com/fabric8io/docker-maven-plugin/actions/runs/31593050968/job/94102286454). It is not specific to CI — any project using `<autoRemove>` can hit it.

### Why

Two removals race each other:

* `<autoRemove>true</autoRemove>` makes **the daemon remove the container itself** the moment it stops.
* [`RunService`](https://github.com/fabric8io/docker-maven-plugin/blob/master/src/main/java/io/fabric8/maven/docker/service/RunService.java#L585) removes it **explicitly** as well, whenever `<keepContainer>` is not set.

`removeContainer` accepted `204 No Content` and `404 Not Found` — so "I removed it" and "the daemon had already finished removing it" were both fine. What it did not accept was landing in between: the daemon's removal still running, answered with `409 Conflict`.

Which side of that window the request lands in is pure timing. A fast local daemon almost always lands on 404; the QEMU-backed macOS runners are slow enough to land on 409, which is why this test flakes there while Linux stays green.

### How

Accept a 409 **only** when it says the removal is already under way.

A 409 is not automatically harmless — the daemon uses the same status to refuse a removal outright, e.g. while the container is still running. Those two can only be told apart by the message, so anything not recognised keeps failing exactly as before. If a future daemon words it differently, the behaviour falls back to today's, it does not get worse.

### Verification

**A. The race, end to end, through DMP's own code path** (Docker 29.7.2)

A small harness asks the daemon to remove one and the same exited container from six independent `DockerAccessWithHcClient` connections at once — the same situation `docker:stop` runs into when the daemon is already removing the container. The container writes an 800 MB file first so the removal takes long enough to overlap.

Before (0.49-SNAPSHOT, i.e. without this change):

```
  request 0 -> DockerAccessException: Unable to remove container [54c4c6f84ff9...] : {"message":"removal of container 54c4c6f84ff9... is already in progress"} (Conflict: 409)
  request 1 -> DockerAccessException: ... is already in progress"} (Conflict: 409)
  request 2 -> DockerAccessException: ... is already in progress"} (Conflict: 409)
  request 3 -> DockerAccessException: ... is already in progress"} (Conflict: 409)
  request 4 -> DockerAccessException: ... is already in progress"} (Conflict: 409)
  request 5 -> OK
RESULT: 1/6 succeeded, 5 failed
```

After:

```
  request 0 -> OK
  request 1 -> OK
  request 2 -> OK
  request 3 -> OK
  request 4 -> OK
  request 5 -> OK
RESULT: 6/6 succeeded, 0 failed
```

**B. A conflict for any other reason still fails**

Same harness, one request, against a container that is still running:

```
  request 0 -> DockerAccessException: Unable to remove container [3da67e4308db...] :
      {"message":"cannot remove container \"3da67e4308db...\": container is running: stop the container before removing or force remove"}
RESULT: 0/1 succeeded, 1 failed
```

**C. Integration test**

`it/graceful-container-removal` — the module that fails in CI — passes unchanged locally, i.e. the ordinary 204/404 path is untouched:

```
DOCKER> [busybox:latest]: Start container f3f78db443a8
DOCKER> [busybox:latest]: Stop and removed container f3f78db443a8 after 0 ms
BUILD SUCCESS
```

**D. Unit tests**

Five tests added to `DockerAccessWithHcClientTest`, covering 204, 404, the accepted 409, the rejected 409 (with the message the daemon really returns, taken from B) and a failing request. Full suite: 982 tests, 0 failures.
