### PR TITLE
Give the compose healthcheck IT the wait timeout its own compose file asks for

### DIFF
--- a/it/docker-compose-dependon/pom.xml
+++ b/it/docker-compose-dependon/pom.xml
@@ -60,6 +60,14 @@
             <phase>verify</phase>
             <configuration>
               <showLogs>true</showLogs>
+              <!--
+                The healthcheck below gives Postgres up to 21s to come up (start_period 1s plus
+                interval 2s times 10 retries), but nothing carries that budget over to the plugin,
+                which falls back to its 10s default and gives up first. Postgres needs more than that
+                on a slow container runtime, so state the timeout here rather than let the two
+                disagree.
+              -->
+              <startContainerWaitTimeout>60000</startContainerWaitTimeout>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
### What

`it/docker-compose-dependon` fails on the macOS CI runners, most recently on [this job](https://github.com/fabric8io/docker-maven-plugin/actions/runs/31606233778/job/94146033939):

```
[ERROR] DOCKER> [localpg:latest] "db": Timeout after 10509 ms
        while waiting on healthcheck '"CMD-SHELL", "pg_isready -U postgres"'
[ERROR]   mvn <args> -rf :dmp-it-docker-compose-dependon
```

### Why

Two timeouts disagree about how long Postgres may take.

The compose file gives it up to **21 seconds** — `start_period` 1s plus `interval` 2s times `retries` 10:

```yaml
healthcheck:
  test: pg_isready -U postgres
  interval: 2s
  timeout: 2s
  retries: 10
  start_period: 1s
```

Nothing carries that budget over to the plugin, though. The module sets no wait timeout of its own, so `WaitService` falls back to `WaitUtil.DEFAULT_MAX_WAIT`, which is **10 seconds** — and the plugin gives up while the healthcheck still has half its retries left.

How long Postgres really takes varies far more than a 10s cutoff can absorb. Measured locally across seven runs of this module:

| run | time to healthy |
| --- | --- |
| 1 | 19518 ms |
| 2 | 13053 ms |
| 3 | 9407 ms |
| 4 | 5447 ms |
| 5 | 5589 ms |
| 6 | 5585 ms |
| 7 | 5553 ms |

The slow ones are the runs right after the image was built — which is what every CI run looks like, since the image is built in the same reactor. The module therefore passes or fails on timing rather than on anything it is meant to test, and the macOS runners, being slower, land on the wrong side more often. CI measured 10509 ms, i.e. it missed by half a second.

### How

`<startContainerWaitTimeout>` exists for precisely this case — [its javadoc](https://github.com/fabric8io/docker-maven-plugin/blob/master/src/main/java/io/fabric8/maven/docker/StartMojo.java#L108) names compose-defined healthchecks as the motivating example — so the module now states the timeout rather than leaving the two settings to disagree. 60s, comfortably above the 21s the compose file itself allows.

This touches one integration test's `pom.xml`. No plugin code changes, so no changelog entry.

### Verification

**The failure reproduces locally, identically to CI**, without the change:

```
[ERROR] DOCKER> [localpg:latest] "db": Timeout after 10394 ms while waiting on healthcheck '"CMD-SHELL", "pg_isready -U postgres"'
[ERROR] Failed to execute goal io.fabric8:docker-maven-plugin:0.50-SNAPSHOT:start (start) on project dmp-it-docker-compose-dependon
BUILD FAILURE
```

**With the change**, the same run gets through the slow start:

```
DOCKER> [localpg:latest] "db": Waited on healthcheck '"CMD-SHELL", "pg_isready -U postgres"' 19518 ms
DOCKER> [alpine:latest] "web": Start container d4573b7dca55
BUILD SUCCESS
```

That run was also given `-Ddocker.startContainerWaitTimeout=1` on the command line, which the new `<configuration>` value correctly overrides — confirming the setting is what takes effect here, and not something else.

The module was then run a further six times; every run reached `BUILD SUCCESS` on the healthcheck, including the 13053 ms and 9407 ms ones above. (One run aborted later, in `docker:stop`, on a Windows named-pipe contention issue local to this machine — unrelated to the wait, and not applicable to the Linux and macOS runners that run this module.)
