### PR TITLE
Do not let a base image registry override the configured push registry

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/RegistryService.java
@@ -175,7 +175,6 @@ public class RegistryService {
             if (StringUtils.isNotBlank(configuredRegistry) && configuredRegistry.equalsIgnoreCase(fromRegistry)) {
                 continue;
             }
-            registryConfig.registry = fromRegistry;
             AuthConfig additionalAuth = registryConfig.createAuthConfig(false, null, fromRegistry);
             if (additionalAuth != null) {
                 authConfigList.addAuthConfig(additionalAuth);

--- a/src/test/java/io/fabric8/maven/docker/service/RegistryServicePushImagesBuildXTest.java
+++ b/src/test/java/io/fabric8/maven/docker/service/RegistryServicePushImagesBuildXTest.java
@@ -30,9 +30,11 @@ import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,6 +48,7 @@ class RegistryServicePushImagesBuildXTest {
   private BuildService.BuildContext buildContext;
   private MojoParameters mojoParameters;
   private MavenProject mavenProject;
+  private DockerAccess dockerAccess;
 
   @TempDir
   private File temporaryFolder;
@@ -58,7 +61,7 @@ class RegistryServicePushImagesBuildXTest {
     authConfigFactory = mock(AuthConfigFactory.class);
     mojoParameters = mock(MojoParameters.class);
     mavenProject = mock(MavenProject.class);
-    DockerAccess dockerAccess = mock(DockerAccess.class);
+    dockerAccess = mock(DockerAccess.class);
     QueryService queryService = new QueryService(dockerAccess);
     imageConfigurationList = Collections.singletonList(createNewImageConfiguration("user1/sample-image:latest", "foo/base:latest", null));
     registryConfig = new RegistryService.RegistryConfig.Builder()
@@ -126,6 +129,61 @@ class RegistryServicePushImagesBuildXTest {
     verifyBuildXServiceInvokedWithAuthConfigListSize(3);
   }
 
+  @Test
+  void whenBaseImageFromOtherRegistry_thenPushRegistryOfSubsequentImagesIsNotOverridden() throws MojoExecutionException, DockerAccessException {
+    // Given two images, the first one having a base image hosted on another registry than the push registry
+    imageConfigurationList = Arrays.asList(
+        createNewImageConfiguration("user1/first-image:latest", "registry2.org/user2/base:latest", null),
+        createNewImageConfiguration("user1/second-image:latest", "busybox:latest", null));
+    givenAuthConfigExistsForRegistry("registry1.org", "user1", "password1");
+    givenAuthConfigExistsForRegistry("registry2.org", "user2", "password2");
+
+    // When
+    registryService.pushImages(projectPaths, imageConfigurationList, 0, registryConfig, false, buildContext);
+
+    // Then both images must be pushed to the configured push registry, not to the base image registry
+    ArgumentCaptor<String> registryCaptor = ArgumentCaptor.forClass(String.class);
+    verify(buildXService, times(2)).push(any(), any(), registryCaptor.capture(), any(), any());
+    assertEquals(Arrays.asList("registry1.org", "registry1.org"), registryCaptor.getAllValues());
+  }
+
+  @Test
+  void whenBaseImageFromOtherRegistry_thenLegacyPushOfSubsequentImageUsesPushRegistry() throws MojoExecutionException, DockerAccessException {
+    // Given a buildx image whose base image comes from docker.io, followed by a plain (non-buildx) image
+    imageConfigurationList = Arrays.asList(
+        createNewImageConfiguration("user1/first-image:latest", "docker.io/library/openjdk:21", null),
+        createNewLegacyImageConfiguration("user1/second-image:latest", "busybox:latest"));
+    givenAuthConfigExistsForRegistry("registry1.org", "user1", "password1");
+    givenAuthConfigExistsForRegistry("docker.io", "user2", "password2");
+
+    // When
+    registryService.pushImages(projectPaths, imageConfigurationList, 0, registryConfig, false, buildContext);
+
+    // Then
+    verify(dockerAccess).pushImage(eq("user1/second-image:latest"), any(), eq("registry1.org"), anyInt());
+  }
+
+  /**
+   * Guards the invariant at its source, independently of which callers happen to reach the helper:
+   * collecting pull credentials must leave the caller's registry configuration alone, since that
+   * configuration is shared across every image of a `docker:push`.
+   */
+  @Test
+  void whenAuthConfigListCreatedForBaseImages_thenRegistryConfigIsNotMutated() throws MojoExecutionException {
+    // Given
+    BuildImageConfiguration buildConfig = createNewImageConfiguration("user1/sample-image:latest", "registry2.org/user2/base:latest", null)
+        .getBuildConfiguration();
+    givenAuthConfigExistsForRegistry("registry2.org", "user2", "password2");
+
+    // When
+    AuthConfigList authConfigList = RegistryService.createAuthConfigListForBaseImages(
+        buildConfig, mojoParameters, "registry1.org", registryConfig, Collections.emptyMap());
+
+    // Then
+    assertEquals(1, authConfigList.size());
+    assertEquals("registry1.org", registryConfig.getRegistry());
+  }
+
   private void verifyBuildXServiceInvokedWithAuthConfigListSize(int expectedSize) throws MojoExecutionException {
     ArgumentCaptor<AuthConfigList> authConfigListArgumentCaptor = ArgumentCaptor.forClass(AuthConfigList.class);
     verify(buildXService).push(any(), any(), anyString(), authConfigListArgumentCaptor.capture(), any());
@@ -138,6 +196,16 @@ class RegistryServicePushImagesBuildXTest {
 
     when(authConfigFactory.createAuthConfig(anyBoolean(), anyBoolean(), any(), any(), any(), eq(registry)))
         .thenReturn(auth);
+  }
+
+  private ImageConfiguration createNewLegacyImageConfiguration(String name, String from) {
+    BuildImageConfiguration buildImageConfiguration = mock(BuildImageConfiguration.class);
+    when(buildImageConfiguration.getFrom()).thenReturn(from);
+    when(buildImageConfiguration.isBuildX()).thenReturn(false);
+    when(buildImageConfiguration.getTags()).thenReturn(Collections.emptyList());
+    return new ImageConfiguration.Builder()
+        .name(name)
+        .buildConfig(buildImageConfiguration).build();
   }
 
   private ImageConfiguration createNewImageConfiguration(String name, String from, File dockerFile) {


### PR DESCRIPTION
## Problem

With several images in one `<configuration>`, only the **first** one honours `docker.push.registry` (or `<registry>`). Every image after it is pushed to — and authenticated against — the registry of the first image's `FROM` line instead.

```xml
<images>
  <image>
    <name>example-app:%l</name>
    <build>
      <dockerFileDir>${project.basedir}/src/main/docker</dockerFileDir>  <!-- FROM docker.io/... -->
      ...
    </build>
  </image>
  <image>
    <name>example-mysql-schema:%l</name>
    <build><from>busybox:latest</from>...</build>
  </image>
</images>
```

```
$ mvn -Ddocker.push.registry=example.com docker:push

Pushed example-app           -> example.com   # correct
Pushed example-mysql-schema  -> docker.io     # FROM registry of image 1
```

## Root cause

`RegistryService.createAuthConfigListForBaseImages` collects credentials for the registries a build pulls its `FROM` images from, and while doing so assigned the base image registry to the `RegistryConfig` it had been handed:

```java
registryConfig.registry = fromRegistry;
AuthConfig additionalAuth = registryConfig.createAuthConfig(false, null, fromRegistry);
```

The assignment does nothing for the credential lookup on the next line, which passes `fromRegistry` explicitly — `RegistryConfig.createAuthConfig` forwards to `AuthConfigFactory.createAuthConfig(..., String registry)` and never reads the field. What it does do is mutate state shared far beyond this method: `PushMojo` builds a single `RegistryConfig` from `docker.push.registry` and `pushImages` walks every configured image with that one object.

Hence the first image being the only correct one. Its `configuredRegistry` is resolved *before* the auth list is built, then the field is overwritten, and from the second image on `EnvUtil.firstRegistryOf` falls through to the leaked `FROM` registry whenever the image itself names no registry.

## Fix

Drop the assignment. Every other reader of the field — the push and pull registry resolution, `createCompleteAuthConfigList`, `JibBuildService` — asks where *this* image goes, and none of them wants the base image registry. `BuildMojo` passes a freshly built `RegistryConfig` into the helper, so nothing there observed the mutation either.

## Tests

Three cases in `RegistryServicePushImagesBuildXTest`, each verified to fail with the line restored:

- `whenAuthConfigListCreatedForBaseImages_thenRegistryConfigIsNotMutated` — pins the invariant at its source, independently of which callers reach the helper: the `RegistryConfig` is left alone and the auth list still holds its base image entry.
- `whenBaseImageFromOtherRegistry_thenPushRegistryOfSubsequentImagesIsNotOverridden` — two images, the first with `FROM registry2.org/...`; both pushes must target `registry1.org`. Fails as `expected: <[registry1.org, registry1.org]> but was: <[registry1.org, registry2.org]>`.
- `whenBaseImageFromOtherRegistry_thenLegacyPushOfSubsequentImageUsesPushRegistry` — the reported shape, ending in a plain (non-buildx) image; `docker.pushImage` must get `registry1.org`.

The four existing auth-list tests pass either way, so removing the line does not weaken their coverage. Full suite green: 1019 tests, 0 failures, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)