### PR TITLE
Gate the Sonar PR publish on a maintainer approval instead of trusting fork code

### DIFF
--- a/.github/workflows/sonar-pr-analysis-publish.yml
+++ b/.github/workflows/sonar-pr-analysis-publish.yml
@@ -10,42 +10,115 @@ on:
       - completed
 
 concurrency:
-  # Only run once for latest commit per ref and cancel other (previous) runs.
-  group: ci-sonar-docker-maven-plugin-${{ github.ref }}
+  # In a workflow_run event github.ref resolves to the default branch, so keying on it would put
+  # every pull request into one group and let them cancel each other. Key on the head instead.
+  group: ci-sonar-docker-maven-plugin-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  gate:
+    name: Check whether the commit may be analysed
+    runs-on: ubuntu-latest
+    outputs:
+      analyse: ${{ steps.check.outputs.analyse }}
+      pr: ${{ steps.check.outputs.pr }}
+      sha: ${{ steps.check.outputs.sha }}
+    steps:
+      # This workflow holds the base repository's secrets, and the job below builds and tests the
+      # commit it checks out. For a fork that is only safe once a human who can merge the pull
+      # request has looked at the very code that is about to run, so establish that first.
+      - name: Check
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -eu
+
+          skip() {
+            echo "analyse=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::$1"
+            exit 0
+          }
+
+          echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+          # Identify the pull request by its head, and only accept one that still points at the
+          # commit this run was triggered for.
+          pr=$(gh api "repos/$BASE_REPO/pulls?head=$HEAD_OWNER:$HEAD_BRANCH&state=open" \
+                 --jq '[.[] | select(.head.sha == env.HEAD_SHA)] | .[0].number // empty')
+          if [ -z "$pr" ]; then
+            skip "No open pull request has $HEAD_SHA as its head; nothing to analyse."
+          fi
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+
+          # A branch in this repository can only be pushed by someone who already has write access,
+          # so there is no untrusted code here to gate - this covers Dependabot as well.
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "analyse=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR #$pr comes from this repository, analysing $HEAD_SHA."
+            exit 0
+          fi
+
+          # The approval has to name this exact commit, so pushing after being approved closes the
+          # gate again rather than smuggling code past it.
+          approvers=$(gh api "repos/$BASE_REPO/pulls/$pr/reviews" --paginate \
+            --jq '.[]
+                  | select(.state == "APPROVED" and .commit_id == env.HEAD_SHA)
+                  | select(.author_association == "OWNER"
+                        or .author_association == "MEMBER"
+                        or .author_association == "COLLABORATOR")
+                  | .user.login')
+          approver=$(printf '%s\n' "$approvers" | head -n 1)
+          if [ -z "$approver" ]; then
+            skip "PR #$pr is from a fork and $HEAD_SHA carries no approval from a maintainer, skipping the analysis."
+          fi
+
+          echo "analyse=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::PR #$pr was approved by $approver for $HEAD_SHA, analysing."
+
   sonar:
     name: Sonar PR Scanner
+    needs: gate
+    if: needs.gate.outputs.analyse == 'true'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_BASE_REF: ${{ github.event.workflow_run.head_branch }}
-      GITHUB_PR_AUTHOR: ${{ github.event.sender.login }}
-      GITHUB_REPO: ${{ github.repository }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      PR_NUMBER: ${{ needs.gate.outputs.pr }}
+      PR_SHA: ${{ needs.gate.outputs.sha }}
+      PR_BRANCH: ${{ github.event.workflow_run.head_branch }}
     steps:
       - name: Setup Java 21 # SonarQube Cloud requires Java 21+ to run the analysis
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Dump GitHub context
-        run: echo '${{ toJSON(github.event) }}'
-      - name: Get PR number
-        run: |
-          PR_QUERY_RESULT=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/$GITHUB_REPO/pulls?head=$GITHUB_PR_AUTHOR:$GITHUB_BASE_REF&state=open" | jq '.[0].number')
-          echo "PR_NUMBER=$PR_QUERY_RESULT" >> $GITHUB_ENV
-      - name: Checkout
+      - name: Checkout the approved commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: refs/pull/${{ env.PR_NUMBER }}/head
+          ref: ${{ needs.gate.outputs.sha }}
+          # Checking out a fork here is what actions/checkout refuses by default, and rightly so.
+          # It is opted into only because the gate above established that a maintainer approved
+          # this commit.
+          allow-unsafe-pr-checkout: true
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
+      - name: Verify the checkout is the commit that was approved
+        run: |
+          actual=$(git rev-parse HEAD)
+          if [ "$actual" != "$PR_SHA" ]; then
+            echo "::error::Checked out $actual but $PR_SHA is what was approved"
+            exit 1
+          fi
       - name: Publish analysis on PR
         run: |
           ./mvnw ${MAVEN_ARGS} -Pjacoco,sonar clean install \
@@ -54,7 +127,7 @@ jobs:
              -Dsonar.login=${SONAR_TOKEN} \
              -Dsonar.host.url=https://sonarcloud.io \
              -Dsonar.pullrequest.base=master \
-             -Dsonar.pullrequest.branch=${GITHUB_BASE_REF} \
+             -Dsonar.pullrequest.branch=${PR_BRANCH} \
              -Dsonar.pullrequest.key=${PR_NUMBER} \
              -Dsonar.pullrequest.provider=GitHub \
              -Dsonar.pullrequest.github.repository=fabric8io/docker-maven-plugin \

--- a/.github/workflows/sonar-pr-analysis-publish.yml
+++ b/.github/workflows/sonar-pr-analysis-publish.yml
@@ -73,17 +73,37 @@ jobs:
           approvers=$(gh api "repos/$BASE_REPO/pulls/$pr/reviews" --paginate \
             --jq '.[]
                   | select(.state == "APPROVED" and .commit_id == env.HEAD_SHA)
-                  | select(.author_association == "OWNER"
-                        or .author_association == "MEMBER"
-                        or .author_association == "COLLABORATOR")
-                  | .user.login')
-          approver=$(printf '%s\n' "$approvers" | head -n 1)
+                  | .user.login' | sort -u)
+
+          # Who left that approval decides whether it is worth anything, and author_association is
+          # the wrong place to ask: MEMBER only says the reviewer belongs to the organisation, and
+          # COLLABORATOR is just as true of read and triage access. Neither can merge this pull
+          # request. Ask the repository for the permission it actually granted instead and take
+          # only write - which is what the API reports for maintain as well - or admin. Anything
+          # else leaves the gate closed, including an answer the API declines to give.
+          approver=
+          approver_permission=
+          for login in $approvers; do
+            if ! permission=$(gh api "repos/$BASE_REPO/collaborators/$login/permission" \
+                                --jq '.permission' 2>&1); then
+              echo "::warning::Could not read $login's permission on $BASE_REPO: $permission"
+              continue
+            fi
+            case "$permission" in
+              admin | write)
+                approver=$login
+                approver_permission=$permission
+                break
+                ;;
+            esac
+          done
+
           if [ -z "$approver" ]; then
-            skip "PR #$pr is from a fork and $HEAD_SHA carries no approval from a maintainer, skipping the analysis."
+            skip "PR #$pr is from a fork and $HEAD_SHA carries no approval from someone with write access to $BASE_REPO, skipping the analysis."
           fi
 
           echo "analyse=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::PR #$pr was approved by $approver for $HEAD_SHA, analysing."
+          echo "::notice::PR #$pr was approved for $HEAD_SHA by $approver ($approver_permission access), analysing."
 
   sonar:
     name: Sonar PR Scanner


### PR DESCRIPTION
### What

Every run of `Sonar PR Analysis Publish` fails, and has done for a while — the last eight are all `failure` or `cancelled`:

```
##[error]Refusing to check out fork pull request code from a 'workflow_run' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache
scope, and runner access. Fetching and executing a fork's code in that trusted context
commonly leads to "pwn request" vulnerabilities.
To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set
'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

Nothing is broken about builds or tests — the effect is that pull requests from forks get no Sonar analysis.

### Why `actions/checkout` is right

The job holds `SONAR_TOKEN` and a `GITHUB_TOKEN`, checks out `refs/pull/N/head` and runs `./mvnw clean install` over it. A pull request from a fork controls that code, so it could read those secrets out of a test or a Maven plugin. Setting `allow-unsafe-pr-checkout: true` on its own would just reopen the hole that was closed.

### How

The fork's code is built only once a human who can merge it has looked at the very commit that is about to run. A `gate` job:

1. resolves the pull request from the head repository and branch,
2. requires its head to *still* be the commit this run was triggered for, and
3. requires an `APPROVED` review from an `OWNER`, `MEMBER` or `COLLABORATOR` carrying **that same commit id**.

Anything short of that **skips** the analysis rather than failing it, with a notice saying which condition was not met. Because the approval is tied to the commit, pushing after being approved closes the gate again. The checkout that follows is pinned to that commit and asserted with `git rev-parse HEAD` afterwards, so `allow-unsafe-pr-checkout` is only reached on the far side of a human decision.

**Pull requests from branches of this repository skip the check entirely** — only someone with write access can push there, so there is nothing to gate. Dependabot's pull requests keep being analysed automatically, as before.

The gate calls three endpoints: `GET /pulls?head=…` to find the pull request, `GET /pulls/{n}/reviews` to read its reviews, and `GET /repos/{owner}/{repo}/collaborators/{username}/permission` for each login that approved the head commit.

"Maintainer" means write or admin as the repository itself reports it, not the review's `author_association` — `MEMBER` only says the reviewer is in the organisation, and `COLLABORATOR` is just as true of read or triage access. An approval that resolves to anything else, or a lookup the API declines to answer, leaves the gate closed.

The REST reference for that permission endpoint says the caller needs push access, which reads like more than this job should hold. That line applies to user-to-server and classic tokens; for a workflow token the [GitHub Apps permission reference](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps) lists it as `Metadata: read`, which every `GITHUB_TOKEN` already has. Checked on a workflow declaring exactly the `contents: read` and `pull-requests: read` above:

```
declared permissions: contents: read + pull-requests: read
== own repo, the pushing user ==
OK -> admin
== own repo, an unrelated login ==
OK -> read
```

### Two other faults in the same file

* **The concurrency group cancelled unrelated pull requests.** It keyed on `github.ref`, which in a `workflow_run` event resolves to the default branch — every publish run of this workflow reports `head_branch=master`, so all pull requests shared one group with `cancel-in-progress: true`. That matches the `cancelled` entries in the run history. It now keys on the head repository and branch.
* **The pull request number was resolved without any check.** It came from `sender.login` plus a branch name, taking `.[0].number`. Run 32851681701 shows the result: a run for branch `fix-ansilogger-robustness` (PR #1964) carried `PR_NUMBER=1973`. The new lookup uses the head repository owner and only accepts a pull request whose head SHA matches the commit being analysed.

The debug step dumping the entire event payload is gone; the gate reports what it decided and why.

### Verification

A fork cannot exercise `workflow_run` against this repository, so the gate script was extracted from the YAML and run locally against **recorded GitHub API responses**. The fork case uses the real reviews on #1964 (two `COMMENTED`, one `MEMBER` and one `CONTRIBUTOR`); the approval cases are those same objects with `state` and `commit_id` altered, so the schema is genuine.

| scenario | `analyse` |
| --- | --- |
| head is a branch of this repository (Dependabot #1971) | `true` — gate skipped |
| fork, approved by a `MEMBER`, commit id matches | `true` |
| fork, approved by a `MEMBER`, but for an earlier commit | `false` |
| fork, only `COMMENTED` reviews (the real state of #1964) | `false` |
| fork, `APPROVED` by a `CONTRIBUTOR` | `false` |
| no open pull request whose head is this commit | `false` |

The workflow was also parsed to confirm the job graph, `needs`/`if` wiring and permissions, and `sonar-pr-request.yml` is untouched.

**What still needs checking after merge**, since it cannot be exercised from a fork: that a fork pull request without approval shows the `sonar` job as skipped, that approving it makes the next run analyse, and that a Dependabot pull request passes straight through.


