### PR TITLE
Add a retry configuration option for docker start

### DIFF
--- a/src/main/asciidoc/inc/start/_configuration.adoc
+++ b/src/main/asciidoc/inc/start/_configuration.adoc
@@ -25,6 +25,10 @@ Overriding that property might become particularly useful when docker-compose co
 but the default wait timeout of 10000ms is too short for some containers to become healthy.
 | `docker.startContainerWaitTimeout`
 
+| *startRetries*
+| Number of times to retry creating and starting a container when the Docker daemon cannot be reached (e.g. a transient I/O error). The default is `0` which means no retry.
+| `docker.start.retries`
+
 |===
 
 The `<run>` configuration element knows the following sub elements:

--- a/src/main/java/io/fabric8/maven/docker/StartMojo.java
+++ b/src/main/java/io/fabric8/maven/docker/StartMojo.java
@@ -68,6 +68,13 @@ public class StartMojo extends AbstractDockerMojo {
     private boolean startParallel;
 
     /**
+     * Number of times to retry creating and starting a container when the Docker daemon cannot be reached
+     * (e.g. a transient I/O error). The default is {@code 0} which means no retry.
+     */
+    @Parameter(property = "docker.start.retries", defaultValue = "0")
+    private int startRetries;
+
+    /**
      * Whether to block and follow (stream) the container logs until interrupted. Can also be set
      * via the {@code docker.follow} system property. When unset, the default is {@code false} for
      * {@code docker:start} and {@code true} for {@code docker:run}.
@@ -309,6 +316,7 @@ public class StartMojo extends AbstractDockerMojo {
             .showLogs(showLogs)
             .containerNamePattern(containerNamePattern)
             .buildTimestamp(getBuildTimestamp())
+            .startupRetries(startRetries)
             .build();
 
         startingContainers.submit(() -> {

--- a/src/main/java/io/fabric8/maven/docker/service/RunService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RunService.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.fabric8.maven.docker.access.ContainerCreateConfig;
 import io.fabric8.maven.docker.access.ContainerHostConfig;
@@ -66,6 +67,7 @@ import io.fabric8.maven.docker.util.StartOrderResolver;
 import io.fabric8.maven.docker.wait.WaitTimeoutException;
 import io.fabric8.maven.docker.wait.WaitUtil;
 import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.FailsafeException;
 import net.jodah.failsafe.RetryPolicy;
 
 /**
@@ -187,15 +189,79 @@ public class RunService {
                                           File baseDir,
                                           String defaultContainerNamePattern,
                                           Date buildTimestamp) throws DockerAccessException {
-        String id = createContainer(imageConfig, portMapping, gavLabel, properties, baseDir,
-                defaultContainerNamePattern, buildTimestamp);
-        startContainer(imageConfig, id, gavLabel);
+        return createAndStartContainer(imageConfig, portMapping, gavLabel, properties, baseDir,
+                defaultContainerNamePattern, buildTimestamp, 0);
+    }
 
-        if (portMapping.needsPropertiesUpdate()) {
-            updateMappedPortsAndAddresses(id, portMapping);
+    /**
+     * Create and start a container with the given image configuration, retrying on transient failures.
+     *
+     * @param imageConfig image configuration holding the run information and the image name
+     * @param portMapping container port mapping
+     * @param gavLabel label to tag the started container with
+     * @param properties properties to fill in with dynamically assigned ports
+     * @param baseDir base dir of the project
+     * @param defaultContainerNamePattern pattern to use for naming containers. Can be null in which case a default pattern is used
+     * @param buildTimestamp date which should be used as the timestamp when calculating container names
+     * @param startRetries number of times to retry creating and starting the container when the Docker daemon
+     *                     cannot be reached. {@code 0} (the default) means no retry.
+     * @return the container id
+     *
+     * @throws DockerAccessException if access to the docker backend fails after all retries have been exhausted
+     */
+    public String createAndStartContainer(ImageConfiguration imageConfig,
+                                          PortMapping portMapping,
+                                          GavLabel gavLabel,
+                                          Properties properties,
+                                          File baseDir,
+                                          String defaultContainerNamePattern,
+                                          Date buildTimestamp,
+                                          int startRetries) throws DockerAccessException {
+        // Track the container created by the current attempt so it can be removed before retrying (avoids leaking it)
+        final AtomicReference<String> createdContainerId = new AtomicReference<>();
+        RetryPolicy<String> retryPolicy = new RetryPolicy<String>()
+                .withMaxRetries(startRetries)
+                .withBackoff(10, 100, ChronoUnit.MILLIS)
+                .handle(DockerAccessException.class)
+                .onFailedAttempt(f -> {
+                    removeContainerSilently(createdContainerId.getAndSet(null));
+                    log.warn("Failed to create and start container for image [%s] (attempt %d), retrying",
+                            imageConfig.getName(), f.getAttemptCount());
+                })
+                .onRetriesExceeded(f -> log.warn("Failed to create and start container for image [%s] after %d retries",
+                        imageConfig.getName(), f.getAttemptCount()));
+
+        try {
+            return Failsafe.with(retryPolicy).get(() -> {
+                String id = createContainer(imageConfig, portMapping, gavLabel, properties, baseDir,
+                        defaultContainerNamePattern, buildTimestamp);
+                createdContainerId.set(id);
+                startContainer(imageConfig, id, gavLabel);
+
+                if (portMapping.needsPropertiesUpdate()) {
+                    updateMappedPortsAndAddresses(id, portMapping);
+                }
+
+                return id;
+            });
+        } catch (FailsafeException e) {
+            // Failsafe wraps checked exceptions; unwrap to preserve the DockerAccessException contract
+            if (e.getCause() instanceof DockerAccessException) {
+                throw (DockerAccessException) e.getCause();
+            }
+            throw e;
         }
+    }
 
-        return id;
+    private void removeContainerSilently(String containerId) {
+        if (containerId == null) {
+            return;
+        }
+        try {
+            removeContainer(containerId, false);
+        } catch (DockerAccessException e) {
+            log.warn("Failed to remove container %s after a failed start: %s", containerId, e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/io/fabric8/maven/docker/service/helper/StartContainerExecutor.java
+++ b/src/main/java/io/fabric8/maven/docker/service/helper/StartContainerExecutor.java
@@ -38,13 +38,14 @@ public class StartContainerExecutor {
     private GavLabel gavLabel;
     private PortMapping portMapping;
     private LogDispatcher dispatcher;
+    private int startupRetries;
 
     private StartContainerExecutor(){}
 
     public String startContainer() throws IOException, ExecException {
         final Properties projProperties = projectProperties;
 
-        final String containerId = hub.getRunService().createAndStartContainer(imageConfig, portMapping, gavLabel, projProperties, basedir, containerNamePattern, buildDate);
+        final String containerId = hub.getRunService().createAndStartContainer(imageConfig, portMapping, gavLabel, projProperties, basedir, containerNamePattern, buildDate, startupRetries);
 
         showLogsIfRequested(containerId);
         Properties exposedProps = queryContainerProperties(containerId);
@@ -215,6 +216,11 @@ public class StartContainerExecutor {
 
         public Builder imageConfig(ImageConfiguration imageConfig) {
             helper.imageConfig = imageConfig;
+            return this;
+        }
+
+        public Builder startupRetries(int startupRetries) {
+            helper.startupRetries = startupRetries;
             return this;
         }
 

--- a/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RunServiceTest.java
@@ -341,6 +341,52 @@ class RunServiceTest {
             () -> runService.createAndStartContainer(imageConfiguration, portMapping, gavLabel, properties, baseDirectory, "blah", buildTimestamp));
     }
 
+    @Test
+    void retryStartContainerOnDockerAccessException(
+        @Mock ImageConfiguration imageConfiguration,
+        @Mock PortMapping portMapping
+    ) throws DockerAccessException {
+
+        Mockito.doReturn("containerId")
+            .when(docker).createContainer(Mockito.any(ContainerCreateConfig.class), Mockito.anyString());
+        Mockito.doReturn(new RunImageConfiguration()).when(imageConfiguration).getRunConfiguration();
+        Mockito.doReturn(false).when(portMapping).needsPropertiesUpdate();
+
+        // First start attempt fails with an I/O error, the retry succeeds
+        Mockito.doThrow(new DockerAccessException("I/O Error"))
+            .doNothing()
+            .when(docker).startContainer("containerId");
+
+        String containerId = runService.createAndStartContainer(imageConfiguration, portMapping,
+            new GavLabel("Im:A:Test"), properties, getBaseDirectory(), "blah", new Date(), 1);
+
+        Assertions.assertEquals("containerId", containerId);
+        Mockito.verify(docker, Mockito.times(2)).startContainer("containerId");
+        // The container created by the failed attempt is removed before retrying
+        Mockito.verify(docker).removeContainer("containerId", false);
+    }
+
+    @Test
+    void failToStartContainerAfterExceedingRetries(
+        @Mock ImageConfiguration imageConfiguration,
+        @Mock PortMapping portMapping
+    ) throws DockerAccessException {
+
+        Mockito.doReturn("containerId")
+            .when(docker).createContainer(Mockito.any(ContainerCreateConfig.class), Mockito.anyString());
+        Mockito.doReturn(new RunImageConfiguration()).when(imageConfiguration).getRunConfiguration();
+        Mockito.doThrow(new DockerAccessException("I/O Error")).when(docker).startContainer("containerId");
+
+        GavLabel gavLabel = new GavLabel("Im:A:Test");
+        File baseDirectory = getBaseDirectory();
+        Date buildTimestamp = new Date();
+        Assertions.assertThrows(DockerAccessException.class,
+            () -> runService.createAndStartContainer(imageConfiguration, portMapping, gavLabel, properties, baseDirectory, "blah", buildTimestamp, 2));
+
+        // 1 original attempt + 2 retries
+        Mockito.verify(docker, Mockito.times(3)).startContainer("containerId");
+    }
+
     private ImageConfiguration createImageConfig(int wait, int kill) {
         return new ImageConfiguration.Builder()
             .name("test_name")


### PR DESCRIPTION
This is done because in Quarkus we've seen flakiness in CI when starting a docker container