### PR TITLE
docs: fix typos implicitely/explicitely

### DIFF
--- a/doc/migration-0.9.x.md
+++ b/doc/migration-0.9.x.md
@@ -64,9 +64,9 @@ In addition the new syntax support also waiting on a log outpbut
 
 The old version of the plugin combined some task: E.g. if you used
 `docker:start` or `docker:pull` a `docker:build` was done
-implicitely. In order to make stuff more explicite and easier to
+implicitly. In order to make stuff more explicite and easier to
 understand this is not the case anymore. So, when you bind to a
-lifecycle phase you have to add all steps explicitely:
+lifecycle phase you have to add all steps explicitly:
 
 ```xml
 <executions>


### PR DESCRIPTION
Two typo fixes in `doc/migration-0.9.x.md`:

- line 67 — `implicitely` → `implicitly`
- line 69 — `explicitely` → `explicitly`

This is the 0.9.x → 0.10.x migration guide, still live user-facing documentation rather than a changelog. Prose only.
