### PR TITLE
Make the Windows and macOS E2E jobs wait for Docker instead of assuming it

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -75,6 +75,10 @@ jobs:
     # Using an Intel runner because ARM64 macOS runners don't support nested virtualization
     # required for Docker/QEMU. See: https://github.com/actions/runner-images/issues/9460
     runs-on: macos-26-intel
+    # Docker lives in a Lima VM here, so every step that talks to it has to be pointed at that
+    # VM's socket. Set once for the whole job, so the value cannot drift apart between steps.
+    env:
+      DOCKER_HOST: unix:///Users/runner/.lima/docker-actions-toolkit/docker.sock
     strategy:
       fail-fast: false
       matrix:
@@ -107,8 +111,30 @@ jobs:
           brew install docker-buildx
           mkdir -p ~/.docker/cli-plugins
           ln -sfn /usr/local/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
+      # Name resolution inside that VM is flaky enough that a single failed lookup of
+      # registry-1.docker.io takes down a whole reactor run - the pull during the build has no retry
+      # of its own. Pulling the base images up front costs no extra time, they are needed anyway, but
+      # it puts the pull somewhere a retry can be wrapped around it.
+      - name: Pre-pull the base images used by the integration tests
+        run: |
+          images="alpine busybox jetty debian:bullseye-slim
+                  eclipse-temurin:17-jre-alpine eclipse-temurin:21-jre-alpine
+                  azul/zulu-openjdk-alpine:11 azul/zulu-openjdk-alpine:17-jre
+                  registry.access.redhat.com/ubi8/ubi-minimal:8.6"
+          for image in $images; do
+            for attempt in 1 2 3 4 5; do
+              if docker pull --quiet "$image"; then
+                break
+              fi
+              if [ "$attempt" -eq 5 ]; then
+                echo "::error::Could not pull $image after 5 attempts"
+                exit 1
+              fi
+              echo "Pulling $image failed, retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            done
+          done
       - name: Run Integration tests
         run: |
-          export DOCKER_HOST=unix:///Users/runner/.lima/docker-actions-toolkit/docker.sock
           cd it/
           mvn clean install

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -30,6 +30,32 @@ jobs:
           java-version: '11'
       - name: Install DMP
         run: mvn ${MAVEN_ARGS} clean install -DskipTests
+      # Nothing on this runner guarantees that the preinstalled Docker daemon is already accepting
+      # requests by the time the integration tests start. When it is not, the very first docker:build
+      # aborts with "No <dockerHost> given, ... no read/writable '//./pipe/docker_engine'" and the job
+      # fails within a minute, even though a plain re-run passes.
+      - name: Wait for Docker to be ready
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $service = Get-Service docker -ErrorAction SilentlyContinue
+          if ($service -and $service.Status -ne 'Running') {
+            Write-Host "The docker service is $($service.Status), starting it"
+            Start-Service docker
+          }
+          $timeoutMinutes = 5
+          $deadline = (Get-Date).AddMinutes($timeoutMinutes)
+          while ((Get-Date) -lt $deadline) {
+            $global:LASTEXITCODE = 1
+            docker info *> $null
+            if ($LASTEXITCODE -eq 0) {
+              docker version
+              exit 0
+            }
+            Start-Sleep -Seconds 5
+          }
+          Write-Host "::error::The Docker daemon did not become available within $timeoutMinutes minutes"
+          exit 1
       - name: Run Integration tests
         run: |
           cd it/windows-build


### PR DESCRIPTION
### Why

The Windows and macOS E2E jobs fail regularly for reasons that have nothing to do with the change under test, and a plain re-run of the very same commit passes. Over the last twenty `E2E Windows` runs the job failed **four times — one in five**, all on branches whose re-run then went green.

### Windows: nothing waits for the daemon

The job goes `ver` → Checkout → Setup Java → Install DMP → Run Integration tests. There is **no Docker setup step at all**, unlike the Linux and macOS jobs which both go through `docker/setup-docker-action` — Windows just assumes the preinstalled daemon is already up.

When it is not, the first `docker:build` aborts and the job is over after ~1m26s:

```
No <dockerHost> given, no DOCKER_HOST environment variable,
no read/writable '/var/run/docker.sock' or '//./pipe/docker_engine',
no running 'wslc' (WSL Containers) session and no external provider ...
```

The job now starts the service if it is not running and waits up to five minutes for the daemon to answer. It sits **after** `Install DMP`, so the build time is spent waiting anyway and the step normally costs nothing. If the daemon never answers, the job fails with a message that says exactly that, rather than the plugin error above.

### macOS: one bad DNS lookup takes down the whole run

Docker runs inside a Lima VM whose name resolution is flaky, and the pull during the build has no retry of its own:

```
Get "https://registry-1.docker.io/v2/": dial tcp:
lookup registry-1.docker.io on 127.0.0.53:53: read udp 127.0.0.1:33196->127.0.0.53:53: i/o timeout
   (Internal Server Error: 500)
   at io.fabric8.maven.docker.service.BuildService.autoPullBaseImage
```

The base images the `it/` reactor builds on are now pulled up front, five attempts each with a growing pause. This costs no extra time — the images are pulled during the run anyway — it just moves the pull somewhere a retry can wrap it.

The list is the set of registry images actually used as bases across `it/`: `alpine`, `busybox`, `jetty`, `debian:bullseye-slim`, `eclipse-temurin:17-jre-alpine`, `eclipse-temurin:21-jre-alpine`, `azul/zulu-openjdk-alpine:11`, `azul/zulu-openjdk-alpine:17-jre` and `registry.access.redhat.com/ubi8/ubi-minimal:8.6`.

### What this does not fix

The other macOS failure seen recently — `docker:stop` hitting a 409 while the daemon is already removing the container — is a plugin bug and is addressed separately in #1967.

### Verification

Both scripts were extracted from the YAML and executed locally, so what ran is what the workflow contains.

**Windows readiness step**, against a running daemon:

```
Client:
 Version:           29.7.2
 API version:       1.55
exit=0
```

Against an unreachable daemon (`DOCKER_HOST=tcp://127.0.0.1:1`, deadline shortened for the test):

```
::error::The Docker daemon did not become available within 5 minutes
exit=1
```

The `Get-Service docker -ErrorAction SilentlyContinue` guard was exercised too: the local machine has no service by that name and the step skipped the start without erroring.

**macOS pre-pull step**, with `docker` stubbed to control the outcome:

| scenario | result |
| --- | --- |
| every pull succeeds | all 9 images, `exit=0` |
| first two attempts fail, third succeeds | retries with growing pause, `exit=0` |
| every attempt fails | 5 attempts, `::error::Could not pull alpine after 5 attempts`, `exit=1` |

All nine image references were checked with `docker manifest inspect`: every one resolves and has a `linux/amd64` entry, which is what the `macos-26-intel` runner needs. Both workflow files were parsed to confirm the YAML is valid and the new steps land in the intended order.


### Where the pre-pull does not reach

Worth stating plainly, since it came up while this was open: the pre-pull only helps the modules that build through the Docker daemon. The `it/buildx-*` modules do not benefit.

`BuildXService` creates its builder with `--driver docker-container`, so BuildKit runs in a container of its own and resolves `FROM` against the registry itself rather than reading the daemon's image store. A pre-pulled image is invisible to it. A run on this branch shows exactly that — the pre-pull step succeeded, and `it/buildx-push` still failed a few minutes later:

```
#2 [internal] load metadata for registry.access.redhat.com/ubi8/ubi-minimal:8.6
#2 ERROR: failed to do request: Head "https://registry-1.docker.io/...": dial tcp:
   lookup registry.access.redhat.com: i/o timeout
```

Two levers the plugin already exposes were measured against this and neither helps:

* `<buildx><configFile>` with a `[dns]` section only configures the containers BuildKit runs for `RUN` steps. Pointing it at an unroutable resolver (`203.0.113.1`) still let `load metadata` finish in 2.7s, while the `RUN` step reported `nameserver 203.0.113.1` — so it does not touch buildkitd's own registry lookups, which is where the failure is.
* `<buildx><driverOpts><network>host</network>` puts buildkitd in the VM's network namespace, i.e. straight onto the resolver at `127.0.0.53`. That is the very resolver the earlier Docker Hub failure timed out against (`lookup registry-1.docker.io on 127.0.0.53:53 ... i/o timeout`), so there is no reason to expect an improvement.

That path needs a different remedy and is left to a follow-up rather than widening this PR.
