### PR TITLE
Make the buildx driver configurable and support Docker Build Cloud

### DIFF
--- a/src/main/asciidoc/inc/build/_buildx.adoc
+++ b/src/main/asciidoc/inc/build/_buildx.adoc
@@ -32,8 +32,18 @@ The `<buildx>` element within `<build>` defines how to build multi-architecture 
 The builder manages the build cache. Set to `default` to leverage the default buildx driver on local builds. This improves
 I/O performance, but will only work for the native platform.
 
+| *driver*
+| BuildX driver to use when the builder is created.  If not supplied, the `docker-container` driver is used.
+Set to `cloud` to build on a https://docs.docker.com/build-cloud/[Docker Cloud] builder; in that case *builderName*
+must be the cloud endpoint in `<org>/<name>` form, which is passed to `docker buildx create` as a positional
+argument instead of via `--name`, and the local builder is named `cloud-<org>-<name>` by Docker.  The `cloud`
+driver manages its own nodes and build configuration, so *nodeName* and *configFile* are not applied to it.
+Can be overridden on the command line with `-Ddocker.buildx.driver`.
+
 | *driverOpts*
-| Optional list of driverOpts to use with the builder. The driverOpts are passed to the builder when it is created.
+| Optional list of driverOpts to use with the builder. The driverOpts are passed to the builder when it is created
+as `--driver-opt <key>=<value>`.  Individual entries can be added or overridden on the command line with
+`-Ddocker.buildx.driverOpts.<key>=<value>`.
 
 | *nodeName*
 | Specify the name of the node to be created or modified.

--- a/src/main/asciidoc/inc/build/_buildx.adoc
+++ b/src/main/asciidoc/inc/build/_buildx.adoc
@@ -38,12 +38,10 @@ Set to `cloud` to build on a https://docs.docker.com/build-cloud/[Docker Cloud] 
 must be the cloud endpoint in `<org>/<name>` form, which is passed to `docker buildx create` as a positional
 argument instead of via `--name`, and the local builder is named `cloud-<org>-<name>` by Docker.  The `cloud`
 driver manages its own nodes and build configuration, so *nodeName* and *configFile* are not applied to it.
-Can be overridden on the command line with `-Ddocker.buildx.driver`.
 
 | *driverOpts*
 | Optional list of driverOpts to use with the builder. The driverOpts are passed to the builder when it is created
-as `--driver-opt <key>=<value>`.  Individual entries can be added or overridden on the command line with
-`-Ddocker.buildx.driverOpts.<key>=<value>`.
+as `--driver-opt <key>=<value>`.
 
 | *nodeName*
 | Specify the name of the node to be created or modified.

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -104,7 +104,7 @@ when a `docker.from` or a `docker.fromExt` is set.
 | BuildX driver used when creating the builder, defaulting to `docker-container`. Use `cloud` for a Docker Cloud builder, which expects `docker.buildx.builderName` in `<org>/<name>` form.
 
 | *docker.buildx.driverOpts.KEY*
-| Driver option passed to the builder as `--driver-opt KEY=value` when it is created. Merges with, and overrides, entries from `<driverOpts>`.
+| Driver option passed to the builder as `--driver-opt KEY=value` when it is created. Multiple such entries can be provided, and they are merged with any `<driverOpts>` from the XML configuration (specified similarly as in `docker.env.VARIABLE`).
 
 | *docker.capAdd.idx*
 | List of kernel capabilities to add to the container. See <<list-properties>>.

--- a/src/main/asciidoc/inc/external/_property_configuration.adoc
+++ b/src/main/asciidoc/inc/external/_property_configuration.adoc
@@ -100,6 +100,12 @@ when a `docker.from` or a `docker.fromExt` is set.
 | *docker.buildx.buildAllPlatforms*
 | When `true`, build all configured platforms already during `docker:build` (warming the cache) instead of only the native platform
 
+| *docker.buildx.driver*
+| BuildX driver used when creating the builder, defaulting to `docker-container`. Use `cloud` for a Docker Cloud builder, which expects `docker.buildx.builderName` in `<org>/<name>` form.
+
+| *docker.buildx.driverOpts.KEY*
+| Driver option passed to the builder as `--driver-opt KEY=value` when it is created. Merges with, and overrides, entries from `<driverOpts>`.
+
 | *docker.capAdd.idx*
 | List of kernel capabilities to add to the container. See <<list-properties>>.
 

--- a/src/main/java/io/fabric8/maven/docker/config/BuildXConfiguration.java
+++ b/src/main/java/io/fabric8/maven/docker/config/BuildXConfiguration.java
@@ -77,6 +77,15 @@ public class BuildXConfiguration implements Serializable {
     @Parameter
     private Boolean buildAllPlatforms;
 
+    /**
+     * BuildX driver to use when creating the builder. Defaults to {@code docker-container}.
+     * Use {@code cloud} to create a Docker Cloud builder; in that case {@link #builderName}
+     * must be the cloud endpoint in {@code <org>/<name>} form and is passed as a positional
+     * argument to {@code docker buildx create} rather than via {@code --name}.
+     */
+    @Parameter
+    private String driver;
+
     public String getBuilderName() {
         return builderName;
     }
@@ -132,6 +141,10 @@ public class BuildXConfiguration implements Serializable {
 
     public boolean isBuildAllPlatforms() {
         return Boolean.TRUE.equals(buildAllPlatforms);
+    }
+
+    public String getDriver() {
+        return driver;
     }
 
     public static class Builder {
@@ -226,6 +239,14 @@ public class BuildXConfiguration implements Serializable {
         public Builder buildAllPlatforms(Boolean buildAllPlatforms) {
             config.buildAllPlatforms = buildAllPlatforms;
             if (buildAllPlatforms != null) {
+                isEmpty = false;
+            }
+            return this;
+        }
+
+        public Builder driver(String driver) {
+            config.driver = driver;
+            if (driver != null) {
                 isEmpty = false;
             }
             return this;

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -53,6 +53,7 @@ public enum ConfigKey {
     BUILDX_CACHE_TO("buildx.cacheTo"),
     BUILDX_BUILD_ALL_PLATFORMS("buildx.buildAllPlatforms"),
     BUILDX_DRIVER("buildx.driver"),
+    BUILDX_DRIVER_OPTS("buildx.driverOpts", ValueCombinePolicy.Merge),
     BUILDX_SECRET_ENVS("buildx.secret.envs", ValueCombinePolicy.Merge),
     BUILDX_SECRET_FILES("buildx.secret.files", ValueCombinePolicy.Merge),
     CAP_ADD,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/ConfigKey.java
@@ -52,6 +52,7 @@ public enum ConfigKey {
     BUILDX_CACHE_FROM("buildx.cacheFrom"),
     BUILDX_CACHE_TO("buildx.cacheTo"),
     BUILDX_BUILD_ALL_PLATFORMS("buildx.buildAllPlatforms"),
+    BUILDX_DRIVER("buildx.driver"),
     BUILDX_SECRET_ENVS("buildx.secret.envs", ValueCombinePolicy.Merge),
     BUILDX_SECRET_FILES("buildx.secret.files", ValueCombinePolicy.Merge),
     CAP_ADD,

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -348,6 +348,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .cacheFrom(valueProvider.getString(BUILDX_CACHE_FROM, config.getCacheFrom()))
             .cacheTo(valueProvider.getString(BUILDX_CACHE_TO, config.getCacheTo()))
             .buildAllPlatforms(valueProvider.getBoolean(BUILDX_BUILD_ALL_PLATFORMS, config.getBuildAllPlatforms()))
+            .driver(valueProvider.getString(BUILDX_DRIVER, config.getDriver()))
             .secret(extractSecret(config.getSecret(), valueProvider))
             .build();
     }

--- a/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandler.java
@@ -349,6 +349,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
             .cacheTo(valueProvider.getString(BUILDX_CACHE_TO, config.getCacheTo()))
             .buildAllPlatforms(valueProvider.getBoolean(BUILDX_BUILD_ALL_PLATFORMS, config.getBuildAllPlatforms()))
             .driver(valueProvider.getString(BUILDX_DRIVER, config.getDriver()))
+            .driverOpts(valueProvider.getMap(BUILDX_DRIVER_OPTS, config.getDriverOpts()))
             .secret(extractSecret(config.getSecret(), valueProvider))
             .build();
     }

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -15,6 +15,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -293,8 +294,8 @@ public class BuildXService {
 
     protected String createBuilder(Path configPath, List<String> buildX, ImageConfiguration imageConfig, BuildDirs buildDirs) throws MojoExecutionException {
         BuildXConfiguration buildXConfiguration = imageConfig.getBuildConfiguration().getBuildX();
-        String builderEndpoint = Optional.ofNullable(buildXConfiguration.getBuilderName()).orElse("maven");
-        String driver = buildXConfiguration.getDriver();
+        String builderEndpoint = resolveBuilderName(buildXConfiguration);
+        String driver = resolveDriver(buildXConfiguration);
 
         // For the cloud driver Docker derives the local builder name as "cloud-<org>-<name>"
         String builderName = isCloudDriver(driver)
@@ -304,21 +305,35 @@ public class BuildXService {
         if ("default".equals(builderName)) {
             logger.info("Using default builder with buildx - only single platforms will be supported");
         } else {
-            createCustomBuilderIfNotExists(configPath, buildX, buildXConfiguration, builderName, builderEndpoint, buildDirs);
+            if (isCloudDriver(driver) && !builderEndpoint.contains("/")) {
+                throw new MojoExecutionException(
+                    "Cloud builder identifier must be in <org>/<name> form, got: " + builderEndpoint);
+            }
+            createCustomBuilderIfNotExists(configPath, buildX, buildXConfiguration, builderName, builderEndpoint, driver, buildDirs);
         }
         return builderName;
+    }
+
+    private static String resolveBuilderName(BuildXConfiguration buildXConfiguration) {
+        String sysProp = System.getProperty("docker.buildx.builderName");
+        return sysProp != null ? sysProp : Optional.ofNullable(buildXConfiguration.getBuilderName()).orElse("maven");
+    }
+
+    // System property takes priority over XML config, matching the pattern used by ConfigHelper.isNoCache / getNetwork
+    private static String resolveDriver(BuildXConfiguration buildXConfiguration) {
+        String sysProp = System.getProperty("docker.buildx.driver");
+        return sysProp != null ? sysProp : buildXConfiguration.getDriver();
     }
 
     private static boolean isCloudDriver(String driver) {
         return "cloud".equals(driver);
     }
 
-    private void createCustomBuilderIfNotExists(Path configPath, List<String> buildX, BuildXConfiguration buildXConfiguration, String builderName, String builderEndpoint, BuildDirs buildDirs) throws MojoExecutionException {
+    private void createCustomBuilderIfNotExists(Path configPath, List<String> buildX, BuildXConfiguration buildXConfiguration, String builderName, String builderEndpoint, String driver, BuildDirs buildDirs) throws MojoExecutionException {
         Path builderPath = configPath.resolve(Paths.get("buildx", "instances", builderName.toLowerCase()));
 
         if (Files.notExists(builderPath)) {
             List<String> cmds = new ArrayList<>(buildX);
-            String driver = buildXConfiguration.getDriver();
 
             if (isCloudDriver(driver)) {
                 // Cloud driver: endpoint is a positional argument; --name and --node are not used
@@ -342,9 +357,16 @@ public class BuildXService {
     }
 
     private void addDriverOptions(List<String> cmds, BuildXConfiguration buildXConfiguration) {
-        if (buildXConfiguration.getDriverOpts() != null && !buildXConfiguration.getDriverOpts().isEmpty()) {
-            buildXConfiguration.getDriverOpts().forEach((key, value) -> append(cmds, "--driver-opt", key + '=' + value));
+        Map<String, String> opts = new LinkedHashMap<>();
+        if (buildXConfiguration.getDriverOpts() != null) {
+            opts.putAll(buildXConfiguration.getDriverOpts());
         }
+        // -Ddocker.buildx.driverOpts.<key>=<value> overrides individual XML-configured entries
+        Map<String, String> sysOpts = EnvUtil.extractFromPropertiesAsMap("docker.buildx.driverOpts", System.getProperties());
+        if (sysOpts != null) {
+            opts.putAll(sysOpts);
+        }
+        opts.forEach((key, value) -> append(cmds, "--driver-opt", key + '=' + value));
     }
 
     private void addBuildConfig(List<String> cmds, BuildXConfiguration buildXConfiguration, BuildDirs buildDirs) {

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -15,13 +15,13 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.MojoExecutionException;
 
@@ -43,6 +43,10 @@ import io.fabric8.maven.docker.util.ProjectPaths;
 
 public class BuildXService {
     private static final String DOCKER = "docker";
+    private static final String DRIVER_DOCKER_CONTAINER = "docker-container";
+    private static final String DRIVER_CLOUD = "cloud";
+    // A Docker Build Cloud endpoint is exactly "<org>/<name>", with no empty or extra segments
+    private static final Pattern CLOUD_ENDPOINT_PATTERN = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*");
     private final DockerAccess dockerAccess;
     private final DockerAssemblyManager dockerAssemblyManager;
     private final Logger logger;
@@ -294,8 +298,8 @@ public class BuildXService {
 
     protected String createBuilder(Path configPath, List<String> buildX, ImageConfiguration imageConfig, BuildDirs buildDirs) throws MojoExecutionException {
         BuildXConfiguration buildXConfiguration = imageConfig.getBuildConfiguration().getBuildX();
-        String builderEndpoint = resolveBuilderName(buildXConfiguration);
-        String driver = resolveDriver(buildXConfiguration);
+        String builderEndpoint = Optional.ofNullable(buildXConfiguration.getBuilderName()).orElse("maven");
+        String driver = Optional.ofNullable(buildXConfiguration.getDriver()).orElse(DRIVER_DOCKER_CONTAINER);
 
         // For the cloud driver Docker derives the local builder name as "cloud-<org>-<name>"
         String builderName = isCloudDriver(driver)
@@ -305,7 +309,7 @@ public class BuildXService {
         if ("default".equals(builderName)) {
             logger.info("Using default builder with buildx - only single platforms will be supported");
         } else {
-            if (isCloudDriver(driver) && !builderEndpoint.contains("/")) {
+            if (isCloudDriver(driver) && !CLOUD_ENDPOINT_PATTERN.matcher(builderEndpoint).matches()) {
                 throw new MojoExecutionException(
                     "Cloud builder identifier must be in <org>/<name> form, got: " + builderEndpoint);
             }
@@ -314,19 +318,8 @@ public class BuildXService {
         return builderName;
     }
 
-    private static String resolveBuilderName(BuildXConfiguration buildXConfiguration) {
-        String sysProp = System.getProperty("docker.buildx.builderName");
-        return sysProp != null ? sysProp : Optional.ofNullable(buildXConfiguration.getBuilderName()).orElse("maven");
-    }
-
-    // System property takes priority over XML config, matching the pattern used by ConfigHelper.isNoCache / getNetwork
-    private static String resolveDriver(BuildXConfiguration buildXConfiguration) {
-        String sysProp = System.getProperty("docker.buildx.driver");
-        return sysProp != null ? sysProp : buildXConfiguration.getDriver();
-    }
-
     private static boolean isCloudDriver(String driver) {
-        return "cloud".equals(driver);
+        return DRIVER_CLOUD.equals(driver);
     }
 
     private void createCustomBuilderIfNotExists(Path configPath, List<String> buildX, BuildXConfiguration buildXConfiguration, String builderName, String builderEndpoint, String driver, BuildDirs buildDirs) throws MojoExecutionException {
@@ -340,7 +333,7 @@ public class BuildXService {
                 append(cmds, "create", "--driver", driver, builderEndpoint);
                 addDriverOptions(cmds, buildXConfiguration);
             } else {
-                append(cmds, "create", "--driver", driver != null ? driver : "docker-container", "--name", builderEndpoint);
+                append(cmds, "create", "--driver", driver, "--name", builderEndpoint);
                 String nodeName = buildXConfiguration.getNodeName();
                 if (nodeName != null) {
                     append(cmds, "--node", nodeName);
@@ -357,16 +350,9 @@ public class BuildXService {
     }
 
     private void addDriverOptions(List<String> cmds, BuildXConfiguration buildXConfiguration) {
-        Map<String, String> opts = new LinkedHashMap<>();
-        if (buildXConfiguration.getDriverOpts() != null) {
-            opts.putAll(buildXConfiguration.getDriverOpts());
+        if (buildXConfiguration.getDriverOpts() != null && !buildXConfiguration.getDriverOpts().isEmpty()) {
+            buildXConfiguration.getDriverOpts().forEach((key, value) -> append(cmds, "--driver-opt", key + '=' + value));
         }
-        // -Ddocker.buildx.driverOpts.<key>=<value> overrides individual XML-configured entries
-        Map<String, String> sysOpts = EnvUtil.extractFromPropertiesAsMap("docker.buildx.driverOpts", System.getProperties());
-        if (sysOpts != null) {
-            opts.putAll(sysOpts);
-        }
-        opts.forEach((key, value) -> append(cmds, "--driver-opt", key + '=' + value));
     }
 
     private void addBuildConfig(List<String> cmds, BuildXConfiguration buildXConfiguration, BuildDirs buildDirs) {

--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -78,10 +78,10 @@ public class BuildXService {
             copyBuildXToConfigPathIfBuildXBinaryInDefaultDockerConfig(configPath);
         }
 
-        String builderName = createBuilder(configPath, buildX, imageConfig, buildDirs);
         Path configJson = configPath.resolve("config.json");
         try {
             createConfigJson(configJson, authConfig);
+            String builderName = createBuilder(configPath, buildX, imageConfig, buildDirs);
             builder.useBuilder(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, buildArgs, context);
         } finally {
             removeConfigJson(configJson);
@@ -293,30 +293,46 @@ public class BuildXService {
 
     protected String createBuilder(Path configPath, List<String> buildX, ImageConfiguration imageConfig, BuildDirs buildDirs) throws MojoExecutionException {
         BuildXConfiguration buildXConfiguration = imageConfig.getBuildConfiguration().getBuildX();
-        String builderName = Optional.ofNullable(buildXConfiguration.getBuilderName()).orElse("maven");
+        String builderEndpoint = Optional.ofNullable(buildXConfiguration.getBuilderName()).orElse("maven");
+        String driver = buildXConfiguration.getDriver();
+
+        // For the cloud driver Docker derives the local builder name as "cloud-<org>-<name>"
+        String builderName = isCloudDriver(driver)
+            ? "cloud-" + builderEndpoint.replace("/", "-").toLowerCase()
+            : builderEndpoint;
 
         if ("default".equals(builderName)) {
             logger.info("Using default builder with buildx - only single platforms will be supported");
         } else {
-            createCustomBuilderIfNotExists(configPath, buildX, buildXConfiguration, builderName, buildDirs);
+            createCustomBuilderIfNotExists(configPath, buildX, buildXConfiguration, builderName, builderEndpoint, buildDirs);
         }
         return builderName;
     }
 
-    private void createCustomBuilderIfNotExists(Path configPath, List<String> buildX, BuildXConfiguration buildXConfiguration, String builderName, BuildDirs buildDirs) throws MojoExecutionException {
-        String nodeName = buildXConfiguration.getNodeName();
+    private static boolean isCloudDriver(String driver) {
+        return "cloud".equals(driver);
+    }
+
+    private void createCustomBuilderIfNotExists(Path configPath, List<String> buildX, BuildXConfiguration buildXConfiguration, String builderName, String builderEndpoint, BuildDirs buildDirs) throws MojoExecutionException {
         Path builderPath = configPath.resolve(Paths.get("buildx", "instances", builderName.toLowerCase()));
 
         if (Files.notExists(builderPath)) {
             List<String> cmds = new ArrayList<>(buildX);
-            append(cmds, "create", "--driver", "docker-container", "--name", builderName);
+            String driver = buildXConfiguration.getDriver();
 
-            if (nodeName != null) {
-                append(cmds, "--node", nodeName);
+            if (isCloudDriver(driver)) {
+                // Cloud driver: endpoint is a positional argument; --name and --node are not used
+                append(cmds, "create", "--driver", driver, builderEndpoint);
+                addDriverOptions(cmds, buildXConfiguration);
+            } else {
+                append(cmds, "create", "--driver", driver != null ? driver : "docker-container", "--name", builderEndpoint);
+                String nodeName = buildXConfiguration.getNodeName();
+                if (nodeName != null) {
+                    append(cmds, "--node", nodeName);
+                }
+                addDriverOptions(cmds, buildXConfiguration);
+                addBuildConfig(cmds, buildXConfiguration, buildDirs);
             }
-
-            addDriverOptions(cmds, buildXConfiguration);
-            addBuildConfig(cmds, buildXConfiguration, buildDirs);
 
             int rc = exec.process(cmds);
             if (rc != 0) {

--- a/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/io/fabric8/maven/docker/config/handler/property/PropertyConfigHandlerTest.java
@@ -19,6 +19,7 @@ package io.fabric8.maven.docker.config.handler.property;
 import io.fabric8.maven.docker.config.Arguments;
 import io.fabric8.maven.docker.config.AssemblyConfiguration;
 import io.fabric8.maven.docker.config.BuildImageConfiguration;
+import io.fabric8.maven.docker.config.BuildXConfiguration;
 import io.fabric8.maven.docker.config.CleanupMode;
 import io.fabric8.maven.docker.config.ConfigHelper;
 import io.fabric8.maven.docker.config.CopyConfiguration;
@@ -846,6 +847,46 @@ class PropertyConfigHandlerTest extends AbstractConfigHandlerTest {
 
         ImageConfiguration config = resolveExternalImageConfig(testData);
         Assertions.assertNotNull(config.getBuildConfiguration());
+    }
+
+    @Test
+    void testBuildXDriverAndDriverOpts() {
+        String[] testData = new String[] {
+            k(ConfigKey.NAME), "image",
+            k(ConfigKey.FROM), "base",
+            k(ConfigKey.BUILDX_DRIVER), "cloud",
+            k(ConfigKey.BUILDX_BUILDERNAME), "myorg/default",
+            k(ConfigKey.BUILDX_DRIVER_OPTS) + ".network", "host"
+        };
+
+        ImageConfiguration config = resolveExternalImageConfig(testData);
+        BuildXConfiguration buildX = config.getBuildConfiguration().getBuildX();
+        Assertions.assertEquals("cloud", buildX.getDriver());
+        Assertions.assertEquals("myorg/default", buildX.getBuilderName());
+        Assertions.assertEquals(Collections.singletonMap("network", "host"), buildX.getDriverOpts());
+    }
+
+    @Test
+    void testBuildXDriverOptsMergeWithConfiguredOnes() {
+        imageConfiguration = new ImageConfiguration.Builder()
+            .externalConfig(externalConfigMode(PropertyMode.Override))
+            .buildConfig(new BuildImageConfiguration.Builder()
+                .buildx(new BuildXConfiguration.Builder()
+                    .driverOpts(Collections.singletonMap("image", "moby/buildkit:latest"))
+                    .build())
+                .build())
+            .build();
+
+        List<ImageConfiguration> configs = resolveImage(imageConfiguration, props(
+            k(ConfigKey.NAME), "image",
+            k(ConfigKey.FROM), "base",
+            k(ConfigKey.BUILDX_DRIVER_OPTS) + ".network", "host"));
+
+        Assertions.assertEquals(1, configs.size());
+        Map<String, String> driverOpts = configs.get(0).getBuildConfiguration().getBuildX().getDriverOpts();
+        Assertions.assertEquals(2, driverOpts.size());
+        Assertions.assertEquals("moby/buildkit:latest", driverOpts.get("image"));
+        Assertions.assertEquals("host", driverOpts.get("network"));
     }
 
     @Test

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceCreateBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceCreateBuilderTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -90,6 +91,67 @@ class BuildXServiceCreateBuilderTest {
 
     //Then
     verifyBuildXArgumentDoesNotContain("--driver-opt", "network=foonet");
+  }
+
+  @Test
+  void cloudDriverUsesEndpointAsPositionalArg() throws Exception {
+    //Given
+    buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX
+        .driver("cloud")
+        .builderName("myorg/default"));
+
+    // When
+    buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+    // Then
+    ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(exec).process(captor.capture());
+    List<String> args = captor.getValue();
+    assertTrue(args.containsAll(Arrays.asList("--driver", "cloud", "myorg/default")));
+    assertFalse(args.contains("--name"));
+  }
+
+  @Test
+  void cloudDriverDerivesBuilderName() throws Exception {
+    //Given
+    buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX
+        .driver("cloud")
+        .builderName("myorg/default"));
+
+    // When
+    String builderName = buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+    // Then
+    assertEquals("cloud-myorg-default", builderName);
+  }
+
+  @Test
+  void cloudDriverExistenceCheckUsesLocalName() throws Exception {
+    Path configPathSpy = Mockito.spy(configPath);
+    Path expectedPath = Paths.get("buildx", "instances", "cloud-myorg-default");
+
+    //Given
+    buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX
+        .driver("cloud")
+        .builderName("myorg/default"));
+
+    // When
+    buildXService.createBuilder(configPathSpy, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+    // Then
+    verify(configPathSpy).resolve(expectedPath);
+  }
+
+  @Test
+  void nonCloudDriverPreservesExistingBehavior() throws Exception {
+    //Given
+    buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX.builderName("mybuilder"));
+
+    // When
+    buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+    // Then
+    verifyBuildXArgumentContains("--driver", "docker-container", "--name", "mybuilder");
   }
 
   private void captureBuildXArguments() throws MojoExecutionException {

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceCreateBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceCreateBuilderTest.java
@@ -12,6 +12,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -94,58 +96,30 @@ class BuildXServiceCreateBuilderTest {
     verifyBuildXArgumentDoesNotContain("--driver-opt", "network=foonet");
   }
 
-  @Test
-  void builderNameOverriddenBySystemProperty() throws Exception {
-    System.setProperty("docker.buildx.builderName", "myorg/default");
-    System.setProperty("docker.buildx.driver", "cloud");
-    try {
-      buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> {});
-
-      String builderName = buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
-
-      assertEquals("cloud-myorg-default", builderName);
-    } finally {
-      System.clearProperty("docker.buildx.builderName");
-      System.clearProperty("docker.buildx.driver");
-    }
-  }
-
-  @Test
-  void driverOverriddenBySystemProperty() throws Exception {
-    System.setProperty("docker.buildx.driver", "cloud");
-    try {
-      buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX.builderName("myorg/default"));
-
-      String builderName = buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
-
-      assertEquals("cloud-myorg-default", builderName);
-    } finally {
-      System.clearProperty("docker.buildx.driver");
-    }
-  }
-
-  @Test
-  void driverOptOverriddenBySystemProperty() throws Exception {
-    System.setProperty("docker.buildx.driverOpts.network", "host");
-    try {
-      buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> {});
-
-      buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
-
-      verifyBuildXArgumentContains("--driver-opt", "network=host");
-    } finally {
-      System.clearProperty("docker.buildx.driverOpts.network");
-    }
-  }
-
-  @Test
-  void cloudDriverRequiresOrgSlashNameFormat() {
+  @ParameterizedTest
+  @ValueSource(strings = { "invalid-no-slash", "myorg/", "/default", "/", "myorg/team/default", "my org/default" })
+  void cloudDriverRequiresOrgSlashNameFormat(String malformedEndpoint) {
     buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX
         .driver("cloud")
-        .builderName("invalid-no-slash"));
+        .builderName(malformedEndpoint));
 
-    assertThrows(MojoExecutionException.class, () ->
+    MojoExecutionException exception = assertThrows(MojoExecutionException.class, () ->
         buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs));
+    assertTrue(exception.getMessage().contains("must be in <org>/<name> form"));
+  }
+
+  @Test
+  void explicitNonCloudDriverIsPassedThrough() throws Exception {
+    //Given
+    buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX
+        .driver("kubernetes")
+        .builderName("mybuilder"));
+
+    // When
+    buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+    // Then
+    verifyBuildXArgumentContains("--driver", "kubernetes", "--name", "mybuilder");
   }
 
   @Test

--- a/src/test/java/io/fabric8/maven/docker/service/BuildXServiceCreateBuilderTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/BuildXServiceCreateBuilderTest.java
@@ -25,6 +25,7 @@ import java.util.function.BiConsumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -91,6 +92,60 @@ class BuildXServiceCreateBuilderTest {
 
     //Then
     verifyBuildXArgumentDoesNotContain("--driver-opt", "network=foonet");
+  }
+
+  @Test
+  void builderNameOverriddenBySystemProperty() throws Exception {
+    System.setProperty("docker.buildx.builderName", "myorg/default");
+    System.setProperty("docker.buildx.driver", "cloud");
+    try {
+      buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> {});
+
+      String builderName = buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+      assertEquals("cloud-myorg-default", builderName);
+    } finally {
+      System.clearProperty("docker.buildx.builderName");
+      System.clearProperty("docker.buildx.driver");
+    }
+  }
+
+  @Test
+  void driverOverriddenBySystemProperty() throws Exception {
+    System.setProperty("docker.buildx.driver", "cloud");
+    try {
+      buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX.builderName("myorg/default"));
+
+      String builderName = buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+      assertEquals("cloud-myorg-default", builderName);
+    } finally {
+      System.clearProperty("docker.buildx.driver");
+    }
+  }
+
+  @Test
+  void driverOptOverriddenBySystemProperty() throws Exception {
+    System.setProperty("docker.buildx.driverOpts.network", "host");
+    try {
+      buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> {});
+
+      buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs);
+
+      verifyBuildXArgumentContains("--driver-opt", "network=host");
+    } finally {
+      System.clearProperty("docker.buildx.driverOpts.network");
+    }
+  }
+
+  @Test
+  void cloudDriverRequiresOrgSlashNameFormat() {
+    buildConfigUsingBuildX(temporaryFolder, (buildX, buildImage) -> buildX
+        .driver("cloud")
+        .builderName("invalid-no-slash"));
+
+    assertThrows(MojoExecutionException.class, () ->
+        buildXService.createBuilder(configPath, Arrays.asList("docker", "buildx"), imageConfig, buildDirs));
   }
 
   @Test


### PR DESCRIPTION
### What

Makes the buildx driver configurable instead of hard-coding `docker-container`, and adds first-class support for building on [Docker Build Cloud](https://docs.docker.com/build-cloud/).

New `<buildx>` option:

```xml
<buildx>
  <driver>cloud</driver>
  <builderName>my-org/my-builder</builderName>
  <driverOpts>
    <key>value</key>
  </driverOpts>
</buildx>
```

### Why

`createCustomBuilderIfNotExists` always passed `--driver docker-container`, so there was no way to target any other buildx driver. Docker Build Cloud builders in particular could not be used at all, even though they are just another driver from the CLI's point of view.

### Details

- `<driver>` defaults to `docker-container`, preserving today's behaviour exactly when unset.
- For `driver=cloud`, `docker buildx create` takes the endpoint as a **positional** argument rather than `--name`, so `<builderName>` is treated as the cloud endpoint and must be in `<org>/<name>` form; a clear `MojoExecutionException` is thrown otherwise.
- Docker derives the local builder name for a cloud builder as `cloud-<org>-<name>`, so that name is used for the instance-path existence check and passed on to the build.
- The `cloud` driver manages its own nodes and build configuration, so `--node` and the buildx config file are not applied to it.
- `<driver>` and `<driverOpts>` are wired through `ConfigKey`/`PropertyConfigHandler`, and can additionally be overridden at invocation time with `-Ddocker.buildx.driver` and `-Ddocker.buildx.driverOpts.<key>=<value>` (per-key merge over the XML config). `-Ddocker.buildx.builderName` is honoured on the same path.
- `createConfigJson` now runs *before* `createBuilder`, so builder creation can see registry credentials. Creating a cloud builder contacts the registry, which failed when `config.json` was only written afterwards.

### Documentation

`src/main/asciidoc/inc/build/_buildx.adoc` and `inc/external/_property_configuration.adoc` document the new element and properties.

### Tests

New `BuildXServiceCreateBuilderTest` (11 cases) covers the default driver, an explicit non-cloud driver, cloud endpoint handling and derived naming, the `<org>/<name>` validation failure, driver-opt merging, and the system-property overrides. `BuildXServiceTest` and `PropertyConfigHandlerTest` pass unchanged.

All commits are signed off per `CONTRIBUTING.md`.
